### PR TITLE
Refactor env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
    cp backend/config/secret.env .env
    cp backend/config/settings.env .
    ```
-   Edit `.env` and set `OPENAI_API_KEY`, `OANDA_API_KEY` and `OANDA_ACCOUNT_ID`. Adjust any values in `settings.env` as needed.
+   Edit `.env` and set `OPENAI_API_KEY`, `OANDA_API_KEY` and `OANDA_ACCOUNT_ID`.
+   The application automatically loads `.env`, `backend/config/settings.env` and
+   `backend/config/secret.env` once at startup using `backend.utils.env_loader`.
+   Adjust any values in `settings.env` as needed.
 
 ## Running the API
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-import os
+from backend.utils import env_loader
 
 import sqlite3
 from fastapi import HTTPException
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
-DATABASE_PATH = os.getenv("TRADES_DB_PATH", "/app/trades.db")
+DATABASE_PATH = env_loader.get_env("TRADES_DB_PATH", "/app/trades.db")
 
 @app.get("/status")
 def status():
@@ -47,9 +47,9 @@ class Settings(BaseModel):
 
 # In-memory settings store
 current_settings = {
-    "ai_cooldown_flat": int(os.getenv("AI_COOLDOWN_SEC_FLAT", "60")),
-    "ai_cooldown_open": int(os.getenv("AI_COOLDOWN_SEC_OPEN", "30")),
-    "review_sec": int(os.getenv("POSITION_REVIEW_SEC", "60")),
+    "ai_cooldown_flat": int(env_loader.get_env("AI_COOLDOWN_SEC_FLAT", "60")),
+    "ai_cooldown_open": int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", "30")),
+    "review_sec": int(env_loader.get_env("POSITION_REVIEW_SEC", "60")),
 }
 
 @app.get("/settings")

--- a/backend/logs/fetch_oanda_trades.py
+++ b/backend/logs/fetch_oanda_trades.py
@@ -1,18 +1,15 @@
-from dotenv import load_dotenv
-from pathlib import Path
+from backend.utils import env_loader
 
-dotenv_path = Path(__file__).resolve().parents[1] / 'config' / 'secret.env'
-load_dotenv(dotenv_path)
+# env_loader automatically loads default env files at import time
 
 import requests
-import os
 import sqlite3
 from datetime import datetime, timedelta
 import backend.logs.log_manager
 
 def fetch_oanda_trades():
-    api_key = os.getenv('OANDA_API_KEY')
-    account_id = os.getenv('OANDA_ACCOUNT_ID')
+    api_key = env_loader.get_env('OANDA_API_KEY')
+    account_id = env_loader.get_env('OANDA_ACCOUNT_ID')
     print(f"Using account_id: {account_id}")
     url = f'https://api-fxtrade.oanda.com/v3/accounts/{account_id}/transactions'
     params = {
@@ -63,7 +60,7 @@ def fetch_and_store_transactions():
 
     initial_response = fetch_oanda_trades()
     pages = initial_response.get('pages', [])
-    api_key = os.getenv('OANDA_API_KEY')
+    api_key = env_loader.get_env('OANDA_API_KEY')
     headers = {
         'Authorization': f'Bearer {api_key}',
         'Content-Type': 'application/json'

--- a/backend/logs/initial_fetch_oanda_trades.py
+++ b/backend/logs/initial_fetch_oanda_trades.py
@@ -1,14 +1,13 @@
-import os
 import requests
-from dotenv import load_dotenv
+from backend.utils import env_loader
 from backend.logs.log_manager import get_db_connection
 from datetime import datetime, timedelta
 import json
 
-load_dotenv('./backend/config/secret.env')
+# env_loader automatically loads default env files at import time
 
-OANDA_API_KEY = os.getenv('OANDA_API_KEY')
-OANDA_ACCOUNT_ID = os.getenv('OANDA_ACCOUNT_ID')
+OANDA_API_KEY = env_loader.get_env('OANDA_API_KEY')
+OANDA_ACCOUNT_ID = env_loader.get_env('OANDA_ACCOUNT_ID')
 OANDA_API_URL = "https://api-fxtrade.oanda.com"
 
 headers = {

--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -1,13 +1,12 @@
-import os
 import logging
 import requests
-from dotenv import load_dotenv
+from backend.utils import env_loader
 from backend.logs.log_manager import get_db_connection
 
-load_dotenv('./backend/config/secret.env')
+# env_loader automatically loads default env files at import time
 
-OANDA_API_KEY = os.getenv('OANDA_API_KEY')
-OANDA_ACCOUNT_ID = os.getenv('OANDA_ACCOUNT_ID')
+OANDA_API_KEY = env_loader.get_env('OANDA_API_KEY')
+OANDA_ACCOUNT_ID = env_loader.get_env('OANDA_ACCOUNT_ID')
 OANDA_API_URL = "https://api-fxtrade.oanda.com"
 
 headers = {

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 """Convenience entry point for running Piphawk components."""
 
 import argparse
-import os
+
+from backend.utils import env_loader
 
 import uvicorn
 
@@ -20,7 +21,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.component == "api":
-        port = int(os.getenv("API_PORT", "8080"))
+        port = int(env_loader.get_env("API_PORT", "8080"))
         uvicorn.run("backend.api.main:app", host="0.0.0.0", port=port)
     else:
         runner = JobRunner()

--- a/backend/market_data/tick_fetcher.py
+++ b/backend/market_data/tick_fetcher.py
@@ -1,14 +1,11 @@
-import os
 import requests
-from dotenv import load_dotenv
+from backend.utils import env_loader
 
-# Load environment variables from .env files
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '../config/settings.env'))
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '../config/secret.env'))
+# env_loader automatically loads default env files at import time
 
-OANDA_API_URL = os.getenv('OANDA_API_URL', 'https://api-fxtrade.oanda.com/v3')
-OANDA_API_KEY = os.getenv('OANDA_API_KEY')
-OANDA_ACCOUNT_ID = os.getenv('OANDA_ACCOUNT_ID')
+OANDA_API_URL = env_loader.get_env('OANDA_API_URL', 'https://api-fxtrade.oanda.com/v3')
+OANDA_API_KEY = env_loader.get_env('OANDA_API_KEY')
+OANDA_ACCOUNT_ID = env_loader.get_env('OANDA_ACCOUNT_ID')
 
 def fetch_tick_data(instrument: str | None = None, count: int = 1):
     """
@@ -20,7 +17,7 @@ def fetch_tick_data(instrument: str | None = None, count: int = 1):
         dict: JSON response from OANDA API with tick data, or None on error.
     """
     if instrument is None:
-        instrument = os.getenv("DEFAULT_PAIR", "USD_JPY")
+        instrument = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
     if not OANDA_API_KEY or not OANDA_ACCOUNT_ID:
         raise EnvironmentError("OANDA_API_KEY or OANDA_ACCOUNT_ID not set in environment variables.")
     url = f"{OANDA_API_URL}/accounts/{OANDA_ACCOUNT_ID}/pricing"
@@ -42,6 +39,6 @@ def fetch_tick_data(instrument: str | None = None, count: int = 1):
 
 # Example usage (remove or comment out in production)
 if __name__ == "__main__":
-    instrument = os.getenv("DEFAULT_PAIR", "USD_JPY")
+    instrument = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
     data = fetch_tick_data(instrument)
     print(data)

--- a/backend/orders/position_manager.py
+++ b/backend/orders/position_manager.py
@@ -1,18 +1,17 @@
-import os
 import requests
-from dotenv import load_dotenv
+from backend.utils import env_loader
 import logging
 
 logger = logging.getLogger(__name__)
 import json
 
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '../config/secret.env'))
+# env_loader automatically loads default env files at import time
 
 from typing import List, Dict, Any, Optional
 
 # Load OANDA API credentials from environment variables
-OANDA_API_KEY = os.getenv("OANDA_API_KEY")
-OANDA_ACCOUNT_ID = os.getenv("OANDA_ACCOUNT_ID")
+OANDA_API_KEY = env_loader.get_env("OANDA_API_KEY")
+OANDA_ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
 OANDA_API_URL = "https://api-fxtrade.oanda.com/v3"
 
 if not OANDA_API_KEY or not OANDA_ACCOUNT_ID:
@@ -99,7 +98,7 @@ def close_position(pair: str, side: str) -> bool:
 
 # Example: List all open positions (for testing)
 if __name__ == "__main__":
-    instrument = os.getenv('DEFAULT_PAIR', 'USD_JPY')
+    instrument = env_loader.get_env('DEFAULT_PAIR', 'USD_JPY')
     if has_open_position(instrument):
         logger.info(f"Position exists for {instrument}")
         details = get_position_details(instrument)

--- a/backend/strategy/strategy_analyzer.py
+++ b/backend/strategy/strategy_analyzer.py
@@ -1,7 +1,6 @@
 import sqlite3
 from datetime import datetime, timedelta
-import os
-import dotenv
+from backend.utils import env_loader
 import json
 import shutil
 from backend.utils.openai_client import ask_openai
@@ -18,18 +17,18 @@ def load_env_settings():
     """
     .envファイルから戦略パラメータを読み込む
     """
-    dotenv.load_dotenv(SETTINGS_PATH, override=True)
+    env_loader.load_env([SETTINGS_PATH])
     settings = {
-        "RSI_PERIOD": int(os.getenv("RSI_PERIOD", 14)),
-        "EMA_PERIOD": int(os.getenv("EMA_PERIOD", 20)),
-        "ATR_PERIOD": int(os.getenv("ATR_PERIOD", 14)),
-        "BOLLINGER_WINDOW": int(os.getenv("BOLLINGER_WINDOW", 20)),
-        "BOLLINGER_STD": float(os.getenv("BOLLINGER_STD", 2.0)),
-        "RSI_ENTRY_LOWER": int(os.getenv("RSI_ENTRY_LOWER", 30)),
-        "RSI_ENTRY_UPPER": int(os.getenv("RSI_ENTRY_UPPER", 70)),
-        "ATR_ENTRY_THRESHOLD": float(os.getenv("ATR_ENTRY_THRESHOLD", 0.05)),
-        "EMA_DIFF_THRESHOLD": float(os.getenv("EMA_DIFF_THRESHOLD", 0.1)),
-        "BB_POSITION_THRESHOLD": float(os.getenv("BB_POSITION_THRESHOLD", 0.9)),
+        "RSI_PERIOD": int(env_loader.get_env("RSI_PERIOD", 14)),
+        "EMA_PERIOD": int(env_loader.get_env("EMA_PERIOD", 20)),
+        "ATR_PERIOD": int(env_loader.get_env("ATR_PERIOD", 14)),
+        "BOLLINGER_WINDOW": int(env_loader.get_env("BOLLINGER_WINDOW", 20)),
+        "BOLLINGER_STD": float(env_loader.get_env("BOLLINGER_STD", 2.0)),
+        "RSI_ENTRY_LOWER": int(env_loader.get_env("RSI_ENTRY_LOWER", 30)),
+        "RSI_ENTRY_UPPER": int(env_loader.get_env("RSI_ENTRY_UPPER", 70)),
+        "ATR_ENTRY_THRESHOLD": float(env_loader.get_env("ATR_ENTRY_THRESHOLD", 0.05)),
+        "EMA_DIFF_THRESHOLD": float(env_loader.get_env("EMA_DIFF_THRESHOLD", 0.1)),
+        "BB_POSITION_THRESHOLD": float(env_loader.get_env("BB_POSITION_THRESHOLD", 0.9)),
     }
     return settings
 
@@ -73,7 +72,7 @@ def apply_param_changes(changes: dict):
             updated_lines.append(f"{key}={changes[key]}\n")
             seen_keys.add(key)
             # Log parameter change
-            log_param_change(key, os.getenv(key, ""), str(changes[key]), ai_reason="strategy_optimizer")
+            log_param_change(key, env_loader.get_env(key, ""), str(changes[key]), ai_reason="strategy_optimizer")
         else:
             updated_lines.append(line)
 

--- a/backend/utils/db_helper.py
+++ b/backend/utils/db_helper.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 """Simple SQLite helper utilities."""
 
-import os
 import sqlite3
+from backend.utils import env_loader
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
 # Default DB path is repository root / trades.db unless TRADES_DB_PATH env var is set
 _BASE_DIR = Path(__file__).resolve().parents[2]
-DB_PATH = os.getenv("TRADES_DB_PATH", str(_BASE_DIR / "trades.db"))
+DB_PATH = env_loader.get_env("TRADES_DB_PATH", str(_BASE_DIR / "trades.db"))
 
 
 def get_connection(db_path: str | None = None) -> sqlite3.Connection:

--- a/backend/utils/oanda_client.py
+++ b/backend/utils/oanda_client.py
@@ -21,9 +21,9 @@ If no order is found – or an HTTP error occurs – it returns *None*.
 from __future__ import annotations
 
 import json
-import os
 import time
 from typing import Any, Dict, Optional
+from backend.utils import env_loader
 
 import requests
 from requests.exceptions import HTTPError, RequestException
@@ -31,9 +31,9 @@ from requests.exceptions import HTTPError, RequestException
 # ──────────────────────────────────
 #   Environment / Constants
 # ──────────────────────────────────
-OANDA_API_URL = os.getenv("OANDA_API_URL", "https://api-fxtrade.oanda.com/v3")
-OANDA_ACCOUNT_ID = os.getenv("OANDA_ACCOUNT_ID")
-OANDA_API_KEY = os.getenv("OANDA_API_KEY")
+OANDA_API_URL = env_loader.get_env("OANDA_API_URL", "https://api-fxtrade.oanda.com/v3")
+OANDA_ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
+OANDA_API_KEY = env_loader.get_env("OANDA_API_KEY")
 
 if not (OANDA_ACCOUNT_ID and OANDA_API_KEY):
     raise EnvironmentError("OANDA_ACCOUNT_ID / OANDA_API_KEY not configured")

--- a/backend/utils/openai_client.py
+++ b/backend/utils/openai_client.py
@@ -1,13 +1,11 @@
-import os
 from openai import OpenAI, APIError
-from dotenv import load_dotenv
+from backend.utils import env_loader
 import json
 
-# Load environment variables from .env files (if present)
-load_dotenv()
+# env_loader automatically loads default .env files at import time
 
 # Get OpenAI API key from environment
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_API_KEY = env_loader.get_env("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
     raise RuntimeError("OPENAI_API_KEY not set in environment variables.")
 
@@ -15,7 +13,7 @@ if not OPENAI_API_KEY:
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 # Default model can be overridden via settings.env → AI_MODEL
-AI_MODEL = os.getenv("AI_MODEL", "gpt-4o-mini")
+AI_MODEL = env_loader.get_env("AI_MODEL", "gpt-4o-mini")
 
 def ask_openai(prompt: str,
                system_prompt: str = "You are a helpful assistant.",


### PR DESCRIPTION
## Summary
- centralize env loading via `backend.utils.env_loader`
- use `env_loader.get_env` instead of scattered `os.getenv`
- stop reloading `.env` in JobRunner loop
- document automatic env loading in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`