### PR TITLE
Add range center block logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
    The application automatically loads `.env`, `backend/config/settings.env` and
    `backend/config/secret.env` once at startup using `backend.utils.env_loader`.
    Adjust any values in `settings.env` as needed.
+   `RANGE_CENTER_BLOCK_PCT` controls how close to the Bollinger band center price
+   can be when ADX is below `ADX_RANGE_THRESHOLD`. Set to `0.3` (30%) to block
+   entries near the middle of a range, helping suppress counter-trend trades.
 
 ## Running the API
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -130,3 +130,6 @@ COOL_ATR_PCT=0.10
 # --- ADXノートレードゾーン ---
 ADX_NO_TRADE_MIN=20
 ADX_NO_TRADE_MAX=30
+
+# BB中央付近ブロック比（レンジ時）
+RANGE_CENTER_BLOCK_PCT=0.3

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -390,7 +390,8 @@ class JobRunner:
                                 continue
 
                         # ── Entry side ───────────────────────────────
-                        if pass_entry_filter(indicators):
+                        current_price = float(tick_data["prices"][0]["bids"][0]["price"])
+                        if pass_entry_filter(indicators, current_price):
                             logger.info("Filter OK → Processing entry decision with AI.")
                             self.last_ai_call = datetime.now()  # record AI call time *before* the call
                             market_cond = get_market_condition(indicators, candles)


### PR DESCRIPTION
## Summary
- block entries near Bollinger mid-line when ADX is low
- expose RANGE_CENTER_BLOCK_PCT in settings
- pass current price to entry filter
- document new env var in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*