### PR TITLE
Add ai_response tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ as on native x86 hardware.
 
 Trade history is stored in `trades.db` (SQLite) at the repository root. This file is no longer tracked in Git. A pre-populated example is available in `backend/logs/` and is copied to `/app/trades.db` when running inside Docker.
 
+The table now includes an `ai_response` column which stores the full text returned
+by the AI when opening or closing a trade.
+
 If you need a clean database locally, either copy the example file:
 
 ```bash
@@ -75,6 +78,8 @@ from backend.logs.log_manager import init_db
 init_db()
 EOF
 ```
+This helper also upgrades older databases to include the new `ai_response`
+column. See `docs/db_migration.md` for details.
 
 ## React UI
 

--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -38,9 +38,16 @@ def init_db():
                 exit_price REAL,
                 units INTEGER NOT NULL,
                 profit_loss REAL,
-                ai_reason TEXT
+                ai_reason TEXT,
+                ai_response TEXT
             )
         ''')
+
+        # ---- simple migration for older DBs ----
+        cursor.execute("PRAGMA table_info(trades)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if 'ai_response' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN ai_response TEXT')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS ai_decisions (
@@ -83,17 +90,20 @@ def init_db():
         ''')
 
 def log_trade(instrument, entry_time, entry_price, units, ai_reason,
-              entry_regime=None, exit_time=None, exit_price=None, profit_loss=None):
+              ai_response=None, entry_regime=None,
+              exit_time=None, exit_price=None, profit_loss=None):
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute('''
             INSERT INTO trades (
                 instrument, entry_time, entry_price, units,
-                ai_reason, entry_regime, exit_time, exit_price, profit_loss
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ai_reason, ai_response, entry_regime,
+                exit_time, exit_price, profit_loss
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''', (
             instrument, entry_time, entry_price, units,
-            ai_reason, entry_regime, exit_time, exit_price, profit_loss
+            ai_reason, ai_response, entry_regime,
+            exit_time, exit_price, profit_loss
         ))
 
 def log_ai_decision(decision_type, instrument, ai_response):

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -276,9 +276,7 @@ class OrderManager:
             entry_price=entry_price,
             units=units,
             ai_reason=strategy_params.get("ai_reason", "manual"),
-            tp_prob=risk_info.get("tp_prob") if risk_info else None,
-            sl_prob=risk_info.get("sl_prob") if risk_info else None,
-            side=side.upper(),
+            ai_response=strategy_params.get("ai_response"),
             entry_regime=entry_regime
         )
         return result

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -109,6 +109,7 @@ def process_entry(indicators, candles, market_data, market_cond: dict | None = N
             "limit_price": limit_price,
             "entry_uuid": entry_uuid,
             "valid_for_sec": valid_sec,
+            "ai_response": ai_raw,
         }
         result = order_manager.enter_trade(
             side=side,
@@ -134,6 +135,7 @@ def process_entry(indicators, candles, market_data, market_cond: dict | None = N
             "sl_pips": sl_pips,
             "mode": "market",
             "limit_price": limit_price,
+            "ai_response": ai_raw,
         }
 
     trade_result = order_manager.enter_trade(
@@ -150,7 +152,14 @@ def process_entry(indicators, candles, market_data, market_cond: dict | None = N
         units = int(lot_size * 1000) if side == "long" else -int(lot_size * 1000)
         entry_price = float(market_data['prices'][0]['bids'][0]['price'])
         entry_time = datetime.utcnow().isoformat()
-        log_trade(instrument, entry_time, entry_price, units, ai_reason=ai_raw)
+        log_trade(
+            instrument,
+            entry_time=entry_time,
+            entry_price=entry_price,
+            units=units,
+            ai_reason=ai_raw,
+            ai_response=ai_raw
+        )
 
     return True
 

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -1,0 +1,23 @@
+# Database Migration
+
+The `trades` table now stores the full AI response for each entry or exit.
+A new column `ai_response` has been added.
+
+## Updating an existing `trades.db`
+
+Run the migration helper to add the new column if your database was created
+with an earlier version:
+
+```bash
+python - <<'PY'
+from backend.logs.log_manager import init_db
+init_db()
+PY
+```
+
+This will create the `ai_response` column when missing.  Alternatively you can
+execute the SQL below manually:
+
+```sql
+ALTER TABLE trades ADD COLUMN ai_response TEXT;
+```


### PR DESCRIPTION
## Summary
- include AI response in trades table and log_trade
- pass raw AI response from entry and exit logic
- document DB migration steps

## Testing
- `python -m py_compile backend/logs/log_manager.py backend/orders/order_manager.py backend/strategy/entry_logic.py backend/strategy/exit_logic.py`