### PR TITLE
Use multi-timeframe candle data

### DIFF
--- a/backend/market_data/candle_fetcher.py
+++ b/backend/market_data/candle_fetcher.py
@@ -59,9 +59,9 @@ def fetch_multiple_timeframes(instrument=None, timeframes=None):
     """
     if timeframes is None:
         timeframes = {
-            "M5": 50,    # Medium-term trend analysis
             "M1": 20,    # Short-term entry analysis
-            "D": 60      # Long-term trend (approx. 3 months)
+            "M5": 50,    # Medium-term trend analysis
+            "D": 90      # Long-term trend (approx. 3 months)
         }
 
     candles_by_timeframe = {}


### PR DESCRIPTION
## Summary
- adjust default `fetch_multiple_timeframes` intervals
- use `fetch_multiple_timeframes` in `JobRunner`
- update references to use M5 data by default and forward all timeframes to market condition checks

## Testing
- `pytest -q` *(fails: pytest not installed)*