### PR TITLE
Remove duplicate function in indicators

### DIFF
--- a/backend/indicators/calculate_indicators.py
+++ b/backend/indicators/calculate_indicators.py
@@ -97,22 +97,4 @@ def calculate_indicators_multi(market_data_dict: dict[str, list], *, pair: str |
         result[tf] = calculate_indicators(data, pair=pair, history_days=history_days)
     return result
 
-def calculate_indicators_multi(candles_dict: dict[str, list]) -> dict:
-    """Calculate indicators for multiple timeframes.
-
-    Parameters
-    ----------
-    candles_dict : dict[str, list]
-        Dictionary mapping timeframe strings (e.g. "M1", "M5", "D") to candle
-        lists.
-
-    Returns
-    -------
-    dict
-        Dictionary mapping each timeframe to its indicators dictionary.
-    """
-    results: dict[str, dict] = {}
-    for tf, candles in candles_dict.items():
-        results[tf] = calculate_indicators(candles)
-    return results
 


### PR DESCRIPTION
## Summary
- remove redundant `calculate_indicators_multi` definition

## Testing
- `python -m unittest discover backend/tests`