### PR TITLE
Fix BE trigger env var name

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -21,7 +21,7 @@ MIN_TP_PROB: float = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
 LIMIT_THRESHOLD_ATR_RATIO: float = float(env_loader.get_env("LIMIT_THRESHOLD_ATR_RATIO", "0.3"))
 MAX_LIMIT_AGE_SEC: int = int(env_loader.get_env("MAX_LIMIT_AGE_SEC", "180"))
 MIN_NET_TP_PIPS: float = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))
-BREAKEVEN_TRIGGER_PIPS: int = int(env_loader.get_env("BREAKEVEN_TRIGGER_PIPS", 4))
+BE_TRIGGER_PIPS: int = int(env_loader.get_env("BE_TRIGGER_PIPS", 4))
 
 # --- Volatility and ADX filters ---
 COOL_BBWIDTH_PCT: float = float(env_loader.get_env("COOL_BBWIDTH_PCT", "0"))
@@ -147,7 +147,7 @@ def get_exit_decision(market_data, current_position,
         except (ValueError, TypeError):
             pips_from_entry = 0
 
-    breakeven_reached = pips_from_entry >= BREAKEVEN_TRIGGER_PIPS
+    breakeven_reached = pips_from_entry >= BE_TRIGGER_PIPS
 
     # Ensure all indicator values are JSON serializable (e.g., pandas Series to list)
     indicators_serializable = {key: value.tolist() if hasattr(value, 'tolist') else value for key, value in indicators.items()}


### PR DESCRIPTION
## Summary
- unify BE trigger env variable name with existing config

## Testing
- `python -m py_compile backend/strategy/openai_analysis.py`
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement annotated-types==0.7.0)*