### PR TITLE
Add RSI cross-up entry filter

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -512,7 +512,7 @@ class JobRunner:
 
                         # ── Entry side ───────────────────────────────
                         current_price = float(tick_data["prices"][0]["bids"][0]["price"])
-                        if pass_entry_filter(indicators, current_price):
+                        if pass_entry_filter(indicators, current_price, self.indicators_M1):
                             logger.info("Filter OK → Processing entry decision with AI.")
                             self.last_ai_call = datetime.now()  # record AI call time *before* the call
                             market_cond = get_market_condition(

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -52,7 +52,25 @@ def _ema_flat_or_cross(
 #  戻り値 True  → AI へ問い合わせる
 #        False → スキップ
 # ────────────────────────────────────────────────
-def pass_entry_filter(indicators: dict, price: float | None = None) -> bool:
+def _rsi_cross_up(series: pd.Series) -> bool:
+    """Return True when RSI crosses up from <30 to ≥35."""
+    try:
+        length = len(series)
+    except Exception:
+        length = len(getattr(series, "_data", []))
+    if length < 2:
+        return False
+    prev = series.iloc[-2] if hasattr(series, "iloc") else series[-2]
+    latest = series.iloc[-1] if hasattr(series, "iloc") else series[-1]
+    try:
+        return float(prev) < 30 and float(latest) >= 35
+    except Exception:
+        return False
+
+
+def pass_entry_filter(
+    indicators: dict, price: float | None = None, indicators_m1: dict | None = None
+) -> bool:
     """
     Pure rule‑based entry filter.
     Returns True when market conditions warrant querying the AI entry decision.
@@ -63,6 +81,9 @@ def pass_entry_filter(indicators: dict, price: float | None = None) -> bool:
         Indicator dictionary returned by ``calculate_indicators``.
     price : float | None
         Latest market price used for Bollinger band deviation checks.
+    indicators_m1 : dict | None
+        Optional M1 timeframe indicator dictionary. If not provided, the
+        function attempts to fetch M1 candles and compute indicators.
     """
     if os.getenv("DISABLE_ENTRY_FILTER", "false").lower() == "true":
         return True
@@ -113,6 +134,26 @@ def pass_entry_filter(indicators: dict, price: float | None = None) -> bool:
         vol_ok = sma_vol >= min_vol
         if not vol_ok:
             logger.debug("EntryFilter blocked: volume below threshold")
+            return False
+
+    # --- M1 RSI cross-up check ----------------------------------------
+    if indicators_m1 is None:
+        try:
+            from backend.market_data.candle_fetcher import fetch_candles
+            from backend.indicators.calculate_indicators import calculate_indicators
+
+            pair = os.getenv("DEFAULT_PAIR", "USD_JPY")
+            candles_m1 = fetch_candles(pair, granularity="M1", count=10)
+            indicators_m1 = calculate_indicators(candles_m1, pair=pair)
+        except Exception as exc:
+            logger.warning("Failed to fetch M1 indicators: %s", exc)
+            indicators_m1 = None
+
+    if indicators_m1 and indicators_m1.get("rsi") is not None:
+        if not _rsi_cross_up(indicators_m1["rsi"]):
+            logger.debug(
+                "EntryFilter blocked: M1 RSI did not cross up from <30 to >=35"
+            )
             return False
 
     ema_fast = indicators["ema_fast"]

--- a/backend/tests/test_entry_filter_rsi.py
+++ b/backend/tests/test_entry_filter_rsi.py
@@ -1,0 +1,113 @@
+import os
+import unittest
+import datetime
+import types
+import sys
+
+pass_entry_filter = None
+_rsi_cross_up = None
+
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return self._data[idx]
+        if isinstance(idx, int) and idx < 0:
+            raise KeyError(idx)
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+
+class TestEntryFilterRSICross(unittest.TestCase):
+    def setUp(self):
+        self._added_modules = []
+
+        def add_module(name: str, module: types.ModuleType):
+            if name not in sys.modules:
+                sys.modules[name] = module
+                self._added_modules.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add_module("pandas", pandas_stub)
+        add_module("requests", types.ModuleType("requests"))
+
+        stub_modules = [
+            "backend.market_data.tick_fetcher",
+            "backend.market_data.candle_fetcher",
+            "backend.indicators.calculate_indicators",
+            "backend.strategy.higher_tf_analysis",
+        ]
+        for name in stub_modules:
+            mod = types.ModuleType(name)
+            add_module(name, mod)
+
+        sys.modules["backend.market_data.tick_fetcher"].fetch_tick_data = lambda *a, **k: {}
+        sys.modules["backend.market_data.candle_fetcher"].fetch_candles = lambda *a, **k: []
+        sys.modules["backend.indicators.calculate_indicators"].calculate_indicators = lambda *a, **k: {"rsi": FakeSeries([20, 40])}
+        sys.modules["backend.strategy.higher_tf_analysis"].analyze_higher_tf = lambda *a, **k: {}
+
+        global pass_entry_filter, _rsi_cross_up
+        import importlib
+        from backend.strategy import signal_filter as sf
+        importlib.reload(sf)
+        pass_entry_filter = sf.pass_entry_filter
+        _rsi_cross_up = sf._rsi_cross_up
+        now = datetime.datetime.utcnow() + datetime.timedelta(hours=9)
+        start = (now.hour + 1) % 24
+        end = (start + 1) % 24
+        os.environ["QUIET_START_HOUR_JST"] = str(start)
+        os.environ["QUIET_END_HOUR_JST"] = str(end)
+        os.environ["HIGHER_TF_ENABLED"] = "false"
+        os.environ["PIP_SIZE"] = "0.01"
+        os.environ["BAND_WIDTH_THRESH_PIPS"] = "4"
+        os.environ["ATR_ENTRY_THRESHOLD"] = "0.09"
+        os.environ["RSI_ENTRY_LOWER"] = "20"
+        os.environ["RSI_ENTRY_UPPER"] = "80"
+        os.environ["DISABLE_ENTRY_FILTER"] = "false"
+
+    def tearDown(self):
+        for name in getattr(self, "_added_modules", []):
+            sys.modules.pop(name, None)
+
+    def _base_indicators(self):
+        return {
+            "rsi": FakeSeries([50, 50]),
+            "atr": FakeSeries([0.1, 0.1]),
+            "ema_fast": FakeSeries([1, 2]),
+            "ema_slow": FakeSeries([2, 1]),
+            "bb_upper": FakeSeries([1.2, 1.3]),
+            "bb_lower": FakeSeries([1.0, 1.1]),
+            "bb_middle": FakeSeries([1.1, 1.2]),
+            "adx": FakeSeries([30, 30]),
+        }
+
+    def test_rsi_cross_up_helper(self):
+        self.assertTrue(_rsi_cross_up(FakeSeries([25, 35])))
+        self.assertFalse(_rsi_cross_up(FakeSeries([31, 33])))
+
+    def test_pass_entry_filter_blocks_without_cross(self):
+        ind = self._base_indicators()
+        m1 = {"rsi": FakeSeries([31, 33])}
+        result = pass_entry_filter(ind, price=1.2, indicators_m1=m1)
+        self.assertFalse(result)
+
+    def test_pass_entry_filter_allows_with_cross(self):
+        ind = self._base_indicators()
+        m1 = {"rsi": FakeSeries([29, 35])}
+        result = pass_entry_filter(ind, price=1.2, indicators_m1=m1)
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- create helper `_rsi_cross_up`
- block entries unless M1 RSI crosses up from <30 to >=35
- pass M1 indicators from job runner
- add tests for the new filter

## Testing
- `python -m unittest discover -v backend/tests`