### PR TITLE
Handle nested units for cooldown

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -42,11 +42,23 @@ def get_ai_cooldown_sec(current_position: dict | None) -> int:
     Return the appropriate cooldown seconds depending on whether we are flat
     or holding an open position.
     """
-    if (
-        current_position
-        and abs(float(current_position.get("units", 0))) > 0
-    ):
-        return AI_COOLDOWN_SEC_OPEN
+    if current_position:
+        try:
+            units_val = float(current_position.get("units", 0))
+        except (TypeError, ValueError):
+            units_val = 0.0
+        if units_val == 0:
+            try:
+                units_val = float(current_position.get("long", {}).get("units", 0))
+            except (TypeError, ValueError):
+                units_val = 0.0
+            if units_val == 0:
+                try:
+                    units_val = float(current_position.get("short", {}).get("units", 0))
+                except (TypeError, ValueError):
+                    units_val = 0.0
+        if abs(units_val) > 0:
+            return AI_COOLDOWN_SEC_OPEN
     return AI_COOLDOWN_SEC_FLAT
 
 logger = logging.getLogger(__name__)

--- a/backend/tests/test_ai_cooldown.py
+++ b/backend/tests/test_ai_cooldown.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class TestGetAICooldownSec(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        self._added_modules = []
+
+        def add_module(name: str, module: types.ModuleType):
+            if name not in sys.modules:
+                sys.modules[name] = module
+                self._added_modules.append(name)
+
+        add_module("pandas", types.ModuleType("pandas"))
+        openai_stub = types.ModuleType("openai")
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add_module("openai", openai_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add_module("dotenv", dotenv_stub)
+        add_module("requests", types.ModuleType("requests"))
+        add_module("numpy", types.ModuleType("numpy"))
+
+        import backend.strategy.openai_analysis as oa
+        importlib.reload(oa)
+        self.oa = oa
+
+    def tearDown(self):
+        for name in getattr(self, "_added_modules", []):
+            sys.modules.pop(name, None)
+
+    def test_nested_units_long_or_short(self):
+        self.assertEqual(
+            self.oa.get_ai_cooldown_sec({"long": {"units": "1"}}),
+            self.oa.AI_COOLDOWN_SEC_OPEN,
+        )
+        self.assertEqual(
+            self.oa.get_ai_cooldown_sec({"short": {"units": "-2"}}),
+            self.oa.AI_COOLDOWN_SEC_OPEN,
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- inspect nested `long` and `short` positions when determining AI cooldown
- add regression test for `get_ai_cooldown_sec` with nested position units

## Testing
- `python3 -m unittest backend.tests.test_exit_cooldown backend.tests.test_range_index_series backend.tests.test_ai_cooldown -v`