### PR TITLE
Remove unused count parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ If `REACT_APP_API_URL` is omitted, the application defaults to
 
 This project is provided as-is under the MIT license.
 
+## Market Data Utilities
+
+Market data helpers are available under `backend/market_data/`.
+`fetch_tick_data` retrieves the latest pricing snapshot for a specified
+instrument.
+
+```python
+from backend.market_data.tick_fetcher import fetch_tick_data
+
+tick = fetch_tick_data("USD_JPY")
+```
+
 ## Frontend Components
 
 Example React components are provided under `docs/examples/` and are styled with `styled-components` for a dark dashboard UI:

--- a/backend/market_data/tick_fetcher.py
+++ b/backend/market_data/tick_fetcher.py
@@ -7,14 +7,19 @@ OANDA_API_URL = env_loader.get_env('OANDA_API_URL', 'https://api-fxtrade.oanda.c
 OANDA_API_KEY = env_loader.get_env('OANDA_API_KEY')
 OANDA_ACCOUNT_ID = env_loader.get_env('OANDA_ACCOUNT_ID')
 
-def fetch_tick_data(instrument: str | None = None, count: int = 1):
-    """
-    Fetch tick (pricing) data for a given instrument from the OANDA API.
-    Args:
-        instrument (str): The instrument to fetch (e.g. "USD_JPY").
-        count (int): Number of price points to fetch (default: 1).
-    Returns:
-        dict: JSON response from OANDA API with tick data, or None on error.
+def fetch_tick_data(instrument: str | None = None):
+    """Fetch the latest tick (pricing) data from the OANDA API.
+
+    Parameters
+    ----------
+    instrument : str | None
+        The instrument to fetch (e.g. ``"USD_JPY"``). If ``None`` the value of
+        ``DEFAULT_PAIR`` from the environment is used.
+
+    Returns
+    -------
+    dict | None
+        JSON response from the OANDA API with tick data, or ``None`` on error.
     """
     if instrument is None:
         instrument = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")


### PR DESCRIPTION
## Summary
- remove unused `count` parameter from `fetch_tick_data`
- update README with new Market Data Utilities section

## Testing
- `pytest -q` *(fails: command not found)*