### PR TITLE
Fix limit order time in force

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -84,7 +84,7 @@ class OrderManager:
                 "units": str(units),
                 "price": str(limit_price),
                 "instrument": instrument,
-                "timeInForce": "GTC",
+                "timeInForce": "GTD",
                 "type": "LIMIT",
                 "positionFill": "DEFAULT",
                 "clientExtensions": {


### PR DESCRIPTION
## Summary
- ensure gtdTime is used by switching `timeInForce` from `GTC` to `GTD`

## Testing
- `pytest backend/tests` *(fails: command not found)*