### PR TITLE
Add noise estimate to AI prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
  `AI_PROFIT_TRIGGER_RATIO` defines what portion of the take-profit target must
  be reached before an AI exit check occurs. The default value is `0.3` (30%).
  `PULLBACK_LIMIT_OFFSET_PIPS` sets how many pips away from the current price to place an automatic pullback limit order when the AI suggests a market entry.
- `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
+`PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
+`想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
 
 ## Running the API
 

--- a/backend/tests/test_noise_prompt.py
+++ b/backend/tests/test_noise_prompt.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return self._data[idx]
+        if isinstance(idx, int) and idx < 0:
+            raise KeyError(idx)
+        return self._data[idx]
+
+class TestNoiseInPrompt(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        self._added_modules = []
+        def add_module(name: str, module: types.ModuleType):
+            if name not in sys.modules:
+                sys.modules[name] = module
+                self._added_modules.append(name)
+        add_module("pandas", types.ModuleType("pandas"))
+        openai_stub = types.ModuleType("openai")
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add_module("openai", openai_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add_module("dotenv", dotenv_stub)
+        add_module("requests", types.ModuleType("requests"))
+        add_module("numpy", types.ModuleType("numpy"))
+        import backend.strategy.openai_analysis as oa
+        importlib.reload(oa)
+        self.oa = oa
+
+    def tearDown(self):
+        for name in getattr(self, "_added_modules", []):
+            sys.modules.pop(name, None)
+
+    def test_prompt_includes_noise(self):
+        captured = []
+        self.oa.ask_openai = lambda prompt, **k: (captured.append(prompt) or '{"entry": {"side": "no"}}')
+        indicators = {
+            "bb_upper": FakeSeries([1.1]),
+            "bb_lower": FakeSeries([1.0]),
+            "atr": FakeSeries([0.001]),
+        }
+        self.oa.get_trade_plan({}, {"M5": indicators}, {"M5": []})
+        self.assertTrue(captured)
+        self.assertIn("想定ノイズ", captured[0])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute short-term noise from ATR and Bollinger band width
- mention estimated noise in the trade-planning prompt
- document the new prompt info in README
- add regression test ensuring the prompt includes `想定ノイズ`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*