### PR TITLE
Add higher timeframe input to exit logic

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -387,7 +387,12 @@ class JobRunner:
                                     }
                                 )
                                 logger.debug(f"Market condition (exit): {market_cond}")
-                                exit_executed = process_exit(indicators, tick_data, market_cond)
+                                exit_executed = process_exit(
+                                    indicators,
+                                    tick_data,
+                                    market_cond,
+                                    higher_tf,
+                                )
                                 if exit_executed:
                                     self.last_close_ts = datetime.utcnow()
                                     logger.info("Position closed based on AI recommendation.")
@@ -456,7 +461,12 @@ class JobRunner:
                                 }
                             )
                             logger.debug(f"Market condition (review): {market_cond}")
-                            exit_executed = process_exit(indicators, tick_data, market_cond)
+                            exit_executed = process_exit(
+                                indicators,
+                                tick_data,
+                                market_cond,
+                                higher_tf,
+                            )
                             if exit_executed:
                                 self.last_close_ts = datetime.utcnow()
                                 logger.info("Position closed based on AI recommendation.")


### PR DESCRIPTION
## Summary
- modify `decide_exit` to accept higher timeframe data
- pass higher timeframe data through `process_exit` and job runner

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*