### PR TITLE
Add M1 indicator input to exit decision flow

### DIFF
--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -48,6 +48,7 @@ def decide_exit(
     market_cond: Dict[str, Any] | None = None,
     *,
     higher_tf: Dict[str, Any] | None = None,
+    indicators_m1: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """
     Use AI to decide whether to exit the given position.
@@ -88,6 +89,7 @@ def decide_exit(
         entry_regime,
         market_cond,
         higher_tf=higher_tf,
+        indicators_m1=indicators_m1,
     )
     raw = ai_response if isinstance(ai_response, str) else json.dumps(ai_response)
 
@@ -131,7 +133,13 @@ def decide_exit(
     # ----- fallback for unknown type -----
     return {"decision": "HOLD", "reason": "Unrecognized AI response", "raw": raw}
 
-def process_exit(indicators, market_data, market_cond=None, higher_tf=None):
+def process_exit(
+    indicators,
+    market_data,
+    market_cond=None,
+    higher_tf=None,
+    indicators_m1=None,
+):
     default_pair = os.getenv("DEFAULT_PAIR", "USD_JPY")
     position = get_position_details(default_pair)
     if position is None:
@@ -192,6 +200,7 @@ def process_exit(indicators, market_data, market_cond=None, higher_tf=None):
                 entry_regime=position.get("entry_regime"),
                 market_cond=market_cond,
                 higher_tf=higher_tf,
+                indicators_m1=indicators_m1,
             )
             logging.info(f"AI early‑exit decision: {exit_decision['decision']} | Reason: {exit_decision['reason']}")
 
@@ -221,6 +230,7 @@ def process_exit(indicators, market_data, market_cond=None, higher_tf=None):
         entry_regime=position.get("entry_regime"),
         market_cond=market_cond,
         higher_tf=higher_tf,
+        indicators_m1=indicators_m1,
     )
     logging.info(f"AI exit decision: {exit_decision['decision']} | Reason: {exit_decision['reason']}")
 

--- a/backend/tests/test_exit_cooldown.py
+++ b/backend/tests/test_exit_cooldown.py
@@ -45,9 +45,9 @@ class TestExitDecisionCooldown(unittest.TestCase):
             return "{}"
         self.oa.ask_openai = dummy_ask
         pos = {"units": "1", "average_price": "1"}
-        self.oa.get_exit_decision({}, pos)
+        self.oa.get_exit_decision({}, pos, indicators_m1={})
         self.assertEqual(len(calls), 1)
-        result = self.oa.get_exit_decision({}, pos)
+        result = self.oa.get_exit_decision({}, pos, indicators_m1={})
         self.assertEqual(len(calls), 1, "ask_openai should not be called during cooldown")
         self.assertIn("Cooldown active", result)
 

--- a/backend/tests/test_range_index_series.py
+++ b/backend/tests/test_range_index_series.py
@@ -115,7 +115,7 @@ class TestSeriesHandling(unittest.TestCase):
             "instrument": "EUR_USD",
         }
         tick = {"prices": [{"bids": [{"price": "1"}], "asks": [{"price": "2"}]}]}
-        context = self.jr.build_exit_context(position, tick, indicators)
+        context = self.jr.build_exit_context(position, tick, indicators, {})
         self.assertEqual(context["atr_pips"], 2)
         self.assertEqual(context["rsi"], 40)
         self.assertEqual(context["ema_slope"], 0.2)


### PR DESCRIPTION
## Summary
- pass M1 timeframe indicators to exit AI routines
- include M1 indicator data in exit prompts
- wire JobRunner to supply M1 indicators
- update unit tests for new parameter

## Testing
- `python -m unittest discover backend/tests`