### PR TITLE
Add chart pattern support

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -81,6 +81,15 @@ order_mgr = OrderManager()
 
 DEFAULT_PAIR = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
 
+# Comma-separated chart pattern names used for AI analysis
+PATTERN_NAMES = [
+    p.strip()
+    for p in env_loader.get_env(
+        "PATTERN_NAMES", "double_bottom,double_top"
+    ).split(",")
+    if p.strip()
+]
+
 OANDA_API_KEY = env_loader.get_env("OANDA_API_KEY")
 OANDA_ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
 # ----- limit‑order housekeeping ------------------------------------
@@ -178,7 +187,12 @@ class JobRunner:
         try:
             candles_dict = {"M5": candles}
             indicators_multi = {"M5": indicators}
-            plan = get_trade_plan(tick_data, indicators_multi or {}, candles_dict or {})
+            plan = get_trade_plan(
+                tick_data,
+                indicators_multi or {},
+                candles_dict or {},
+                patterns=PATTERN_NAMES,
+            )
         except Exception as exc:
             logger.warning(f"get_trade_plan failed: {exc}")
             return
@@ -399,6 +413,7 @@ class JobRunner:
                                     market_cond,
                                     higher_tf,
                                     indicators_m1=self.indicators_M1,
+                                    patterns=PATTERN_NAMES,
                                 )
                                 if exit_executed:
                                     self.last_close_ts = datetime.utcnow()
@@ -474,6 +489,7 @@ class JobRunner:
                                 market_cond,
                                 higher_tf,
                                 indicators_m1=self.indicators_M1,
+                                patterns=PATTERN_NAMES,
                             )
                             if exit_executed:
                                 self.last_close_ts = datetime.utcnow()
@@ -551,6 +567,7 @@ class JobRunner:
                                 tick_data,
                                 market_cond,
                                 higher_tf=higher_tf,
+                                patterns=PATTERN_NAMES,
                             )
                             if not result:
                                 logger.info("process_entry returned False → aborting entry and continuing loop")

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -34,6 +34,7 @@ def process_entry(
     strategy_params=None,
     *,
     higher_tf: dict | None = None,
+    patterns: list[str] | None = None,
 ):
     """
     Ask OpenAI whether to enter a trade.
@@ -57,7 +58,12 @@ def process_entry(
     # ------------------------------------------------------------
     candles_dict = {"M5": candles}
     indicators_multi = {"M5": indicators}
-    plan = get_trade_plan(market_data, indicators_multi, candles_dict)
+    plan = get_trade_plan(
+        market_data,
+        indicators_multi,
+        candles_dict,
+        patterns=patterns,
+    )
 
     # Raw JSON for audit log
     ai_raw = json.dumps(plan, ensure_ascii=False)

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -49,6 +49,7 @@ def decide_exit(
     *,
     higher_tf: Dict[str, Any] | None = None,
     indicators_m1: Dict[str, Any] | None = None,
+    patterns: list[str] | None = None,
 ) -> Dict[str, Any]:
     """
     Use AI to decide whether to exit the given position.
@@ -90,6 +91,7 @@ def decide_exit(
         market_cond,
         higher_tf=higher_tf,
         indicators_m1=indicators_m1,
+        patterns=patterns,
     )
     raw = ai_response if isinstance(ai_response, str) else json.dumps(ai_response)
 
@@ -139,6 +141,7 @@ def process_exit(
     market_cond=None,
     higher_tf=None,
     indicators_m1=None,
+    patterns=None,
 ):
     default_pair = os.getenv("DEFAULT_PAIR", "USD_JPY")
     position = get_position_details(default_pair)
@@ -201,6 +204,7 @@ def process_exit(
                 market_cond=market_cond,
                 higher_tf=higher_tf,
                 indicators_m1=indicators_m1,
+                patterns=patterns,
             )
             logging.info(f"AI early‑exit decision: {exit_decision['decision']} | Reason: {exit_decision['reason']}")
 
@@ -231,6 +235,7 @@ def process_exit(
         market_cond=market_cond,
         higher_tf=higher_tf,
         indicators_m1=indicators_m1,
+        patterns=patterns,
     )
     logging.info(f"AI exit decision: {exit_decision['decision']} | Reason: {exit_decision['reason']}")
 


### PR DESCRIPTION
## Summary
- allow JobRunner to pass chart pattern names to OpenAI analysis
- forward patterns through entry_logic and exit_logic
- enable pattern detection when renewing limits and evaluating entries/exits

## Testing
- `python3 -m unittest backend/tests/test_pattern_prompt.py`
- `python3 -m unittest backend/tests/test_pattern_ai_detection.py`
