### PR TITLE
Implement dynamic pullback offsets and limit order handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
    entries near the middle of a range, helping suppress counter-trend trades.
  `AI_PROFIT_TRIGGER_RATIO` defines what portion of the take-profit target must
  be reached before an AI exit check occurs. The default value is `0.3` (30%).
- `PULLBACK_LIMIT_OFFSET_PIPS` sets how many pips away from the current price to place an automatic pullback limit order when the AI suggests a market entry.
-`PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
+  `PULLBACK_LIMIT_OFFSET_PIPS` is the base distance for a pullback LIMIT order when the AI proposes a market entry. The actual offset is derived from ATR and ADX, and if price runs away while the trend persists the order is converted to a market order.
+ `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
 
 ## Running the API

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -159,6 +159,48 @@ class JobRunner:
                     _pending_limits.pop(key, None)
             return
 
+        local_info = None
+        for key, info in _pending_limits.items():
+            if info.get("order_id") == pend.get("order_id"):
+                local_info = info | {"key": key}
+                break
+
+        if local_info:
+            pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+            price = (
+                float(tick_data["prices"][0]["bids"][0]["price"])
+                if local_info.get("side") == "long"
+                else float(tick_data["prices"][0]["asks"][0]["price"])
+            )
+            limit_price = float(local_info.get("limit_price", price))
+            diff_pips = abs(price - limit_price) / pip_size
+
+            atr_series = indicators.get("atr")
+            if atr_series is not None and len(atr_series):
+                atr_val = atr_series.iloc[-1] if hasattr(atr_series, "iloc") else atr_series[-1]
+                atr_pips = float(atr_val) / pip_size
+            else:
+                atr_pips = 0.0
+
+            threshold_ratio = float(env_loader.get_env("LIMIT_THRESHOLD_ATR_RATIO", "0.3"))
+            adx_series = indicators.get("adx")
+            adx_val = adx_series.iloc[-1] if adx_series is not None and len(adx_series) else 0.0
+            if atr_pips and diff_pips >= atr_pips * threshold_ratio and adx_val >= 25:
+                try:
+                    logger.info(
+                        f"Switching LIMIT {pend['order_id']} to market (diff {diff_pips:.1f} pips)"
+                    )
+                    order_mgr.cancel_order(pend["order_id"])
+                    units = int(float(env_loader.get_env("TRADE_LOT_SIZE", "1.0")) * 1000)
+                    if local_info.get("side") == "short":
+                        units = -units
+                    order_mgr.place_market_order(instrument, units)
+                except Exception as exc:
+                    logger.warning(f"Failed to convert to market order: {exc}")
+                finally:
+                    _pending_limits.pop(local_info["key"], None)
+                return
+
         age = time.time() - pend["ts"]
         if age < self.max_limit_age_sec:
             return
@@ -218,6 +260,8 @@ class JobRunner:
                 "instrument": instrument,
                 "order_id": result.get("order_id"),
                 "ts": int(datetime.utcnow().timestamp()),
+                "limit_price": limit_price,
+                "side": side,
             }
             logger.info(f"Renewed LIMIT order {result.get('order_id')}")
 

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -26,6 +26,41 @@ def pullback_limit(side: str, price: float, offset_pips: float) -> float:
     return price - offset_pips * pip_size if side == "long" else price + offset_pips * pip_size
 
 
+def calculate_pullback_offset(indicators: dict, market_cond: dict | None) -> float:
+    """Return dynamic pullback offset in pips.
+
+    The base value comes from ``PULLBACK_LIMIT_OFFSET_PIPS`` and is adjusted
+    according to the latest ATR value and trend strength (ADX).
+    """
+    offset = float(env_loader.get_env("PULLBACK_LIMIT_OFFSET_PIPS", "2"))
+    try:
+        pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+
+        atr_series = indicators.get("atr")
+        if atr_series is not None and len(atr_series):
+            atr_val = atr_series.iloc[-1] if hasattr(atr_series, "iloc") else atr_series[-1]
+            atr_pips = float(atr_val) / pip_size
+            ratio = float(env_loader.get_env("PULLBACK_ATR_RATIO", "0.5"))
+            offset = offset + atr_pips * ratio
+
+        adx_series = indicators.get("adx")
+        if (
+            market_cond
+            and market_cond.get("market_condition") == "trend"
+            and adx_series is not None
+            and len(adx_series)
+        ):
+            adx_val = adx_series.iloc[-1] if hasattr(adx_series, "iloc") else adx_series[-1]
+            if float(adx_val) >= 30:
+                offset *= 1.5
+            elif float(adx_val) < 20:
+                offset *= 0.7
+    except Exception as exc:
+        logging.debug(f"[calculate_pullback_offset] failed: {exc}")
+
+    return offset
+
+
 def process_entry(
     indicators,
     candles,
@@ -103,7 +138,7 @@ def process_entry(
                     offset = pullback
                     break
         if offset == 0.0:
-            offset = float(env_loader.get_env("PULLBACK_LIMIT_OFFSET_PIPS", "0"))
+            offset = calculate_pullback_offset(indicators, market_cond)
         if offset and price_ref is not None:
             limit_price = pullback_limit(side, price_ref, offset)
             mode = "limit"
@@ -182,6 +217,8 @@ def process_entry(
                 "instrument": instrument,
                 "order_id": result.get("order_id"),
                 "ts": int(datetime.utcnow().timestamp()),
+                "limit_price": limit_price,
+                "side": side,
             }
         return bool(result)
     else:

--- a/backend/tests/test_dynamic_pullback.py
+++ b/backend/tests/test_dynamic_pullback.py
@@ -1,0 +1,129 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return self._data[idx]
+        if isinstance(idx, int) and idx < 0:
+            raise KeyError(idx)
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+class TestDynamicPullback(unittest.TestCase):
+    def setUp(self):
+        self._added = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._added.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        add("requests", types.ModuleType("requests"))
+        add("numpy", types.ModuleType("numpy"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.get_trade_plan = lambda *a, **k: {"entry": {"side": "long", "mode": "market"}, "risk": {"tp_pips": 10, "sl_pips": 5}}
+        oa.get_market_condition = lambda *a, **k: {"market_condition": "trend", "trend_direction": "long"}
+        add("backend.strategy.openai_analysis", oa)
+
+        om = types.ModuleType("backend.orders.order_manager")
+        class DummyMgr:
+            def __init__(self):
+                self.market_called = False
+            def enter_trade(self, side, lot_size, market_data, strategy_params, force_limit_only=False):
+                return {"order_id": "1"}
+            def place_market_order(self, instrument, units):
+                self.market_called = True
+                return {"order_id": "m1"}
+            def cancel_order(self, oid):
+                pass
+        om.OrderManager = DummyMgr
+        add("backend.orders.order_manager", om)
+
+        log_mod = types.ModuleType("backend.logs.log_manager")
+        log_mod.log_trade = lambda *a, **k: None
+        add("backend.logs.log_manager", log_mod)
+
+        oc = types.ModuleType("backend.utils.oanda_client")
+        oc.get_pending_entry_order = lambda instrument: {"order_id": "1", "ts": 0}
+        add("backend.utils.oanda_client", oc)
+
+        stub_names = [
+            "backend.market_data.tick_fetcher",
+            "backend.market_data.candle_fetcher",
+            "backend.indicators.calculate_indicators",
+            "backend.strategy.exit_logic",
+            "backend.orders.position_manager",
+            "backend.strategy.signal_filter",
+            "backend.strategy.higher_tf_analysis",
+            "backend.utils.notification",
+            "backend.logs.update_oanda_trades",
+            "backend.logs.log_manager",
+        ]
+        for name in stub_names:
+            mod = types.ModuleType(name)
+            add(name, mod)
+
+        sys.modules["backend.market_data.tick_fetcher"].fetch_tick_data = lambda *a, **k: None
+        sys.modules["backend.market_data.candle_fetcher"].fetch_multiple_timeframes = lambda *a, **k: {"M5": []}
+        sys.modules["backend.indicators.calculate_indicators"].calculate_indicators = lambda *a, **k: {}
+        sys.modules["backend.indicators.calculate_indicators"].calculate_indicators_multi = lambda *a, **k: {"M5": {}}
+        sys.modules["backend.strategy.exit_logic"].process_exit = lambda *a, **k: None
+        sys.modules["backend.orders.position_manager"].check_current_position = lambda *a, **k: None
+        sys.modules["backend.strategy.signal_filter"].pass_entry_filter = lambda *a, **k: True
+        sys.modules["backend.strategy.signal_filter"].pass_exit_filter = lambda *a, **k: True
+        sys.modules["backend.strategy.higher_tf_analysis"].analyze_higher_tf = lambda *a, **k: {}
+        sys.modules["backend.utils.notification"].send_line_message = lambda *a, **k: None
+        sys.modules["backend.logs.update_oanda_trades"].update_oanda_trades = lambda *a, **k: None
+        sys.modules["backend.logs.update_oanda_trades"].fetch_trade_details = lambda *a, **k: {}
+        sys.modules["backend.logs.log_manager"].get_db_connection = lambda *a, **k: None
+        sys.modules["backend.logs.log_manager"].log_trade = lambda *a, **k: None
+
+        os.environ["PULLBACK_LIMIT_OFFSET_PIPS"] = "2"
+        os.environ["PULLBACK_ATR_RATIO"] = "0.5"
+        os.environ["PIP_SIZE"] = "0.01"
+
+        import backend.strategy.entry_logic as el
+        import backend.scheduler.job_runner as jr
+        importlib.reload(el)
+        importlib.reload(jr)
+        self.el = el
+        self.jr = jr
+        self.runner = jr.JobRunner(interval_seconds=1)
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+
+    def test_calculate_offset_atr(self):
+        indicators = {"atr": FakeSeries([0.2]), "adx": FakeSeries([40])}
+        offset = self.el.calculate_pullback_offset(indicators, {"market_condition": "trend"})
+        self.assertGreater(offset, 2)
+
+    def test_switch_limit_to_market(self):
+        self.el._pending_limits.clear()
+        self.el._pending_limits["a"] = {"instrument": "USD_JPY", "order_id": "1", "ts": 0, "limit_price": 1.0, "side": "long"}
+        indicators = {"atr": FakeSeries([0.1]), "adx": FakeSeries([40])}
+        tick = {"prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.05"}], "asks": [{"price": "1.06"}]}]}
+        self.runner._manage_pending_limits("USD_JPY", indicators, [], tick)
+        self.assertTrue(self.jr.order_mgr.market_called)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute dynamic pullback offsets from ATR and ADX
- convert aged limits to market orders when trend continues
- store extra info about pending limit orders
- document new behaviour of `PULLBACK_LIMIT_OFFSET_PIPS`
- add dynamic pullback unit tests

## Testing
- `python -m unittest backend.tests.test_dynamic_pullback -v`
- `python -m unittest discover -s backend/tests -p 'test_*.py'`
