### PR TITLE
Add AI-driven limit order conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
    entries near the middle of a range, helping suppress counter-trend trades.
  `AI_PROFIT_TRIGGER_RATIO` defines what portion of the take-profit target must
  be reached before an AI exit check occurs. The default value is `0.3` (30%).
-  `PULLBACK_LIMIT_OFFSET_PIPS` is the base distance for a pullback LIMIT order when the AI proposes a market entry. The actual offset is derived from ATR and ADX, and if price runs away while the trend persists the order is converted to a market order.
- `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
+`PULLBACK_LIMIT_OFFSET_PIPS` is the base distance for a pullback LIMIT order when the AI proposes a market entry. The actual offset is derived from ATR and ADX, and if price runs away while the trend persists the order can be switched to a market order under AI control.
+`AI_LIMIT_CONVERT_MODEL` sets the OpenAI model used when asking whether a pending LIMIT should be switched to a market order. The default is `gpt-4o-mini`.
+`PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
 `PATTERN_NAMES` lists chart pattern names passed to the AI for detection, e.g. `double_bottom,double_top`.
 `USE_LOCAL_PATTERN` を `true` にすると、AI を使わずローカルの `pattern_scanner` でチャートパターンを判定します。デフォルトは `false` です。

--- a/backend/config/default_settings.json
+++ b/backend/config/default_settings.json
@@ -56,6 +56,7 @@
     "MIN_TP_PROB": 0.75,
     "TP_PROB_HOURS": 24,
     "AI_TRADE_MODEL": "gpt-4o-mini",
+    "AI_LIMIT_CONVERT_MODEL": "gpt-4o-mini",
     "LIMIT_THRESHOLD_ATR_RATIO": 0.3,
     "MAX_LIMIT_AGE_SEC": 180,
     "MAX_LIMIT_RETRY": 3,

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -112,6 +112,7 @@ TP_PROB_HOURS=1
 
 # --- Unified AI trade model ---
 AI_TRADE_MODEL=gpt-4.1-nano
+AI_LIMIT_CONVERT_MODEL=gpt-4o-mini
 
 # --- Limit‑order parameters ---
 # ATR 比による指値エントリー閾値（0.3 = 30% ATR 以上の乖離で指値に切替）

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -19,7 +19,11 @@ from backend.orders.position_manager import check_current_position
 from backend.orders.order_manager import OrderManager
 from backend.strategy.signal_filter import pass_entry_filter
 from backend.strategy.signal_filter import pass_exit_filter
-from backend.strategy.openai_analysis import get_market_condition, get_trade_plan
+from backend.strategy.openai_analysis import (
+    get_market_condition,
+    get_trade_plan,
+    should_convert_limit_to_market,
+)
 from backend.strategy.higher_tf_analysis import analyze_higher_tf
 import requests
 
@@ -195,20 +199,33 @@ class JobRunner:
             adx_series = indicators.get("adx")
             adx_val = adx_series.iloc[-1] if adx_series is not None and len(adx_series) else 0.0
             if atr_pips and diff_pips >= atr_pips * threshold_ratio and adx_val >= 25:
+                ctx = {
+                    "diff_pips": diff_pips,
+                    "atr_pips": atr_pips,
+                    "adx": adx_val,
+                    "side": local_info.get("side"),
+                }
                 try:
-                    logger.info(
-                        f"Switching LIMIT {pend['order_id']} to market (diff {diff_pips:.1f} pips)"
-                    )
-                    order_mgr.cancel_order(pend["order_id"])
-                    units = int(float(env_loader.get_env("TRADE_LOT_SIZE", "1.0")) * 1000)
-                    if local_info.get("side") == "short":
-                        units = -units
-                    order_mgr.place_market_order(instrument, units)
+                    allow = should_convert_limit_to_market(ctx)
                 except Exception as exc:
-                    logger.warning(f"Failed to convert to market order: {exc}")
-                finally:
-                    _pending_limits.pop(local_info["key"], None)
-                return
+                    logger.warning(f"AI check failed: {exc}")
+                    allow = False
+
+                if allow:
+                    try:
+                        logger.info(
+                            f"Switching LIMIT {pend['order_id']} to market (diff {diff_pips:.1f} pips)"
+                        )
+                        order_mgr.cancel_order(pend["order_id"])
+                        units = int(float(env_loader.get_env("TRADE_LOT_SIZE", "1.0")) * 1000)
+                        if local_info.get("side") == "short":
+                            units = -units
+                        order_mgr.place_market_order(instrument, units)
+                    except Exception as exc:
+                        logger.warning(f"Failed to convert to market order: {exc}")
+                    finally:
+                        _pending_limits.pop(local_info["key"], None)
+                    return
 
         age = time.time() - pend["ts"]
         if age < self.max_limit_age_sec:

--- a/backend/tests/test_dynamic_pullback.py
+++ b/backend/tests/test_dynamic_pullback.py
@@ -41,6 +41,7 @@ class TestDynamicPullback(unittest.TestCase):
         oa = types.ModuleType("backend.strategy.openai_analysis")
         oa.get_trade_plan = lambda *a, **k: {"entry": {"side": "long", "mode": "market"}, "risk": {"tp_pips": 10, "sl_pips": 5}}
         oa.get_market_condition = lambda *a, **k: {"market_condition": "trend", "trend_direction": "long"}
+        oa.should_convert_limit_to_market = lambda ctx: True
         add("backend.strategy.openai_analysis", oa)
 
         om = types.ModuleType("backend.orders.order_manager")

--- a/backend/tests/test_pullback_limit.py
+++ b/backend/tests/test_pullback_limit.py
@@ -40,6 +40,7 @@ class TestPullbackLimit(unittest.TestCase):
 
         oa = types.ModuleType("backend.strategy.openai_analysis")
         oa.get_trade_plan = lambda *a, **k: {"entry": {"side": "long", "mode": "market"}, "risk": {"tp_pips": 10, "sl_pips": 5}}
+        oa.should_convert_limit_to_market = lambda ctx: True
         add("backend.strategy.openai_analysis", oa)
 
         om = types.ModuleType("backend.orders.order_manager")


### PR DESCRIPTION
## Summary
- support AI-driven LIMIT→MARKET conversion via `should_convert_limit_to_market`
- use new helper inside `_manage_pending_limits`
- document the feature and add `AI_LIMIT_CONVERT_MODEL`
- update configs for the new env var
- adapt unit tests for the extra function

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*