### PR TITLE
Add scan for pattern detection across timeframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ print(result)
 返り値は `{"pattern": "<一致したパターン名>"}` もしくは `{"pattern": None}` の形式です。
 
 `USE_LOCAL_PATTERN=true` を設定すると、OpenAI を使用せずローカル判定を行います。
+ローカル判定時は `pattern_scanner.scan()` を使うことで複数時間足のローソク足データ
+から時間足ごとの検出結果を得られます。
 
 対応パターン例:
 - `double_bottom`

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -206,6 +206,17 @@ def get_exit_decision(
                 pattern_name = pattern_res.get("pattern")
         except Exception:
             pattern_name = None
+
+    pattern_line = None
+    if detected_patterns:
+        try:
+            pattern_line = ", ".join(
+                f"{tf}:{p}" for tf, p in detected_patterns.items() if p
+            ) or None
+        except Exception:
+            pattern_line = str(detected_patterns)
+    elif pattern_name:
+        pattern_line = pattern_name
             
     prompt = (
         "You are an expert FX trader AI. Your job is to decide, with clear and concise reasoning, whether to HOLD or EXIT an open position based on the latest market context and indicators.\n\n"
@@ -320,6 +331,17 @@ def get_trade_plan(
                 pattern_name = pattern_res.get("pattern")
         except Exception:
             pattern_name = None
+
+    pattern_line = None
+    if detected_patterns:
+        try:
+            pattern_line = ", ".join(
+                f"{tf}:{p}" for tf, p in detected_patterns.items() if p
+            ) or None
+        except Exception:
+            pattern_line = str(detected_patterns)
+    elif pattern_name:
+        pattern_line = pattern_name
 
     # --------------------------------------------------------------
     # Estimate market "noise" from ATR and Bollinger band width

--- a/backend/strategy/pattern_scanner.py
+++ b/backend/strategy/pattern_scanner.py
@@ -52,3 +52,29 @@ def scan_all(data: Iterable[Mapping]) -> str | None:
     if detect_double_top(rows):
         return "double_top"
     return None
+
+
+def scan(candles_dict: dict[str, list], pattern_names: list[str]) -> dict[str, str | None]:
+    """Scan candle data for chart patterns per timeframe.
+
+    Parameters
+    ----------
+    candles_dict : dict[str, list]
+        Mapping of timeframe labels to candle lists.
+    pattern_names : list[str]
+        Names of patterns to check. Currently unused but kept for
+        compatibility with the AI interface.
+
+    Returns
+    -------
+    dict[str, str | None]
+        Detected pattern name for each timeframe, or ``None`` if no match.
+    """
+
+    results: dict[str, str | None] = {}
+    for tf, candles in candles_dict.items():
+        try:
+            results[tf] = scan_all(candles)
+        except Exception:
+            results[tf] = None
+    return results

--- a/backend/tests/test_pattern_scanner.py
+++ b/backend/tests/test_pattern_scanner.py
@@ -109,5 +109,22 @@ class TestPatternScanner(unittest.TestCase):
         ]
         self.assertEqual(self.ps.scan_all(data), "double_top")
 
+    def test_scan_multi_timeframes(self):
+        data_bottom = [
+            {"o": 1.2, "h": 1.25, "l": 1.0, "c": 1.1},
+            {"o": 1.1, "h": 1.3, "l": 1.1, "c": 1.2},
+            {"o": 1.2, "h": 1.24, "l": 1.0, "c": 1.1},
+            {"o": 1.1, "h": 1.35, "l": 1.1, "c": 1.3},
+        ]
+        data_top = [
+            {"o": 1.0, "h": 1.4, "l": 0.9, "c": 1.3},
+            {"o": 1.3, "h": 1.4, "l": 1.2, "c": 1.3},
+            {"o": 1.3, "h": 1.2, "l": 1.0, "c": 1.1},
+            {"o": 1.1, "h": 1.4, "l": 1.1, "c": 1.3},
+            {"o": 1.3, "h": 1.1, "l": 0.8, "c": 0.9},
+        ]
+        result = self.ps.scan({"M1": data_bottom, "M5": data_top}, ["double_bottom", "double_top"])
+        self.assertEqual(result, {"M1": "double_bottom", "M5": "double_top"})
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add new `scan` that loops over all timeframe candles
- show example usage of `pattern_scanner.scan()` in README when using local pattern detection
- update OpenAI analysis helpers to display detected patterns from multiple timeframes
- add unit test for multi-timeframe scan

## Testing
- `python -m unittest discover -s backend/tests -p 'test_*.py' -v`