### PR TITLE
Add head and shoulders pattern detection

### DIFF
--- a/backend/strategy/pattern_scanner.py
+++ b/backend/strategy/pattern_scanner.py
@@ -45,12 +45,75 @@ def detect_double_top(data: list[dict]) -> bool:
                 return True
     return False
 
-def scan_all(data: Iterable[Mapping]) -> str | None:
+
+def _find_max_index(seq: list[float]) -> int:
+    return seq.index(max(seq)) if seq else -1
+
+
+def _find_min_index(seq: list[float]) -> int:
+    return seq.index(min(seq)) if seq else -1
+
+
+def detect_head_and_shoulders(data: list[dict]) -> bool:
+    """Very naive head-and-shoulders detection."""
+    if len(data) < 5:
+        return False
+    highs = [row['h'] for row in data]
+    head_idx = _find_max_index(highs)
+    if head_idx in (0, len(highs) - 1):
+        return False
+    left_idx = _find_max_index(highs[:head_idx])
+    right_idx = _find_max_index(highs[head_idx + 1:])
+    if left_idx < 0 or right_idx < 0:
+        return False
+    right_idx += head_idx + 1
+    left = highs[left_idx]
+    right = highs[right_idx]
+    head = highs[head_idx]
+    if head <= left or head <= right:
+        return False
+    if not _is_close(left, right, tol=head * 0.05):
+        return False
+    return True
+
+
+def detect_inverse_head_and_shoulders(data: list[dict]) -> bool:
+    """Inverse head-and-shoulders pattern."""
+    if len(data) < 5:
+        return False
+    lows = [row['l'] for row in data]
+    head_idx = _find_min_index(lows)
+    if head_idx in (0, len(lows) - 1):
+        return False
+    left_idx = _find_min_index(lows[:head_idx])
+    right_idx = _find_min_index(lows[head_idx + 1:])
+    if left_idx < 0 or right_idx < 0:
+        return False
+    right_idx += head_idx + 1
+    left = lows[left_idx]
+    right = lows[right_idx]
+    head = lows[head_idx]
+    if head >= left or head >= right:
+        return False
+    if not _is_close(left, right, tol=abs(head) * 0.05):
+        return False
+    return True
+
+PATTERN_FUNCS = {
+    "double_bottom": detect_double_bottom,
+    "double_top": detect_double_top,
+    "head_and_shoulders": detect_head_and_shoulders,
+    "inverse_head_and_shoulders": detect_inverse_head_and_shoulders,
+}
+
+
+def scan_all(data: Iterable[Mapping], pattern_names: list[str] | None = None) -> str | None:
     rows = _as_list(data)
-    if detect_double_bottom(rows):
-        return "double_bottom"
-    if detect_double_top(rows):
-        return "double_top"
+    names = pattern_names or list(PATTERN_FUNCS.keys())
+    for name in names:
+        func = PATTERN_FUNCS.get(name)
+        if func and func(rows):
+            return name
     return None
 
 
@@ -62,8 +125,7 @@ def scan(candles_dict: dict[str, list], pattern_names: list[str]) -> dict[str, s
     candles_dict : dict[str, list]
         Mapping of timeframe labels to candle lists.
     pattern_names : list[str]
-        Names of patterns to check. Currently unused but kept for
-        compatibility with the AI interface.
+        Names of patterns to check. If empty, all available patterns are tested.
 
     Returns
     -------
@@ -74,7 +136,7 @@ def scan(candles_dict: dict[str, list], pattern_names: list[str]) -> dict[str, s
     results: dict[str, str | None] = {}
     for tf, candles in candles_dict.items():
         try:
-            results[tf] = scan_all(candles)
+            results[tf] = scan_all(candles, pattern_names)
         except Exception:
             results[tf] = None
     return results

--- a/backend/tests/test_pattern_scanner.py
+++ b/backend/tests/test_pattern_scanner.py
@@ -97,7 +97,17 @@ class TestPatternScanner(unittest.TestCase):
             {"o":1.2,"h":1.24,"l":1.0,"c":1.1},
             {"o":1.1,"h":1.35,"l":1.1,"c":1.3},
         ]
-        self.assertEqual(self.ps.scan_all(data), "double_bottom")
+        self.assertEqual(self.ps.scan_all(data, ["double_bottom"]), "double_bottom")
+
+    def test_head_and_shoulders(self):
+        data = [
+            {"o":1.0,"h":1.1,"l":0.9,"c":1.0},
+            {"o":1.0,"h":1.3,"l":0.95,"c":1.1},
+            {"o":1.1,"h":1.5,"l":0.9,"c":1.3},
+            {"o":1.3,"h":1.3,"l":1.0,"c":1.2},
+            {"o":1.2,"h":1.0,"l":0.8,"c":0.9},
+        ]
+        self.assertEqual(self.ps.scan_all(data, ["head_and_shoulders"]), "head_and_shoulders")
 
     def test_double_top(self):
         data = [
@@ -107,7 +117,16 @@ class TestPatternScanner(unittest.TestCase):
             {"o":1.1,"h":1.4,"l":1.1,"c":1.3},
             {"o":1.3,"h":1.1,"l":0.8,"c":0.9},
         ]
-        self.assertEqual(self.ps.scan_all(data), "double_top")
+        self.assertEqual(self.ps.scan_all(data, ["double_top"]), "double_top")
+
+    def test_pattern_names_filter(self):
+        data = [
+            {"o":1.2,"h":1.25,"l":1.0,"c":1.1},
+            {"o":1.1,"h":1.3,"l":1.1,"c":1.2},
+            {"o":1.2,"h":1.24,"l":1.0,"c":1.1},
+            {"o":1.1,"h":1.35,"l":1.1,"c":1.3},
+        ]
+        self.assertIsNone(self.ps.scan_all(data, ["double_top"]))
 
     def test_scan_multi_timeframes(self):
         data_bottom = [
@@ -125,6 +144,9 @@ class TestPatternScanner(unittest.TestCase):
         ]
         result = self.ps.scan({"M1": data_bottom, "M5": data_top}, ["double_bottom", "double_top"])
         self.assertEqual(result, {"M1": "double_bottom", "M5": "double_top"})
+
+        result2 = self.ps.scan({"M1": data_bottom, "M5": data_top}, ["double_top"])
+        self.assertEqual(result2, {"M1": None, "M5": "double_top"})
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support head-and-shoulders and inverse head-and-shoulders patterns
- extend `scan_all` and `scan` to use selected pattern names
- test new patterns and pattern selection behaviour

## Testing
- `python -m pytest -q backend/tests/test_pattern_scanner.py` *(fails: No module named pytest)*