### PR TITLE
Fix market mode handling

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -149,7 +149,6 @@ def process_entry(
             offset = calculate_pullback_offset(indicators, market_cond)
         if offset and price_ref is not None:
             limit_price = pullback_limit(side, price_ref, offset)
-            mode = "limit"
 
     # ------------------------------------------------------------
     #  Detect narrow-range market (Bollinger band width < threshold)
@@ -218,7 +217,7 @@ def process_entry(
             lot_size=float(env_loader.get_env("TRADE_LOT_SIZE", "1.0")),
             market_data=market_data,
             strategy_params=params_limit,
-            force_limit_only=narrow_range,
+            force_limit_only=False,
         )
         if result:
             _pending_limits[entry_uuid] = {
@@ -247,7 +246,7 @@ def process_entry(
         lot_size=float(env_loader.get_env("TRADE_LOT_SIZE", "1.0")),
         market_data=market_data,
         strategy_params=params,
-        force_limit_only=narrow_range
+        force_limit_only=False
     )
 
     if trade_result and mode == "market":

--- a/backend/tests/test_pullback_limit.py
+++ b/backend/tests/test_pullback_limit.py
@@ -70,14 +70,14 @@ class TestPullbackLimit(unittest.TestCase):
         for name in self._added:
             sys.modules.pop(name, None)
 
-    def test_market_to_limit_near_pivot(self):
+    def test_market_order_when_ai_says_market(self):
         indicators = {"atr": FakeSeries([0.1, 0.1])}
         candles = []
         market_data = {"prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}]}
         higher_tf = {"pivot_d": 1.0}
         result = self.el.process_entry(indicators, candles, market_data, higher_tf=higher_tf)
         self.assertTrue(result)
-        self.assertEqual(self.el.order_manager.last_params["mode"], "limit")
+        self.assertEqual(self.el.order_manager.last_params["mode"], "market")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stop auto-conversion of market entries to limit orders
- always call `enter_trade` with `force_limit_only=False`
- update pullback limit test to expect a market order

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*