### PR TITLE
Add candlestick patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 `AI_LIMIT_CONVERT_MODEL` sets the OpenAI model used when asking whether a pending LIMIT should be switched to a market order. The default is `gpt-4o-mini`.
 `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
-`PATTERN_NAMES` lists chart pattern names passed to the AI for detection, e.g. `double_bottom,double_top`.
+`PATTERN_NAMES` lists chart pattern names passed to the AI or local scanner for detection, e.g. `double_bottom,double_top,doji`.
 `USE_LOCAL_PATTERN` を `true` にすると、AI を使わずローカルの `pattern_scanner` でチャートパターンを判定します。デフォルトは `false` です。
 
 ## Running the API
@@ -189,6 +189,12 @@ print(result)
 - `double_bottom`
 - `double_top`
 - `head_and_shoulders`
+- `doji`
+- `hammer`
+- `bullish_engulfing`
+- `bearish_engulfing`
+- `morning_star`
+- `evening_star`
 
 複数時間足を使う場合は `get_trade_plan` の `pattern_tf` 引数で判定に利用する足を指定します。
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -80,7 +80,7 @@ AI_ENTRY_MODEL=gpt-4.1-nano
 AI_EXIT_MODEL=gpt-4.1-nano
 
 # --- Chart pattern detection ---
-PATTERN_NAMES=double_bottom,double_top
+PATTERN_NAMES=double_bottom,double_top,doji,hammer,bullish_engulfing,bearish_engulfing,morning_star,evening_star
 
 # --- ボリューム関連 ---
 VOL_MA_PERIOD=10

--- a/backend/strategy/pattern_scanner.py
+++ b/backend/strategy/pattern_scanner.py
@@ -99,7 +99,90 @@ def detect_inverse_head_and_shoulders(data: list[dict]) -> bool:
         return False
     return True
 
+
+def is_doji(data: list[dict]) -> bool:
+    """Detect a doji candle."""
+    if not data:
+        return False
+    row = data[-1]
+    rng = row["h"] - row["l"]
+    if rng == 0:
+        return False
+    body = abs(row["c"] - row["o"])
+    return body <= rng * 0.1
+
+
+def is_hammer(data: list[dict]) -> bool:
+    """Detect a hammer candle."""
+    if not data:
+        return False
+    row = data[-1]
+    body = abs(row["c"] - row["o"])
+    upper = row["h"] - max(row["o"], row["c"])
+    lower = min(row["o"], row["c"]) - row["l"]
+    if body == 0:
+        body = (row["h"] - row["l"]) * 0.001
+    return lower >= body * 2 and upper <= body
+
+
+def is_bullish_engulfing(data: list[dict]) -> bool:
+    if len(data) < 2:
+        return False
+    prev, curr = data[-2], data[-1]
+    return (
+        prev["c"] < prev["o"]
+        and curr["c"] > curr["o"]
+        and curr["o"] <= prev["c"]
+        and curr["c"] >= prev["o"]
+    )
+
+
+def is_bearish_engulfing(data: list[dict]) -> bool:
+    if len(data) < 2:
+        return False
+    prev, curr = data[-2], data[-1]
+    return (
+        prev["c"] > prev["o"]
+        and curr["c"] < curr["o"]
+        and curr["o"] >= prev["c"]
+        and curr["c"] <= prev["o"]
+    )
+
+
+def is_morning_star(data: list[dict]) -> bool:
+    if len(data) < 3:
+        return False
+    a, b, c = data[-3], data[-2], data[-1]
+    body_a = abs(a["c"] - a["o"])
+    body_b = abs(b["c"] - b["o"])
+    return (
+        a["c"] < a["o"]
+        and body_b <= body_a * 0.5
+        and c["c"] > c["o"]
+        and c["c"] > a["o"] - body_a * 0.5
+    )
+
+
+def is_evening_star(data: list[dict]) -> bool:
+    if len(data) < 3:
+        return False
+    a, b, c = data[-3], data[-2], data[-1]
+    body_a = abs(a["c"] - a["o"])
+    body_b = abs(b["c"] - b["o"])
+    return (
+        a["c"] > a["o"]
+        and body_b <= body_a * 0.5
+        and c["c"] < c["o"]
+        and c["c"] < a["o"] + body_a * 0.5
+    )
+
 PATTERN_FUNCS = {
+    "doji": is_doji,
+    "hammer": is_hammer,
+    "bullish_engulfing": is_bullish_engulfing,
+    "bearish_engulfing": is_bearish_engulfing,
+    "morning_star": is_morning_star,
+    "evening_star": is_evening_star,
     "double_bottom": detect_double_bottom,
     "double_top": detect_double_top,
     "head_and_shoulders": detect_head_and_shoulders,

--- a/backend/tests/test_pattern_scanner.py
+++ b/backend/tests/test_pattern_scanner.py
@@ -119,6 +119,33 @@ class TestPatternScanner(unittest.TestCase):
         ]
         self.assertEqual(self.ps.scan_all(data, ["double_top"]), "double_top")
 
+    def test_doji(self):
+        data = [
+            {"o": 1.0, "h": 1.05, "l": 0.95, "c": 1.001},
+        ]
+        self.assertEqual(self.ps.scan_all(data, ["doji"]), "doji")
+
+    def test_hammer(self):
+        data = [
+            {"o": 1.1, "h": 1.16, "l": 1.0, "c": 1.15},
+        ]
+        self.assertEqual(self.ps.scan_all(data, ["hammer"]), "hammer")
+
+    def test_bullish_engulfing(self):
+        data = [
+            {"o": 1.2, "h": 1.25, "l": 1.1, "c": 1.15},
+            {"o": 1.14, "h": 1.28, "l": 1.12, "c": 1.24},
+        ]
+        self.assertEqual(self.ps.scan_all(data, ["bullish_engulfing"]), "bullish_engulfing")
+
+    def test_morning_star(self):
+        data = [
+            {"o": 1.3, "h": 1.32, "l": 1.1, "c": 1.15},
+            {"o": 1.14, "h": 1.16, "l": 1.13, "c": 1.14},
+            {"o": 1.15, "h": 1.34, "l": 1.15, "c": 1.30},
+        ]
+        self.assertEqual(self.ps.scan_all(data, ["morning_star"]), "morning_star")
+
     def test_pattern_names_filter(self):
         data = [
             {"o":1.2,"h":1.25,"l":1.0,"c":1.1},


### PR DESCRIPTION
## Summary
- add candlestick pattern detection functions such as doji, hammer, engulfing and star patterns
- register new functions in `PATTERN_FUNCS`
- update README with the new pattern names
- expand the default `PATTERN_NAMES` in settings
- test new patterns in the scanner tests

## Testing
- `python -m unittest discover backend/tests`