### PR TITLE
Fix duplicate comment in openai_analysis

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -40,7 +40,6 @@ USE_LOCAL_PATTERN: bool = (
 )
 
 # Global variables to store last AI call timestamps
-# Global variables to store last AI call timestamps
 _last_entry_ai_call_time = 0.0
 _last_exit_ai_call_time = 0.0
 # Regime‑AI cache


### PR DESCRIPTION
## Summary
- remove redundant comment in `openai_analysis.py`

## Testing
- `pytest -q` *(fails: command not found)*