### PR TITLE
Fix exit LINE message

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -496,7 +496,7 @@ class JobRunner:
                                     self.last_close_ts = datetime.utcnow()
                                     logger.info("Position closed based on AI recommendation.")
                                     send_line_message(
-                                        f"【EXIT】{DEFAULT_PAIR} {current_price} で決済しました。PL={current_profit_pips * pip_size:.2f}"
+                                        f"【EXIT】{DEFAULT_PAIR} {current_price} で決済しました。PL={current_profit_pips:.1f}pips"
                                     )
                                 else:
                                     logger.info("AI decision was HOLD → No exit executed.")


### PR DESCRIPTION
## Summary
- fix exit notification to display pips without multiplying by pip size

## Testing
- `pytest -q` *(fails: pytest not installed)*