### PR TITLE
Relax pattern detection & tweak thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
 `PATTERN_NAMES` lists chart pattern names passed to the AI or local scanner for detection, e.g. `double_bottom,double_top,doji`.
 `USE_LOCAL_PATTERN` を `true` にすると、AI を使わずローカルの `pattern_scanner` でチャートパターンを判定します。デフォルトは `false` です。
+`PATTERN_MIN_BARS` でパターン完成に必要なローソク足の本数を、`PATTERN_TOLERANCE` で高値・安値の許容誤差を調整できます。
 
 ## Running the API
 

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -57,3 +57,14 @@ ATR（ボラティリティ指標）の計算期間。
   発動条件 = ATR × TRAIL_TRIGGER_MULTIPLIER、
   距離 = ATR × TRAIL_DISTANCE_MULTIPLIER で計算される。
 
+■ チャートパターン検出設定
+
+- PATTERN_MIN_BARS:
+  パターン完成判定に必要な最小ローソク足本数。デフォルトは5本。
+
+- PATTERN_TOLERANCE:
+  高値・安値の許容誤差。デフォルトは0.005。
+
+- ADX_NO_TRADE_MIN / ADX_NO_TRADE_MAX:
+  ADXがこの範囲に収まっているとエントリーを見送る。
+

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -32,8 +32,8 @@ MAX_TRADE_LOT=30.0
 # ローソク足の粒度（OANDA のフォーマット）
 CANDLE_GRANULARITY=M5
 
-RSI_EXIT_LOWER=25
-RSI_EXIT_UPPER=75
+RSI_EXIT_LOWER=30
+RSI_EXIT_UPPER=70
 ATR_EXIT_THRESHOLD=0.06
 
 DISABLE_ENTRY_FILTER=true
@@ -81,6 +81,8 @@ AI_EXIT_MODEL=gpt-4.1-nano
 
 # --- Chart pattern detection ---
 PATTERN_NAMES=double_bottom,double_top,doji,hammer,bullish_engulfing,bearish_engulfing,morning_star,evening_star
+PATTERN_MIN_BARS=5
+PATTERN_TOLERANCE=0.005
 
 # --- ボリューム関連 ---
 VOL_MA_PERIOD=10
@@ -137,8 +139,10 @@ COOL_BBWIDTH_PCT=0
 COOL_ATR_PCT=0
 
 # --- ADXノートレードゾーン ---
-ADX_NO_TRADE_MIN=0
-ADX_NO_TRADE_MAX=0
+ADX_NO_TRADE_MIN=15
+ADX_NO_TRADE_MAX=25
+# ADX value used to judge range conditions for entry filters
+ADX_RANGE_THRESHOLD=25
 
 # BB中央付近ブロック比（レンジ時）
 RANGE_CENTER_BLOCK_PCT=0.5

--- a/backend/strategy/pattern_scanner.py
+++ b/backend/strategy/pattern_scanner.py
@@ -1,7 +1,12 @@
 import math
+import os
 from typing import Iterable, Mapping
 
 CANDLE_KEYS = ('o', 'h', 'l', 'c')
+
+# Pattern detection tunables
+PATTERN_MIN_BARS = int(os.getenv("PATTERN_MIN_BARS", "5"))
+PATTERN_TOLERANCE = float(os.getenv("PATTERN_TOLERANCE", "0.005"))
 
 def _as_list(data: Iterable[Mapping]) -> list[dict]:
     return [
@@ -9,11 +14,11 @@ def _as_list(data: Iterable[Mapping]) -> list[dict]:
         for row in data
     ]
 
-def _is_close(a: float, b: float, tol: float = 0.001) -> bool:
+def _is_close(a: float, b: float, tol: float = PATTERN_TOLERANCE) -> bool:
     return abs(a - b) <= tol
 
 def detect_double_bottom(data: list[dict]) -> bool:
-    if len(data) < 4:
+    if len(data) < PATTERN_MIN_BARS:
         return False
     lows = [row['l'] for row in data]
     highs = [row['h'] for row in data]
@@ -32,7 +37,7 @@ def detect_double_bottom(data: list[dict]) -> bool:
     return hi_after > hi_between
 
 def detect_double_top(data: list[dict]) -> bool:
-    if len(data) < 4:
+    if len(data) < PATTERN_MIN_BARS:
         return False
     highs = [row['h'] for row in data]
     lows = [row['l'] for row in data]
@@ -56,7 +61,7 @@ def _find_min_index(seq: list[float]) -> int:
 
 def detect_head_and_shoulders(data: list[dict]) -> bool:
     """Very naive head-and-shoulders detection."""
-    if len(data) < 5:
+    if len(data) < max(PATTERN_MIN_BARS, 5):
         return False
     highs = [row['h'] for row in data]
     head_idx = _find_max_index(highs)
@@ -79,7 +84,7 @@ def detect_head_and_shoulders(data: list[dict]) -> bool:
 
 def detect_inverse_head_and_shoulders(data: list[dict]) -> bool:
     """Inverse head-and-shoulders pattern."""
-    if len(data) < 5:
+    if len(data) < max(PATTERN_MIN_BARS, 5):
         return False
     lows = [row['l'] for row in data]
     head_idx = _find_min_index(lows)

--- a/backend/tests/test_pattern_scanner.py
+++ b/backend/tests/test_pattern_scanner.py
@@ -71,6 +71,8 @@ class FakePandas(types.ModuleType):
 class TestPatternScanner(unittest.TestCase):
     def setUp(self):
         os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ.setdefault("PATTERN_MIN_BARS", "4")
+        os.environ.setdefault("PATTERN_TOLERANCE", "0.001")
         self._added = []
 
         def add(name, mod):
@@ -89,6 +91,8 @@ class TestPatternScanner(unittest.TestCase):
     def tearDown(self):
         for name in getattr(self, "_added", []):
             sys.modules.pop(name, None)
+        os.environ.pop("PATTERN_MIN_BARS", None)
+        os.environ.pop("PATTERN_TOLERANCE", None)
 
     def test_double_bottom(self):
         data = [


### PR DESCRIPTION
## Summary
- add PATTERN_MIN_BARS and PATTERN_TOLERANCE env vars
- use them in `pattern_scanner`
- update default thresholds for RSI and ADX
- document new options in README and ENV_README
- adjust tests for new env vars

## Testing
- `pytest -q` *(fails: command not found)*