### PR TITLE
Update AI noise instruction

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -522,6 +522,7 @@ EMA_s: {ind_d1.get('ema_slow', [])[-20:]}
 ### 想定ノイズ (Estimated Noise)
 {noise_val} pips is the approximate short-term market noise.
 Use this as a baseline for setting wider stop-loss levels.
+TP到達確率を算出した後、SLを少なくとも {env_loader.get_env("NOISE_SL_MULT", "1.5")} 倍に広げること。
 
 Your task:
 1. Clearly classify the current regime as "trend" or "range". If "trend", specify direction as "long" or "short". Output this at JSON key "regime".


### PR DESCRIPTION
## Summary
- clarify stop-loss expansion using noise multiplier in openai prompt

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*