### PR TITLE
Fix ask_openai param mismatch

### DIFF
--- a/backend/tests/test_market_condition_override.py
+++ b/backend/tests/test_market_condition_override.py
@@ -37,19 +37,19 @@ class TestMarketConditionOverride(unittest.TestCase):
             sys.modules.pop(name, None)
 
     def test_local_range_overrides_llm_trend(self):
-        self.oa.ask_openai = lambda *a, **k: "trend"
+        self.oa.ask_openai = lambda *a, **k: {"market_condition": "trend"}
         ctx = {"indicators": {"adx": [10, 12, 11], "ema_slope": [0.1, 0.1, 0.1]}}
         with self.assertLogs(self.oa.logger, level="WARNING") as cm:
             res = self.oa.get_market_condition(ctx)
-        self.assertEqual(res, "range")
+        self.assertEqual(res["market_condition"], "range")
         self.assertTrue(any("conflicts" in m for m in cm.output))
 
     def test_local_trend_overrides_llm_range(self):
-        self.oa.ask_openai = lambda *a, **k: "range"
+        self.oa.ask_openai = lambda *a, **k: {"market_condition": "range"}
         ctx = {"indicators": {"adx": [25, 26, 27], "ema_slope": [-0.2, -0.3, -0.1]}}
         with self.assertLogs(self.oa.logger, level="WARNING") as cm:
             res = self.oa.get_market_condition(ctx)
-        self.assertEqual(res, "trend")
+        self.assertEqual(res["market_condition"], "trend")
         self.assertTrue(any("conflicts" in m for m in cm.output))
 
 if __name__ == "__main__":

--- a/backend/utils/openai_client.py
+++ b/backend/utils/openai_client.py
@@ -25,6 +25,7 @@ def ask_openai(
     *,
     max_tokens: int = 512,
     temperature: float = 0.7,
+    response_format: dict | None = None,
 ) -> dict:
     """
     Send a prompt to OpenAI's API and return the response text.
@@ -32,6 +33,9 @@ def ask_openai(
         prompt (str): The user prompt/question.
         system_prompt (str): The system message (instructions for the assistant).
         model (str): The OpenAI model to use.
+        response_format (dict | None): Optional response_format passed directly
+            to ``client.chat.completions.create``. Defaults to requesting a
+            JSON object when not provided.
     Returns:
         dict: Parsed JSON object returned by the assistant.
     Raises:
@@ -41,6 +45,9 @@ def ask_openai(
     if model is None:
         model = AI_MODEL
     try:
+        if response_format is None:
+            response_format = {"type": "json_object"}
+
         response = client.chat.completions.create(
             model=model,
             messages=[
@@ -49,7 +56,7 @@ def ask_openai(
             ],
             max_tokens=max_tokens,
             temperature=temperature,
-            response_format={"type": "json_object"},
+            response_format=response_format,
         )
         response_content = response.choices[0].message.content.strip()
         return json.loads(response_content)


### PR DESCRIPTION
## Summary
- allow `ask_openai()` to accept optional `response_format`
- adjust tests for new return format

## Testing
- `PYTHONPATH=. pytest -q`