### PR TITLE
Add range entry limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 `PULLBACK_LIMIT_OFFSET_PIPS` is the base distance for a pullback LIMIT order when the AI proposes a market entry. The actual offset is derived from ATR and ADX, and if price runs away while the trend persists the order can be switched to a market order under AI control.
 `AI_LIMIT_CONVERT_MODEL` sets the OpenAI model used when asking whether a pending LIMIT should be switched to a market order. The default is `gpt-4.1-nano`.
 `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
+`RANGE_ENTRY_OFFSET_PIPS` determines how far from the Bollinger band center price must be (in pips) before keeping a market entry. When closer, the entry switches to a LIMIT at the band high or low. The default is `3`.
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
 `NOISE_SL_MULT` は AI が算出した SL をこの倍率で拡大します (default `1.5`).
 `PATTERN_NAMES` lists chart pattern names passed to the AI or local scanner for detection, e.g. `double_bottom,double_top,doji`.

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -148,6 +148,8 @@ ADX_RANGE_THRESHOLD=25
 
 # BB中央付近ブロック比（レンジ時）
 RANGE_CENTER_BLOCK_PCT=0.5
+# ボリンジャーバンド中心から何pips離れていればMarketエントリーを維持するか
+RANGE_ENTRY_OFFSET_PIPS=3
 # 日足ピボット付近のエントリー抑制幅 (pips)
 PIVOT_SUPPRESSION_PIPS=15
 # 抑制対象タイムフレーム (例: D,H4,H1)


### PR DESCRIPTION
## Summary
- switch to LIMIT when price is near Bollinger band center in a range
- expose `RANGE_ENTRY_OFFSET_PIPS` setting
- document the new option

## Testing
- `pytest -q`