### PR TITLE
Enhance local/AI consistency scoring

### DIFF
--- a/backend/tests/test_market_condition_override.py
+++ b/backend/tests/test_market_condition_override.py
@@ -39,19 +39,37 @@ class TestMarketConditionOverride(unittest.TestCase):
 
     def test_local_wins_when_alpha_high(self):
         self.oa.ask_openai = lambda *a, **k: {"market_condition": "trend"}
-        self.oa.calc_consistency = lambda *a, **k: 0.8
+        calls = []
+        def _calc(local, ai, **params):
+            calls.append((local, ai, params))
+            return 0.8
+        self.oa.calc_consistency = _calc
         ctx = {"indicators": {"adx": [10, 12, 11], "ema_slope": [0.1, 0.1, 0.1]}}
         with self.assertLogs(self.oa.logger, level="WARNING") as cm:
             res = self.oa.get_market_condition(ctx)
         self.assertEqual(res["market_condition"], "range")
         self.assertTrue(any("conflicts" in m for m in cm.output))
+        self.assertEqual(calls[-1][0], "range")
+        self.assertEqual(calls[-1][1], "trend")
+        self.assertAlmostEqual(calls[-1][2].get("ema_ok"), 1.0)
+        self.assertAlmostEqual(calls[-1][2].get("adx_ok"), 0.0)
+        self.assertAlmostEqual(calls[-1][2].get("rsi_cross_ok"), 0.0)
 
     def test_ai_wins_when_alpha_low(self):
         self.oa.ask_openai = lambda *a, **k: {"market_condition": "range"}
-        self.oa.calc_consistency = lambda *a, **k: 0.2
+        calls = []
+        def _calc(local, ai, **params):
+            calls.append((local, ai, params))
+            return 0.2
+        self.oa.calc_consistency = _calc
         ctx = {"indicators": {"adx": [25, 26, 27], "ema_slope": [-0.2, -0.3, -0.1]}}
         res = self.oa.get_market_condition(ctx)
         self.assertEqual(res["market_condition"], "range")
+        self.assertEqual(calls[-1][0], "trend")
+        self.assertEqual(calls[-1][1], "range")
+        self.assertAlmostEqual(calls[-1][2].get("ema_ok"), 1.0)
+        self.assertAlmostEqual(calls[-1][2].get("adx_ok"), 1.0)
+        self.assertAlmostEqual(calls[-1][2].get("rsi_cross_ok"), 0.0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expand `calc_consistency` to blend EMA/ADX/RSI signals
- compute new metrics in `get_market_condition`
- update tests for new parameters

## Testing
- `PYTHONPATH=. pytest -q`