### PR TITLE
Add dynamic pullback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 `PULLBACK_LIMIT_OFFSET_PIPS` is the base distance for a pullback LIMIT order when the AI proposes a market entry. The actual offset is derived from ATR and ADX, and if price runs away while the trend persists the order can be switched to a market order under AI control.
 `AI_LIMIT_CONVERT_MODEL` sets the OpenAI model used when asking whether a pending LIMIT should be switched to a market order. The default is `gpt-4.1-nano`.
 `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
+`PIP_SIZE` specifies the pip value for the traded pair (e.g. `0.01` for JPY pairs) and is used when calculating the new volatility‑based pullback threshold.
+The system derives a dynamic pullback requirement from ATR, ADX and recent price swings. If indicators are missing, the fallback is `PULLBACK_PIPS`.
 `RANGE_ENTRY_OFFSET_PIPS` determines how far from the Bollinger band center price must be (in pips) before keeping a market entry. When closer, the entry switches to a LIMIT at the band high or low. The default is `3`.
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
 `NOISE_SL_MULT` は AI が算出した SL をこの倍率で拡大します (default `1.5`).

--- a/backend/strategy/dynamic_pullback.py
+++ b/backend/strategy/dynamic_pullback.py
@@ -1,0 +1,26 @@
+"""Dynamic pullback threshold calculation."""
+
+from backend.utils import env_loader
+
+
+def calculate_dynamic_pullback(indicators: dict, recent_high: float, recent_low: float) -> float:
+    """Return dynamic pullback threshold in pips."""
+    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+    atr = indicators.get("atr")
+    adx = indicators.get("adx")
+    noise = indicators.get("noise")
+    if atr is None or adx is None or noise is None:
+        return float(env_loader.get_env("PULLBACK_PIPS", "5"))
+
+    atr_val = float(atr.iloc[-1]) / pip_size
+    adx_val = float(adx.iloc[-1])
+    noise_val = float(noise.iloc[-1])
+    last_leg = abs(recent_low - recent_high) / pip_size
+
+    thr_atr = atr_val * (1.2 if adx_val < 30 else 0.9)
+    thr_noise = 0.15 * noise_val
+    thr_fibo = 0.236 * last_leg
+
+    pullback = max(thr_atr, thr_noise, thr_fibo)
+    pullback = min(max(pullback, 3), 15)
+    return pullback

--- a/backend/tests/test_dynamic_pullback.py
+++ b/backend/tests/test_dynamic_pullback.py
@@ -126,5 +126,15 @@ class TestDynamicPullback(unittest.TestCase):
         self.runner._manage_pending_limits("USD_JPY", indicators, [], tick)
         self.assertTrue(self.jr.order_mgr.market_called)
 
+    def test_calculate_dynamic_pullback(self):
+        from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
+        indicators = {
+            "atr": FakeSeries([0.2]),
+            "adx": FakeSeries([25]),
+            "noise": FakeSeries([4.0]),
+        }
+        result = calculate_dynamic_pullback(indicators, 1.2, 1.0)
+        self.assertEqual(result, 15.0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `calculate_dynamic_pullback`
- embed dynamic pullback value in OpenAI prompts
- integrate dynamic pullback with entry logic
- test helper for `calculate_dynamic_pullback`
- document volatility-based pullback threshold

## Testing
- `PYTHONPATH=. pytest -q`