### PR TITLE
Fix risk field when no trade

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -780,10 +780,14 @@ Respond with **one-line valid JSON** exactly as:
                 plan["entry"]["side"] = "no"
         except (TypeError, ValueError):
             plan["entry"]["side"] = "no"
+            plan["risk"] = {}
             return plan
 
         if p < MIN_TP_PROB or (tp * p - sl * q) <= 0:
             plan["entry"]["side"] = "no"
+
+    if plan.get("entry", {}).get("side") == "no":
+        plan["risk"] = {}
 
     # Over-cool filter using Bollinger Band width and ATR
     try:

--- a/backend/tests/test_range_index_series.py
+++ b/backend/tests/test_range_index_series.py
@@ -102,6 +102,7 @@ class TestSeriesHandling(unittest.TestCase):
         }
         plan = self.oa.get_trade_plan({}, {"M5": indicators}, {"M5": []})
         self.assertIn("entry", plan)
+        self.assertEqual(plan.get("risk"), {})
 
     def test_build_exit_context_range_index(self):
         indicators = {

--- a/backend/tests/test_risk_expected_value.py
+++ b/backend/tests/test_risk_expected_value.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class TestRiskExpectedValue(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        self._added = []
+        def add(name, mod):
+            if name not in sys.modules:
+                sys.modules[name] = mod
+                self._added.append(name)
+        add("pandas", types.ModuleType("pandas"))
+        openai_stub = types.ModuleType("openai")
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add("openai", openai_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+        add("requests", types.ModuleType("requests"))
+        add("numpy", types.ModuleType("numpy"))
+        import backend.strategy.openai_analysis as oa
+        importlib.reload(oa)
+        self.oa = oa
+
+    def tearDown(self):
+        for name in getattr(self, "_added", []):
+            sys.modules.pop(name, None)
+
+    def test_negative_expected_value(self):
+        resp = {"entry": {"side": "long"}, "risk": {"tp_pips": 10, "sl_pips": 40.5, "tp_prob": 0.8, "sl_prob": 0.5}}
+        self.oa.ask_openai = lambda *a, **k: resp
+        plan = self.oa.get_trade_plan({}, {"M5": {}}, {"M5": []})
+        self.assertEqual(plan.get("entry", {}).get("side"), "no")
+        self.assertEqual(plan.get("risk"), {})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure risk info is cleared when no trade entry
- update range index test to confirm risk is empty
- add regression test covering negative expected value

## Testing
- `PYTHONPATH=. pytest -q`