### PR TITLE
Fix trailing stop trigger to use absolute profit

### DIFF
--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -319,7 +319,8 @@ def process_exit(
                     f"trigger={trigger_pips:.1f}p"
                 )
 
-                if profit_pips >= trigger_pips:
+                # 利益が正負どちらの場合でもトレーリングストップを発動させるため絶対値で比較
+                if abs(profit_pips) >= trigger_pips:
                     # --- attach trailing stop to the first open trade ID ---
                     trade_ids = position.get(position_side, {}).get("tradeIDs", [])
                     if trade_ids:

--- a/backend/tests/test_trailing_stop_abs.py
+++ b/backend/tests/test_trailing_stop_abs.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class DummyResp:
+    def __init__(self):
+        self.ok = True
+        self.status_code = 200
+        self.text = ''
+    def json(self):
+        return {}
+    def raise_for_status(self):
+        pass
+
+class TestTrailingStopAbsProfit(unittest.TestCase):
+    def setUp(self):
+        self._added = []
+        def add(name, mod):
+            if name not in sys.modules:
+                sys.modules[name] = mod
+                self._added.append(name)
+
+        os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")
+        os.environ.setdefault("OANDA_API_KEY", "dummy")
+        os.environ["TRAIL_ENABLED"] = "true"
+        os.environ["TRAIL_TRIGGER_PIPS"] = "10"
+        os.environ["TRAIL_DISTANCE_PIPS"] = "6"
+        os.environ["EARLY_EXIT_ENABLED"] = "false"
+        os.environ["DEFAULT_PAIR"] = "EUR_USD"
+
+        req = types.ModuleType("requests")
+        req.post = req.put = req.get = lambda *a, **k: DummyResp()
+        add("requests", req)
+        add("pandas", types.ModuleType("pandas"))
+        dotenv = types.ModuleType("dotenv")
+        dotenv.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv)
+        add("numpy", types.ModuleType("numpy"))
+
+        self.position = {}
+        pm = types.ModuleType("backend.orders.position_manager")
+        pm.get_position_details = lambda *a, **k: self.position
+        add("backend.orders.position_manager", pm)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.get_exit_decision = lambda *a, **k: {"decision": "HOLD", "reason": ""}
+        add("backend.strategy.openai_analysis", oa)
+
+        import backend.orders.order_manager as om
+        importlib.reload(om)
+
+        class DummyOM(om.OrderManager):
+            def __init__(self):
+                self.calls = []
+            def place_trailing_stop(self, trade_id, instrument, distance_pips=None):
+                self.calls.append((trade_id, instrument, distance_pips))
+                return {}
+            def exit_trade(self, *a, **k):
+                pass
+        self.DummyOM = DummyOM
+
+        import backend.strategy.exit_logic as el
+        importlib.reload(el)
+        el.order_manager = DummyOM()
+        self.el = el
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+
+    def test_short_position_triggers_on_abs_profit(self):
+        self.position.update({
+            "instrument": "EUR_USD",
+            "short": {"units": "-1", "averagePrice": "1.2345", "tradeIDs": ["t1"]},
+            "pl": "0",
+            "entry_time": "2024-01-01T00:00:00Z",
+        })
+        market = {"prices": [{"bids": [{"price": "1.2330"}], "asks": [{"price": "1.2330"}]}]}
+        self.el.process_exit({}, market)
+        calls = self.el.order_manager.calls
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "t1")
+        self.assertEqual(calls[0][1], "EUR_USD")
+        self.assertEqual(calls[0][2], 6)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use `abs(profit_pips)` when checking the trailing-stop trigger so shorts work correctly
- document the absolute-value check
- add unit test for short position trailing stop

## Testing
- `python -m pytest -q`