### PR TITLE
Add timeout parameter to candle fetcher

### DIFF
--- a/backend/market_data/candle_fetcher.py
+++ b/backend/market_data/candle_fetcher.py
@@ -6,7 +6,7 @@ OANDA_API_URL = "https://api-fxtrade.oanda.com/v3/instruments/{instrument}/candl
 OANDA_API_KEY = os.getenv("OANDA_API_KEY")
 OANDA_ACCOUNT_ID = os.getenv("OANDA_ACCOUNT_ID")
 
-def fetch_candles(instrument=None, granularity="M1", count=500):
+def fetch_candles(instrument=None, granularity="M1", count=500, timeout=10):
     """
     Fetch candlestick data from OANDA API.
     
@@ -14,6 +14,7 @@ def fetch_candles(instrument=None, granularity="M1", count=500):
         instrument (str): The instrument to fetch data for (e.g. "USD_JPY").
         granularity (str): The granularity of the candles (e.g. "M1", "H1").
         count (int): Number of candles to fetch (max 5000).
+        timeout (int | float): Timeout in seconds for the HTTP request.
         
     Returns:
         list: List of candle data dictionaries.
@@ -32,7 +33,9 @@ def fetch_candles(instrument=None, granularity="M1", count=500):
     }
     url = OANDA_API_URL.format(instrument=instrument)
     try:
-        response = requests.get(url, headers=headers, params=params)
+        response = requests.get(
+            url, headers=headers, params=params, timeout=timeout
+        )
         response.raise_for_status()
         data = response.json()
         if "candles" in data:
@@ -40,6 +43,9 @@ def fetch_candles(instrument=None, granularity="M1", count=500):
         else:
             print(f"No candles found in response for {instrument}")
             return []
+    except requests.Timeout:
+        print(f"Request timed out while fetching candles for {instrument}")
+        return []
     except requests.RequestException as e:
         print(f"Error fetching candles for {instrument}: {e}")
         return []

--- a/backend/tests/test_candle_fetcher.py
+++ b/backend/tests/test_candle_fetcher.py
@@ -1,0 +1,50 @@
+import sys
+import types
+import importlib
+import unittest
+
+
+class TestCandleFetcherTimeout(unittest.TestCase):
+    def setUp(self):
+        self._added = []
+
+        def add(name: str, mod: types.ModuleType):
+            if name not in sys.modules:
+                sys.modules[name] = mod
+                self._added.append(name)
+
+        req = types.ModuleType("requests")
+
+        class Timeout(Exception):
+            pass
+
+        class RequestException(Exception):
+            pass
+
+        req.Timeout = Timeout
+        req.RequestException = RequestException
+
+        def get(*a, **k):
+            raise Timeout()
+
+        req.get = get
+        add("requests", req)
+
+        # also stub pandas to prevent import errors elsewhere if needed
+        add("pandas", types.ModuleType("pandas"))
+
+        import backend.market_data.candle_fetcher as cf
+        importlib.reload(cf)
+        self.cf = cf
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+
+    def test_timeout_returns_empty_list(self):
+        res = self.cf.fetch_candles("USD_JPY")
+        self.assertEqual(res, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying a timeout when fetching candles
- handle timeout exceptions by returning an empty list
- test candle_fetcher returns empty list on request timeout

## Testing
- `pytest -q`