### PR TITLE
Fix update_trade_sl endpoint

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -495,12 +495,12 @@ class OrderManager:
 
     def update_trade_sl(self, trade_id, instrument, new_sl_price):
         """Create or modify a Stop Loss order for the given trade."""
-        url = f"{OANDA_API_URL}/accounts/{OANDA_ACCOUNT_ID}/orders"
+        url = (
+            f"{OANDA_API_URL}/accounts/{OANDA_ACCOUNT_ID}/trades/"
+            f"{trade_id}/orders"
+        )
         body = {
-            "order": {
-                "type": "STOP_LOSS",
-
-                "tradeID": trade_id,
+            "stopLoss": {
                 "price": format_price(instrument, new_sl_price),
                 "timeInForce": "GTC",
             }
@@ -519,12 +519,14 @@ class OrderManager:
 
             return None
 
+        result = response.json()
         log_trade(
             instrument,
             datetime.utcnow().isoformat(),
             new_sl_price,
             0,
             "SL dynamically updated",
-            "SL_UPDATE",
+            json.dumps(result),
         )
-        return response.json()
+        logger.debug(f"SL update response: {result}")
+        return result

--- a/backend/tests/test_update_trade_sl.py
+++ b/backend/tests/test_update_trade_sl.py
@@ -59,12 +59,12 @@ class TestUpdateTradeSL(unittest.TestCase):
         for name in self._added:
             sys.modules.pop(name, None)
 
-    def test_payload_contains_stop_loss_type(self):
+    def test_payload_contains_stop_loss_block(self):
         self.om.update_trade_sl("t1", "USD_JPY", 150.1234)
         body = self.captured.get('body')
         self.assertIsNotNone(body)
-        self.assertEqual(body['order']['type'], 'STOP_LOSS')
-        self.assertEqual(body['order']['price'], '150.123')
+        self.assertIn('stopLoss', body)
+        self.assertEqual(body['stopLoss']['price'], '150.123')
 
     def test_error_logging_records_details(self):
         def error_put(url, json=None, headers=None):
@@ -77,6 +77,11 @@ class TestUpdateTradeSL(unittest.TestCase):
         sys.modules['requests'].put = error_put
         self.om.update_trade_sl("t1", "USD_JPY", 150.1234)
         self.assertEqual(self.log_calls, [("Failed to update SL: ERR bad", "bad")])
+
+    def test_success_returns_json(self):
+        result = self.om.update_trade_sl("t1", "USD_JPY", 150.1234)
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(self.log_calls, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- update update_trade_sl endpoint to /trades/{trade_id}/orders
- store API response and log it
- adjust unit tests

## Testing
- `pytest -q`