### PR TITLE
Relax filters and adjust AI prompts

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -23,8 +23,8 @@ MIN_SL_PIPS=20
 # --- その他設定 ---
 
 # --- AI クールダウン（秒）---
-AI_COOLDOWN_SEC_FLAT=60
-AI_COOLDOWN_SEC_OPEN=180
+AI_COOLDOWN_SEC_FLAT=30
+AI_COOLDOWN_SEC_OPEN=60
 
 # --- ロット制限 (1 lot = 100 00 units) ---
 MIN_TRADE_LOT=30.0
@@ -103,7 +103,7 @@ AI_EXIT_CONF_THRESH=0.6
 HIGHER_TF_ENABLED=true
 
 # Entry cooldown period (seconds) after a position close during which new entries are skipped
-ENTRY_COOLDOWN_SEC=180
+ENTRY_COOLDOWN_SEC=60
 # Exit check interval for periodic AI exit decision (seconds)
 EXIT_CHECK_SEC=60
 
@@ -141,8 +141,8 @@ COOL_BBWIDTH_PCT=0
 COOL_ATR_PCT=0
 
 # --- ADXノートレードゾーン ---
-ADX_NO_TRADE_MIN=0
-ADX_NO_TRADE_MAX=15
+ADX_NO_TRADE_MIN=10
+ADX_NO_TRADE_MAX=20
 # ADX value used to judge range conditions for entry filters
 ADX_RANGE_THRESHOLD=25
 

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -716,14 +716,15 @@ Classify as "TREND" if ANY TWO of the following conditions are met:
 If these conditions are not clearly met, classify the market as "RANGE".
 
 🚫【Counter-trend Trade Prohibition】
-Under clearly identified TREND conditions, strictly prohibit any counter-trend trades. Never initiate trades solely based on RSI extremes. If the pullback requirement is satisfied, treat the setup as trend continuation, not counter-trend.
+Under clearly identified TREND conditions, avoid counter-trend trades and never rely solely on RSI extremes. Treat pullbacks as trend continuation. However, if a strong reversal pattern such as a double top/bottom or head-and-shoulders is detected and ADX is turning down, a small counter-trend position is acceptable.
 
 🔄【Counter-Trend Trade Allowance】
-Allow short-term counter-trend trades ONLY when ALL of the following conditions are met:
+Allow short-term counter-trend trades only when all of the following are true:
 - ADX ≤ 20 or clearly declining.
-- RSI ≤ 30 for LONG entries or ≥ 70 for SHORT entries, indicating potential exhaustion.
-- Price action shows clear signs of stabilization (e.g., price stopped making new highs/lows, minor reversal candles present).
-- TP set very conservatively (5-10 pips) with strict risk control.
+- A clear reversal pattern (double top/bottom, head-and-shoulders) is present.
+- RSI ≤ 30 for LONG or ≥ 70 for SHORT, showing potential exhaustion.
+- Price action has stabilized with minor reversal candles.
+- TP kept small (5–10 pips) and risk tightly controlled.
 
 📈【Trend Entry Clarification】
 Once a TREND is confirmed, prioritize entries on pullbacks. Shorts enter after price rises {pullback_needed:.1f} pips above the latest low, longs after price drops {pullback_needed:.1f} pips below the latest high. This pullback rule overrides RSI extremes.
@@ -873,7 +874,7 @@ Respond with **one-line valid JSON** exactly as:
             adx_val = float(adx_series.iloc[-1])
         else:
             adx_val = float(adx_series[-1])
-        if ADX_NO_TRADE_MIN <= adx_val <= ADX_NO_TRADE_MAX:
+        if ADX_NO_TRADE_MIN <= adx_val <= ADX_NO_TRADE_MAX and not pattern_name:
             plan["entry"]["side"] = "no"
     except (TypeError, ValueError, IndexError):
         pass


### PR DESCRIPTION
## Summary
- shorten AI cooldown and entry cooldown periods
- expand ADX filter range
- skip ADX filter when a chart pattern is detected
- allow pattern-based counter-trend trades in AI prompt

## Testing
- `pytest -q`