### PR TITLE
Fix indicator NaN handling

### DIFF
--- a/backend/indicators/calculate_indicators.py
+++ b/backend/indicators/calculate_indicators.py
@@ -65,6 +65,11 @@ def calculate_indicators(
         'adx': adx_series,
     }
 
+    # 各指標の欠損値を前後の値で補完
+    for key, series in indicators.items():
+        if isinstance(series, pd.Series):
+            indicators[key] = series.ffill().bfill()
+
     # --- Percentile stats from historical daily data --------------------
     if pair is None:
         pair = os.getenv("DEFAULT_PAIR")

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -240,7 +240,19 @@ def pass_entry_filter(
                 )
                 return False
 
-    if None in [latest_rsi, latest_atr, latest_ema_fast, latest_ema_slow, prev_ema_fast, prev_ema_slow]:
+    def _is_nan(v):
+        try:
+            return v != v
+        except Exception:
+            return False
+
+    if _is_nan(latest_atr) or _is_nan(latest_adx):
+        logger.debug(
+            "EntryFilter bypassed: ATR/ADX history insufficient"
+        )
+        return True
+
+    if None in [latest_rsi, latest_ema_fast, latest_ema_slow, prev_ema_fast, prev_ema_slow]:
         return False  # insufficient data
 
     # --- Composite conditions ------------------------------------------

--- a/backend/tests/test_entry_filter_rsi.py
+++ b/backend/tests/test_entry_filter_rsi.py
@@ -132,6 +132,14 @@ class TestEntryFilterRSICross(unittest.TestCase):
         result = pass_entry_filter(ind, price=1.2, indicators_m1=m1)
         self.assertTrue(result)
 
+    def test_pass_entry_filter_allows_when_atr_adx_nan(self):
+        ind = self._base_indicators()
+        ind["atr"] = FakeSeries([0.1, float('nan')])
+        ind["adx"] = FakeSeries([30, float('nan')])
+        m1 = {"rsi": FakeSeries([29, 35])}
+        result = pass_entry_filter(ind, price=1.2, indicators_m1=m1)
+        self.assertTrue(result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fill NaN values in technical indicator series
- allow entry filter when ATR/ADX history is insufficient
- test that NaN ATR/ADX does not block entry

## Testing
- `pytest -q`