### PR TITLE
Fix trailing stop profit check

### DIFF
--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -335,8 +335,8 @@ def process_exit(
                     f"trigger={trigger_pips:.1f}p"
                 )
 
-                # 利益が正負どちらの場合でもトレーリングストップを発動させるため絶対値で比較
-                if abs(profit_pips) >= trigger_pips:
+                # 利益が正の場合のみトレーリングストップを発動する
+                if profit_pips >= trigger_pips:
                     # --- attach trailing stop to the first open trade ID ---
                     trade_ids = position.get(position_side, {}).get("tradeIDs", [])
                     if trade_ids:

--- a/backend/tests/test_trailing_stop_abs.py
+++ b/backend/tests/test_trailing_stop_abs.py
@@ -70,20 +70,32 @@ class TestTrailingStopAbsProfit(unittest.TestCase):
         for name in self._added:
             sys.modules.pop(name, None)
 
-    def test_short_position_triggers_on_abs_profit(self):
+    def test_long_position_triggers_on_positive_profit(self):
         self.position.update({
             "instrument": "EUR_USD",
-            "short": {"units": "-1", "averagePrice": "1.2345", "tradeIDs": ["t1"]},
+            "long": {"units": "1", "averagePrice": "1.2345", "tradeIDs": ["t1"]},
             "pl": "0",
             "entry_time": "2024-01-01T00:00:00Z",
         })
-        market = {"prices": [{"bids": [{"price": "1.2330"}], "asks": [{"price": "1.2330"}]}]}
+        market = {"prices": [{"bids": [{"price": "1.2355"}], "asks": [{"price": "1.2355"}]}]}
         self.el.process_exit({}, market)
         calls = self.el.order_manager.calls
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0][0], "t1")
         self.assertEqual(calls[0][1], "EUR_USD")
         self.assertEqual(calls[0][2], 6)
+
+    def test_trailing_stop_not_triggered_on_negative_profit(self):
+        self.position.update({
+            "instrument": "EUR_USD",
+            "long": {"units": "1", "averagePrice": "1.2345", "tradeIDs": ["t1"]},
+            "pl": "0",
+            "entry_time": "2024-01-01T00:00:00Z",
+        })
+        market = {"prices": [{"bids": [{"price": "1.2330"}], "asks": [{"price": "1.2330"}]}]}
+        self.el.process_exit({}, market)
+        calls = self.el.order_manager.calls
+        self.assertEqual(len(calls), 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- update trailing stop logic to check positive profit only
- add regression test for negative profit case

## Testing
- `pytest -q`
