### PR TITLE
Implement EMA slope checks with new gradient helper

### DIFF
--- a/backend/indicators/ema.py
+++ b/backend/indicators/ema.py
@@ -26,3 +26,41 @@ def calculate_ema(
     prices_series = pd.Series(prices)
     ema = prices_series.ewm(span=period, adjust=False).mean()
     return ema
+
+
+def get_ema_gradient(series: Union[List[float], pd.Series], *, pip_size: float = 0.01) -> str:
+    """Return the latest EMA gradient as ``"up"``, ``"down"`` or ``"flat"``.
+
+    Parameters
+    ----------
+    series : list or pandas.Series
+        EMA series ordered oldest → newest.
+    pip_size : float, default 0.01
+        Threshold used to judge a "flat" slope.
+
+    Returns
+    -------
+    str
+        ``"up"`` | ``"down"`` | ``"flat"``
+    """
+
+    try:
+        if hasattr(series, "iloc"):
+            if len(series) < 2:
+                return "flat"
+            latest = float(series.iloc[-1])
+            prev = float(series.iloc[-2])
+        else:
+            if len(series) < 2:
+                return "flat"
+            latest = float(series[-1])
+            prev = float(series[-2])
+    except Exception:
+        return "flat"
+
+    diff = latest - prev
+    if diff > pip_size * 0.05:
+        return "up"
+    if diff < -pip_size * 0.05:
+        return "down"
+    return "flat"

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -461,7 +461,7 @@ def process_exit(
                         atr_pips * TRAIL_DISTANCE_MULTIPLIER,
                         TRAIL_DISTANCE_PIPS,
                     )
-                    if int(os.getenv("CALENDAR_VOLATILITY_LEVEL", "0")) >= CALENDAR_VOL_THRESHOLD:
+                    if int(os.getenv("CALENDAR_VOLATILITY_LEVEL", "0")) > CALENDAR_VOL_THRESHOLD:
                         distance_pips *= CALENDAR_TRAIL_MULTIPLIER
 
 

--- a/backend/tests/test_entry_filter_rsi.py
+++ b/backend/tests/test_entry_filter_rsi.py
@@ -165,6 +165,14 @@ class TestEntryFilterRSICross(unittest.TestCase):
         self.assertIn("ATR", msg)
         self.assertIn("RSI", msg)
 
+    def test_ema_convergence_blocks_entry(self):
+        ind = self._base_indicators()
+        ind["ema_fast"] = FakeSeries([1.0, 1.2, 1.1])
+        ind["ema_slow"] = FakeSeries([0.9, 1.0, 1.05])
+        m1 = {"rsi": FakeSeries([29, 35])}
+        result = pass_entry_filter(ind, price=1.2, indicators_m1=m1)
+        self.assertFalse(result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_tp_bb_ratio.py
+++ b/backend/tests/test_tp_bb_ratio.py
@@ -46,7 +46,7 @@ class TestTpBbRatio(unittest.TestCase):
         oa.should_convert_limit_to_market = lambda ctx: True
         oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(action="HOLD", confidence=0.0, reason="")
         oa.EXIT_BIAS_FACTOR = 1.0
-        add("backend.strategy.openai_analysis", oa, remove=False)
+        add("backend.strategy.openai_analysis", oa)
 
         om = types.ModuleType("backend.orders.order_manager")
         class DummyMgr:


### PR DESCRIPTION
## Summary
- add `get_ema_gradient` helper for EMA slope classification
- block entry when EMAs converge and slope reverses or flattens
- include EMA trend info in market condition logic
- adjust calendar trailing logic threshold check
- expand entry filter tests with EMA slope scenario
- cleanup lingering test stub for tp_bb_ratio

## Testing
- `pytest -q`