### PR TITLE
Implement dynamic ADX threshold based on Bollinger width

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -169,6 +169,7 @@ ADX_NO_TRADE_MIN=3
 ADX_NO_TRADE_MAX=10
 # ADX value used to judge range conditions for entry filters
 ADX_RANGE_THRESHOLD=25
+ADX_DYNAMIC_COEFF=0
 
 # BB中央付近ブロック比（レンジ時）
 RANGE_CENTER_BLOCK_PCT=0.15

--- a/backend/indicators/bollinger.py
+++ b/backend/indicators/bollinger.py
@@ -34,3 +34,9 @@ def calculate_bollinger_bands(prices, window=None, num_std=None):
         'upper_band': upper_band,
         'lower_band': lower_band
     })
+
+
+def calculate_bb_width(prices, window=None, num_std=None):
+    """Return Bollinger Band width as a Series."""
+    df = calculate_bollinger_bands(prices, window=window, num_std=num_std)
+    return df['upper_band'] - df['lower_band']

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -159,6 +159,24 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
     ind_h1 = context.get("indicators_h1") or {}
     ind_h4 = context.get("indicators_h4") or {}
 
+    # --- Bollinger band width for dynamic ADX threshold -----------------
+    bb_upper = indicators.get("bb_upper")
+    bb_lower = indicators.get("bb_lower")
+    bw_pips = None
+    try:
+        if bb_upper is not None and bb_lower is not None:
+            pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+            bb_u = float(bb_upper.iloc[-1]) if hasattr(bb_upper, "iloc") else float(bb_upper[-1])
+            bb_l = float(bb_lower.iloc[-1]) if hasattr(bb_lower, "iloc") else float(bb_lower[-1])
+            bw_pips = (bb_u - bb_l) / pip_size
+    except Exception:
+        bw_pips = None
+    bw_thresh = float(env_loader.get_env("BAND_WIDTH_THRESH_PIPS", "4"))
+    adx_base = float(env_loader.get_env("ADX_RANGE_THRESHOLD", "25"))
+    coeff = float(env_loader.get_env("ADX_DYNAMIC_COEFF", "0"))
+    width_ratio = ((bw_pips - bw_thresh) / bw_thresh) if bw_pips is not None else 0.0
+    adx_dynamic_thresh = adx_base * (1 + coeff * width_ratio)
+
     def _extract_latest(series):
         if series is None:
             return []
@@ -198,7 +216,7 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
         ema_sign_consistent = all(pos) or all(neg)
     ema_ok = 1.0 if ema_sign_consistent else 0.0
 
-    adx_ok = 1.0 if adx_latest is not None and adx_latest >= 20 else 0.0
+    adx_ok = 1.0 if adx_latest is not None and adx_latest >= adx_dynamic_thresh else 0.0
 
     rsi_cross_ok = 0.0
     rsi_m1 = ind_m1.get("rsi")
@@ -212,7 +230,7 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
 
     local_regime = None
     if adx_latest is not None and ema_sign_consistent:
-        local_regime = "trend" if adx_latest >= 20 else "range"
+        local_regime = "trend" if adx_latest >= adx_dynamic_thresh else "range"
 
     def _is_trend(ind: dict) -> bool | None:
         adx = ind.get("adx")
@@ -234,7 +252,7 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
         )
         if adx_val is None or not ema_ok_local:
             return None
-        return adx_val >= 20
+        return adx_val >= adx_dynamic_thresh
 
     if local_regime != "trend":
         for ind in (ind_h4, ind_h1):
@@ -545,7 +563,7 @@ def get_exit_decision(
                 last_adx = (
                     float(adx_series.iloc[-1]) if hasattr(adx_series, "iloc") else float(adx_series[-1])
                 )
-                if last_adx >= 25:
+                if last_adx >= adx_dynamic_thresh:
                     # Determine EMA slope over last 3 candles
                     if hasattr(ema_fast_series, "iloc") and len(ema_fast_series) >= 3:
                         ema_last = float(ema_fast_series.iloc[-1])

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -153,8 +153,6 @@ def pass_entry_filter(
     atr_series = indicators["atr"]
     adx_series = indicators.get("adx")
     latest_adx = adx_series.iloc[-1] if adx_series is not None and len(adx_series) else None
-    adx_thresh = float(os.getenv("ADX_RANGE_THRESHOLD", "25"))
-    range_mode = latest_adx is not None and latest_adx < adx_thresh
 
     # --- Volume check ---------------------------------------------------
     vol_series = indicators.get("volume")
@@ -219,6 +217,13 @@ def pass_entry_filter(
         if price is not None and price <= threshold:
             logger.debug("EntryFilter blocked: price overshoot below lower BB")
             return False
+
+    # --- Dynamic ADX threshold based on BB width -----------------------
+    adx_base = float(os.getenv("ADX_RANGE_THRESHOLD", "25"))
+    coeff = float(os.getenv("ADX_DYNAMIC_COEFF", "0"))
+    width_ratio = ((bw_pips - bw_thresh) / bw_thresh) if bw_pips is not None else 0.0
+    adx_thresh = adx_base * (1 + coeff * width_ratio)
+    range_mode = latest_adx is not None and latest_adx < adx_thresh
 
     # --- Range center block --------------------------------------------
     block_pct = float(os.getenv("RANGE_CENTER_BLOCK_PCT", "0.3"))


### PR DESCRIPTION
## Summary
- expose Bollinger Band width calculation
- adjust entry filter to compute ADX threshold from band width
- apply the same logic inside `get_market_condition`
- add `ADX_DYNAMIC_COEFF` environment variable

## Testing
- `pytest -q` *(fails: ImportError in some tests)*