### PR TITLE
Add pattern scan in entry logic and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The system derives a dynamic pullback requirement from ATR, ADX and recent price
 `LOCAL_WEIGHT_THRESHOLD` は 0〜1 の値で、ローカル判定と AI 判定の整合度スコアがこの値以上ならローカルを、未満なら AI を優先します。旧 `USE_LOCAL_PATTERN` は廃止されました。
 `PATTERN_MIN_BARS` でパターン完成に必要なローソク足の本数を、`PATTERN_TOLERANCE` で高値・安値の許容誤差を調整できます。
 `PATTERN_EXCLUDE_TFS` に `M1` などを指定すると、その時間足ではパターン検出を行いません。
+`PATTERN_TFS` を `M1,M5` のように設定すると、指定した時間足のみをスキャンします。
 `STRICT_ENTRY_FILTER` controls whether the M1 RSI cross signal is required. Set to `false` to skip the cross check (default `true`).
 
 ## Running the API

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -108,6 +108,7 @@ AI_EXIT_MODEL=gpt-4.1-nano
 PATTERN_NAMES=double_bottom,double_top,doji,hammer,bullish_engulfing,bearish_engulfing,morning_star,evening_star
 PATTERN_MIN_BARS=5
 PATTERN_TOLERANCE=0.005
+PATTERN_TFS=M1,M5
 
 # --- ボリューム関連 ---
 VOL_MA_PERIOD=10

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -824,6 +824,7 @@ class JobRunner:
                                 market_cond,
                                 higher_tf=higher_tf,
                                 patterns=PATTERN_NAMES,
+                                candles_dict={"M1": candles_m1, "M5": candles_m5},
                                 pattern_names=self.patterns_by_tf,
                             )
                             if not result:

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -461,7 +461,7 @@ def process_exit(
                         atr_pips * TRAIL_DISTANCE_MULTIPLIER,
                         TRAIL_DISTANCE_PIPS,
                     )
-                    if int(os.getenv("CALENDAR_VOLATILITY_LEVEL", "0")) >= CALENDAR_VOL_THRESHOLD:
+                    if int(os.getenv("CALENDAR_VOLATILITY_LEVEL", "0")) > CALENDAR_VOL_THRESHOLD:
                         distance_pips *= CALENDAR_TRAIL_MULTIPLIER
 
 

--- a/backend/tests/test_pattern_detection.py
+++ b/backend/tests/test_pattern_detection.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class TestPatternDetection(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ["PATTERN_TFS"] = "M1,M5"
+        os.environ.setdefault("PATTERN_MIN_BARS", "4")
+        os.environ.setdefault("PATTERN_TOLERANCE", "0.001")
+        os.environ.setdefault("PATTERN_EXCLUDE_TFS", "")
+        import importlib
+        import backend.strategy.pattern_scanner as ps
+        importlib.reload(ps)
+        self._added = []
+        def add(name, mod):
+            if name not in sys.modules:
+                sys.modules[name] = mod
+                self._added.append(name)
+        add("requests", types.ModuleType("requests"))
+        add("numpy", types.ModuleType("numpy"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        self.captured = {}
+        def dummy_get_trade_plan(market_data, indicators, candles_dict, **k):
+            self.captured.update(k.get("detected_patterns") or {})
+            return {"entry": {"side": "no"}}
+        oa.get_trade_plan = dummy_get_trade_plan
+        add("backend.strategy.openai_analysis", oa)
+        om = types.ModuleType("backend.orders.order_manager")
+        class DummyMgr:
+            def enter_trade(self, *a, **k):
+                return {"order_id": "1"}
+        om.OrderManager = DummyMgr
+        add("backend.orders.order_manager", om)
+        log_mod = types.ModuleType("backend.logs.log_manager")
+        log_mod.log_trade = lambda *a, **k: None
+        add("backend.logs.log_manager", log_mod)
+        oc = types.ModuleType("backend.utils.oanda_client")
+        oc.get_pending_entry_order = lambda instrument: None
+        add("backend.utils.oanda_client", oc)
+        import backend.strategy.entry_logic as el
+        importlib.reload(el)
+        self.el = el
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+        os.environ.pop("PATTERN_TFS", None)
+        os.environ.pop("PATTERN_MIN_BARS", None)
+        os.environ.pop("PATTERN_TOLERANCE", None)
+        os.environ.pop("PATTERN_EXCLUDE_TFS", None)
+
+    def test_detect_double_top_bottom(self):
+        m1 = [
+            {"o":1.2,"h":1.25,"l":1.0,"c":1.1},
+            {"o":1.1,"h":1.3,"l":1.1,"c":1.2},
+            {"o":1.2,"h":1.24,"l":1.0,"c":1.1},
+            {"o":1.1,"h":1.35,"l":1.1,"c":1.3},
+        ]
+        m5 = [
+            {"o":1.0,"h":1.4,"l":0.9,"c":1.3},
+            {"o":1.3,"h":1.4,"l":1.2,"c":1.3},
+            {"o":1.3,"h":1.2,"l":1.0,"c":1.1},
+            {"o":1.1,"h":1.4,"l":1.1,"c":1.3},
+            {"o":1.3,"h":1.1,"l":0.8,"c":0.9},
+        ]
+        market_data = {"prices": [{"instrument": "USD_JPY", "bids": [{"price": "1"}], "asks": [{"price": "1"}]}]}
+        self.el.process_entry({}, m5, market_data, candles_dict={"M1": m1, "M5": m5}, patterns=["double_bottom","double_top"])
+        self.assertEqual(self.captured, {"M1": "double_bottom", "M5": "double_top"})
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_pullback_limit.py
+++ b/backend/tests/test_pullback_limit.py
@@ -77,7 +77,13 @@ class TestPullbackLimit(unittest.TestCase):
         candles = []
         market_data = {"prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}]}
         higher_tf = {"pivot_d": 1.0}
-        result = self.el.process_entry(indicators, candles, market_data, higher_tf=higher_tf)
+        result = self.el.process_entry(
+            indicators,
+            candles,
+            market_data,
+            higher_tf=higher_tf,
+            candles_dict={"M5": candles},
+        )
         self.assertTrue(result)
         self.assertEqual(self.el.order_manager.last_params["mode"], "market")
 

--- a/backend/tests/test_tp_bb_ratio.py
+++ b/backend/tests/test_tp_bb_ratio.py
@@ -43,10 +43,11 @@ class TestTpBbRatio(unittest.TestCase):
             "entry": {"side": "long", "mode": "market"},
             "risk": {"tp_pips": None, "sl_pips": 5}
         }
+        oa.get_market_condition = lambda *a, **k: {"market_condition": "trend", "trend_direction": "long"}
         oa.should_convert_limit_to_market = lambda ctx: True
         oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(action="HOLD", confidence=0.0, reason="")
         oa.EXIT_BIAS_FACTOR = 1.0
-        add("backend.strategy.openai_analysis", oa, remove=False)
+        add("backend.strategy.openai_analysis", oa)
 
         om = types.ModuleType("backend.orders.order_manager")
         class DummyMgr:
@@ -87,7 +88,12 @@ class TestTpBbRatio(unittest.TestCase):
         market_data = {
             "prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}]
         }
-        result = self.el.process_entry(indicators, candles, market_data)
+        result = self.el.process_entry(
+            indicators,
+            candles,
+            market_data,
+            candles_dict={"M5": candles},
+        )
         self.assertTrue(result)
         self.assertAlmostEqual(self.el.order_manager.last_params["tp_pips"], 5.0)
 


### PR DESCRIPTION
## Summary
- scan recent candles for chart patterns inside entry logic
- allow configurable PATTERN_TFS environment variable
- pass detected pattern names to OpenAI prompts
- adjust calendar volatility check and improve tests
- new unit test for pattern detection

## Testing
- `pytest -q`