### PR TITLE
Fix missing pandas import in ADX indicator

### DIFF
--- a/backend/indicators/adx.py
+++ b/backend/indicators/adx.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 from typing import Sequence
+import pandas as pd
 
 def calculate_adx(
     high: Sequence[float],


### PR DESCRIPTION
## Summary
- import pandas in the ADX indicator to avoid runtime NameError

## Testing
- `pytest -q`