### PR TITLE
Add breakout follow helper

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -33,6 +33,7 @@ from backend.strategy.openai_analysis import (
 )
 from backend.strategy.higher_tf_analysis import analyze_higher_tf
 from backend.strategy import pattern_scanner
+from backend.strategy.momentum_follow import follow_breakout
 import requests
 
 from backend.utils.notification import send_line_message
@@ -861,6 +862,14 @@ class JobRunner:
                                 higher_tf,
                             )
                             logger.debug(f"Market condition (post‑filter): {market_cond}")
+
+                            if not has_position and market_cond.get("market_condition") == "break":
+                                try:
+                                    direction = market_cond.get("range_break")
+                                    follow = follow_breakout(candles_m5, indicators, direction)
+                                    logger.info(f"follow_breakout result: {follow}")
+                                except Exception as exc:
+                                    logger.warning(f"follow_breakout failed: {exc}")
 
                             margin_used = get_margin_used()
                             logger.info(f"marginUsed={margin_used}")

--- a/backend/strategy/momentum_follow.py
+++ b/backend/strategy/momentum_follow.py
@@ -1,0 +1,24 @@
+"""ブレイク後のモメンタムを利用した追随エントリー判定用モジュール."""
+
+from typing import List, Dict, Optional
+
+
+def follow_breakout(candles: List[dict], indicators: Dict[str, list], direction: Optional[str]) -> bool:
+    """ブレイクアウト後に追随エントリーすべきか判定して返す.
+
+    Parameters
+    ----------
+    candles : list of dict
+        最新のローソク足データ
+    indicators : dict
+        ADX などの計算済み指標
+    direction : str or None
+        ブレイク方向 ``"up"`` もしくは ``"down"``
+
+    Returns
+    -------
+    bool
+        エントリーすべきと判断した場合 ``True``
+    """
+    # TODO: Use pullback size after breakout and ADX value to decide entry
+    return False

--- a/docs/momentum_follow.md
+++ b/docs/momentum_follow.md
@@ -1,0 +1,14 @@
+# ブレイクアウト追随エントリー
+
+`follow_breakout` 関数はレンジブレイク後の押し戻しを利用してエントリーすべきかどうかを判定します。
+
+```python
+from backend.strategy.momentum_follow import follow_breakout
+
+# candles は直近のローソク足リスト、indicators は計算済み指標
+if follow_breakout(candles, indicators, "up"):
+    # エントリー処理を実行
+    pass
+```
+
+実装内部では押し戻し量や ADX を用いて判断する想定ですが、現時点では TODO として残しています。


### PR DESCRIPTION
## Summary
- create `momentum_follow` for following breakouts
- call `follow_breakout` in job runner when market cond indicates a break
- document usage of `follow_breakout`

## Testing
- `pytest -q`