### PR TITLE
Add ATR breakout detection

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -125,7 +125,11 @@ def calc_consistency(
 # ----------------------------------------------------------------------
 # Market‑regime classification helper (OpenAI direct, enhanced English prompt)
 # ----------------------------------------------------------------------
-from backend.strategy.range_break import detect_range_break, classify_breakout
+from backend.strategy.range_break import (
+    detect_range_break,
+    classify_breakout,
+    detect_atr_breakout,
+)
 
 
 def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
@@ -388,6 +392,12 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
             break_class = classify_breakout(indicators)
             if break_class == "trend":
                 final_regime = "trend"
+
+        # --- ATR ブレイク判定 ----------------------------------------
+        atr_series = indicators.get("atr")
+        atr_break = detect_atr_breakout(candles, atr_series) if atr_series is not None else None
+        if atr_break:
+            final_regime = "break"
 
     return {
         "market_condition": final_regime,

--- a/backend/strategy/range_break.py
+++ b/backend/strategy/range_break.py
@@ -63,3 +63,48 @@ def classify_breakout(indicators: dict, adx_thresh: float = 25.0, ema_thresh: fl
     if adx_val >= adx_thresh and abs(ema_val) >= ema_thresh:
         return "trend"
     return "range"
+
+
+def detect_atr_breakout(
+    candles: List[dict],
+    atr_series,
+    lookback: int = 20,
+    mult: float = 0.5,
+) -> Optional[str]:
+    """ATR に基づくブレイクアウト判定を行う。
+
+    直近 ``lookback`` 本の高値・安値から最高値・最安値を求め、
+    ATR の最新値に ``mult`` を掛けた値を閾値として終値が上抜け・下抜け
+    した場合に ``"up"`` もしくは ``"down"`` を返す。
+    """
+
+    if not candles or len(candles) < lookback + 1 or atr_series is None:
+        return None
+
+    try:
+        if hasattr(atr_series, "iloc"):
+            atr_val = float(atr_series.iloc[-1])
+        else:
+            atr_val = float(atr_series[-1])
+    except Exception:
+        return None
+
+    threshold = atr_val * mult
+
+    recent = [c for c in candles[-(lookback + 1):-1] if c.get("complete", True)]
+    last = candles[-1]
+    if not recent or "mid" not in last:
+        return None
+
+    highs = [float(c["mid"]["h"]) for c in recent]
+    lows = [float(c["mid"]["l"]) for c in recent]
+    last_close = float(last["mid"]["c"])
+
+    range_high = max(highs)
+    range_low = min(lows)
+
+    if last_close > range_high + threshold:
+        return "up"
+    if last_close < range_low - threshold:
+        return "down"
+    return None

--- a/backend/tests/test_atr_breakout.py
+++ b/backend/tests/test_atr_breakout.py
@@ -1,0 +1,57 @@
+import unittest
+
+from backend.strategy.range_break import detect_atr_breakout
+
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+
+class TestAtrBreakout(unittest.TestCase):
+    def test_breakout_up(self):
+        candles = [
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.95"}, "complete": True},
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.92"}, "complete": True},
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.93"}, "complete": True},
+            {"mid": {"h": "1.2", "l": "0.9", "c": "1.12"}, "complete": True},
+        ]
+        atr = FakeSeries([0.2])
+        res = detect_atr_breakout(candles, atr, lookback=3)
+        self.assertEqual(res, "up")
+
+    def test_breakout_down(self):
+        candles = [
+            {"mid": {"h": "1.1", "l": "1.0", "c": "1.05"}, "complete": True},
+            {"mid": {"h": "1.1", "l": "1.0", "c": "1.03"}, "complete": True},
+            {"mid": {"h": "1.1", "l": "1.0", "c": "1.04"}, "complete": True},
+            {"mid": {"h": "1.1", "l": "0.8", "c": "0.88"}, "complete": True},
+        ]
+        atr = FakeSeries([0.2])
+        res = detect_atr_breakout(candles, atr, lookback=3)
+        self.assertEqual(res, "down")
+
+    def test_no_breakout(self):
+        candles = [
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.95"}, "complete": True},
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.92"}, "complete": True},
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.93"}, "complete": True},
+            {"mid": {"h": "1.0", "l": "0.9", "c": "1.02"}, "complete": True},
+        ]
+        atr = FakeSeries([0.2])
+        res = detect_atr_breakout(candles, atr, lookback=3)
+        self.assertIsNone(res)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `detect_atr_breakout` helper for ATR-based breakout check
- integrate new breakout logic in `get_market_condition`
- test ATR breakout detection logic

## Testing
- `pytest -q`
