### PR TITLE
Handle incomplete last candle in range break detection

### DIFF
--- a/backend/strategy/range_break.py
+++ b/backend/strategy/range_break.py
@@ -22,7 +22,7 @@ def detect_range_break(candles: List[dict], *, lookback: int = 20, pivot: Option
 
     recent = [c for c in candles[-(lookback + 1):-1] if c.get("complete", True)]
     last = candles[-1]
-    if not recent or "mid" not in last:
+    if not recent or "mid" not in last or not last.get("complete", True):
         return {"break": False, "direction": None}
 
     highs = [float(c["mid"]["h"]) for c in recent]

--- a/backend/tests/test_range_break_detection.py
+++ b/backend/tests/test_range_break_detection.py
@@ -30,6 +30,17 @@ class TestRangeBreakDetection(unittest.TestCase):
         self.assertTrue(res["break"])
         self.assertEqual(res["direction"], "up")
 
+    def test_ignore_incomplete_last_candle(self):
+        candles = [
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.95"}, "complete": True},
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.92"}, "complete": True},
+            {"mid": {"h": "1.0", "l": "0.9", "c": "0.93"}, "complete": True},
+            {"mid": {"h": "1.1", "l": "0.9", "c": "1.11"}, "complete": False},
+        ]
+        res = detect_range_break(candles, lookback=3)
+        self.assertFalse(res["break"])
+        self.assertIsNone(res["direction"])
+
     def test_classify_trend(self):
         indicators = {"adx": FakeSeries([20, 30]), "ema_slope": FakeSeries([0.1, 0.2])}
         cls = classify_breakout(indicators)


### PR DESCRIPTION
## Summary
- avoid range break check if the last candle is not complete
- add regression test for incomplete candle scenario

## Testing
- `pytest -q backend/tests/test_range_break_detection.py`
- `pytest -q` *(fails: KeyboardInterrupt after completion)*