### PR TITLE
Add breakout follow logic with tests

### DIFF
--- a/backend/strategy/momentum_follow.py
+++ b/backend/strategy/momentum_follow.py
@@ -2,6 +2,8 @@
 
 from typing import List, Dict, Optional
 
+from backend.utils import env_loader
+
 
 def follow_breakout(candles: List[dict], indicators: Dict[str, list], direction: Optional[str]) -> bool:
     """ブレイクアウト後に追随エントリーすべきか判定して返す.
@@ -20,5 +22,37 @@ def follow_breakout(candles: List[dict], indicators: Dict[str, list], direction:
     bool
         エントリーすべきと判断した場合 ``True``
     """
-    # TODO: Use pullback size after breakout and ADX value to decide entry
-    return False
+
+    if direction not in ("up", "down") or len(candles) < 2:
+        return False
+
+    adx_series = indicators.get("adx")
+    atr_series = indicators.get("atr")
+    if adx_series is None or atr_series is None:
+        return False
+
+    if not len(adx_series) or not len(atr_series):
+        return False
+
+    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+    adx_min = float(env_loader.get_env("FOLLOW_ADX_MIN", "25"))
+    pull_ratio = float(env_loader.get_env("FOLLOW_PULLBACK_ATR_RATIO", "0.5"))
+
+    adx_val = adx_series.iloc[-1] if hasattr(adx_series, "iloc") else adx_series[-1]
+    atr_val = atr_series.iloc[-1] if hasattr(atr_series, "iloc") else atr_series[-1]
+
+    if float(adx_val) < adx_min:
+        return False
+
+    breakout_candle = candles[-2]
+    last_candle = candles[-1]
+
+    if direction == "up":
+        pull = float(breakout_candle["mid"]["h"]) - float(last_candle["mid"]["c"])
+    else:
+        pull = float(last_candle["mid"]["c"]) - float(breakout_candle["mid"]["l"])
+
+    pull_pips = max(pull, 0.0) / pip_size
+    atr_pips = float(atr_val) / pip_size
+
+    return pull_pips <= atr_pips * pull_ratio

--- a/backend/tests/test_follow_breakout_call.py
+++ b/backend/tests/test_follow_breakout_call.py
@@ -1,0 +1,135 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+class TestFollowBreakoutCall(unittest.TestCase):
+    def setUp(self):
+        self._added = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._added.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        add("requests", types.ModuleType("requests"))
+        add("numpy", types.ModuleType("numpy"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.get_market_condition = lambda *a, **k: {"market_condition": "break", "range_break": "up"}
+        oa.get_trade_plan = lambda *a, **k: {"entry": {"side": "no"}, "risk": {}}
+        oa.should_convert_limit_to_market = lambda ctx: False
+        oa.evaluate_exit = lambda ctx, bias_factor=1.0: types.SimpleNamespace(action="HOLD", confidence=0.0, reason="")
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add("backend.strategy.openai_analysis", oa)
+
+        om = types.ModuleType("backend.orders.order_manager")
+        class DummyMgr:
+            def update_trade_sl(self, *a, **k):
+                return {}
+            def enter_trade(self, *a, **k):
+                return {}
+            def cancel_order(self, *a, **k):
+                pass
+            def place_market_order(self, *a, **k):
+                pass
+        om.OrderManager = DummyMgr
+        add("backend.orders.order_manager", om)
+
+        upd = types.ModuleType("backend.logs.update_oanda_trades")
+        def stop(*a, **k):
+            raise SystemExit()
+        upd.update_oanda_trades = stop
+        upd.fetch_trade_details = lambda *a, **k: {}
+        add("backend.logs.update_oanda_trades", upd)
+
+        stub_names = [
+            "backend.market_data.tick_fetcher",
+            "backend.market_data.candle_fetcher",
+            "backend.indicators.calculate_indicators",
+            "backend.strategy.exit_logic",
+            "backend.orders.position_manager",
+            "backend.strategy.signal_filter",
+            "backend.strategy.higher_tf_analysis",
+            "backend.utils.notification",
+            "backend.strategy.pattern_scanner",
+        ]
+        for name in stub_names:
+            mod = types.ModuleType(name)
+            add(name, mod)
+
+        sys.modules["backend.market_data.tick_fetcher"].fetch_tick_data = lambda *a, **k: {
+            "prices": [{"bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}], "tradeable": True}]
+        }
+        sys.modules["backend.market_data.candle_fetcher"].fetch_multiple_timeframes = lambda *a, **k: {
+            "M5": [{"mid": {"h": "1.1", "l": "1.0", "c": "1.05"}, "complete": True}],
+            "M1": [], "H1": [], "H4": [], "D": []
+        }
+        sys.modules["backend.indicators.calculate_indicators"].calculate_indicators = lambda *a, **k: {}
+        sys.modules["backend.indicators.calculate_indicators"].calculate_indicators_multi = lambda *a, **k: {
+            "M5": {"adx": FakeSeries([30]), "atr": FakeSeries([0.1])},
+            "M1": {}, "H1": {"adx": FakeSeries([30])}, "H4": {"adx": FakeSeries([30])}, "D": {}
+        }
+        sys.modules["backend.strategy.exit_logic"].process_exit = lambda *a, **k: None
+        sys.modules["backend.orders.position_manager"].check_current_position = lambda *a, **k: None
+        sys.modules["backend.strategy.signal_filter"].pass_entry_filter = lambda *a, **k: True
+        sys.modules["backend.strategy.signal_filter"].pass_exit_filter = lambda *a, **k: True
+        sys.modules["backend.strategy.higher_tf_analysis"].analyze_higher_tf = lambda *a, **k: {}
+        sys.modules["backend.utils.notification"].send_line_message = lambda *a, **k: None
+        sys.modules["backend.strategy.pattern_scanner"].scan = lambda *a, **k: {}
+        sys.modules["backend.strategy.pattern_scanner"].PATTERN_DIRECTION = {}
+
+        self.calls = []
+        mf = types.ModuleType("backend.strategy.momentum_follow")
+        def follow_stub(candles, indicators, direction):
+            self.calls.append((candles, indicators, direction))
+            return True
+        mf.follow_breakout = follow_stub
+        add("backend.strategy.momentum_follow", mf)
+
+        os.environ.pop("OANDA_API_KEY", None)
+        os.environ.pop("OANDA_ACCOUNT_ID", None)
+        os.environ["PIP_SIZE"] = "0.01"
+
+        import backend.scheduler.job_runner as jr
+        importlib.reload(jr)
+        jr.instrument_is_tradeable = lambda instrument: True
+        self.jr = jr
+        self.runner = jr.JobRunner(interval_seconds=1)
+        self.runner._manage_pending_limits = lambda *a, **k: None
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+        os.environ.pop("PIP_SIZE", None)
+
+    def test_follow_breakout_called(self):
+        with self.assertRaises(SystemExit):
+            self.runner.run()
+        self.assertEqual(len(self.calls), 1)
+        candles, indicators, direction = self.calls[0]
+        self.assertEqual(direction, "up")
+        self.assertTrue(candles)
+        self.assertEqual(indicators["adx"].iloc[-1], 30)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/momentum_follow.md
+++ b/docs/momentum_follow.md
@@ -11,4 +11,4 @@ if follow_breakout(candles, indicators, "up"):
     pass
 ```
 
-実装内部では押し戻し量や ADX を用いて判断する想定ですが、現時点では TODO として残しています。
+実装では直近の押し戻し量が ATR の一定割合以内かつ ADX が閾値以上かを確認してエントリー可否を判定します。


### PR DESCRIPTION
## Summary
- add breakout follow logic using pullback and ADX
- document breakout follow algorithm
- ensure `follow_breakout` is called from JobRunner

## Testing
- `pytest -q`