### PR TITLE
Add ATR breakout direction to market condition

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -399,9 +399,12 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
 
         # --- ATR ブレイク判定 ----------------------------------------
         atr_series = indicators.get("atr")
-        atr_break = detect_atr_breakout(candles, atr_series) if atr_series is not None else None
+        atr_break = (
+            detect_atr_breakout(candles, atr_series) if atr_series is not None else None
+        )
         if atr_break:
             final_regime = "break"
+            range_break = atr_break
 
     return {
         "market_condition": final_regime,


### PR DESCRIPTION
## Summary
- ensure `get_market_condition()` propagates ATR breakout direction
- test ATR breakout direction through market condition logic

## Testing
- `pytest backend/tests/test_atr_breakout.py::TestMarketConditionAtrBreak::test_market_condition_returns_atr_direction -q`
- `pytest -q`