### PR TITLE
Add get_current_tp and skip TP adjustments when unchanged

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -247,6 +247,22 @@ class OrderManager:
 
         return results if results else None
 
+    def get_current_tp(self, trade_id: str) -> float | None:
+        """現在設定されているTP価格を取得する。"""
+        url = f"{OANDA_API_URL}/accounts/{OANDA_ACCOUNT_ID}/trades/{trade_id}/orders"
+        try:
+            resp = requests.get(url, headers=HEADERS, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            tp_info = data.get("takeProfitOrder") or data.get("trade", {}).get("takeProfitOrder")
+            if isinstance(tp_info, dict):
+                price = tp_info.get("price")
+                if price is not None:
+                    return float(price)
+        except Exception as exc:
+            logger.warning(f"get_current_tp failed for {trade_id}: {exc}")
+        return None
+
     def market_close_position(self, instrument):
         # delegate to unified close_position() helper
         logger.debug(f"[market_close_position] closing BOTH sides for {instrument}")

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -393,11 +393,16 @@ class JobRunner:
         except Exception:
             return
         new_tp = entry_price + ext_pips * pip_size if side == "long" else entry_price - ext_pips * pip_size
+        current_tp = None
+        if hasattr(order_mgr, "get_current_tp"):
+            current_tp = order_mgr.get_current_tp(trade_id)
+        if current_tp is not None and abs(current_tp - new_tp) < pip_size * 0.1:
+            return
         try:
             res = order_mgr.adjust_tp_sl(DEFAULT_PAIR, trade_id, new_tp=new_tp)
             if res is not None:
                 logger.info(
-                    f"TP extended to {new_tp} ({ext_pips:.1f}pips) due to strong trend"
+                    f"TP extended from {current_tp} to {new_tp} ({ext_pips:.1f}pips) due to strong trend"
                 )
                 self.tp_extended = True
         except Exception as exc:
@@ -430,11 +435,16 @@ class JobRunner:
         except Exception:
             return
         new_tp = entry_price + red_pips * pip_size if side == "long" else entry_price - red_pips * pip_size
+        current_tp = None
+        if hasattr(order_mgr, "get_current_tp"):
+            current_tp = order_mgr.get_current_tp(trade_id)
+        if current_tp is not None and abs(current_tp - new_tp) < pip_size * 0.1:
+            return
         try:
             res = order_mgr.adjust_tp_sl(DEFAULT_PAIR, trade_id, new_tp=new_tp)
             if res is not None:
                 logger.info(
-                    f"TP reduced to {new_tp} ({red_pips:.1f}pips) due to weak trend"
+                    f"TP reduced from {current_tp} to {new_tp} ({red_pips:.1f}pips) due to weak trend"
                 )
                 self.tp_reduced = True
         except Exception as exc:


### PR DESCRIPTION
## Summary
- add helper to fetch current TP price for a trade
- use current TP to avoid redundant TP updates
- log old and new TP when TP is adjusted

## Testing
- `pytest -q`