### PR TITLE
Add higher timeframe pivot TP logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The system derives a dynamic pullback requirement from ATR, ADX and recent price
 `PATTERN_EXCLUDE_TFS` に `M1` などを指定すると、その時間足ではパターン検出を行いません。
 `PATTERN_TFS` を `M1,M5` のように設定すると、指定した時間足のみをスキャンします。
 `STRICT_ENTRY_FILTER` controls whether the M1 RSI cross signal is required. Set to `false` to skip the cross check (default `true`).
+`HIGHER_TF_ENABLED` を `true` にすると、上位足ピボットとの距離も TP 計算に利用します。
 
 ## Running the API
 

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -323,6 +323,20 @@ def process_entry(
             bb_tp = width_pips * bb_ratio
             if fallback_tp is None or bb_tp < fallback_tp:
                 fallback_tp = bb_tp
+
+        # 上位足ピボットとの距離を TP 候補として追加
+        if (
+            env_loader.get_env("HIGHER_TF_ENABLED", "true").lower() == "true"
+            and higher_tf
+            and price_ref is not None
+        ):
+            for key in ("pivot_h1", "pivot_h4", "pivot_d"):
+                pivot_val = higher_tf.get(key)
+                if pivot_val is None:
+                    continue
+                dist = abs(pivot_val - price_ref) / pip_size
+                if fallback_tp is None or dist < fallback_tp:
+                    fallback_tp = dist
     except Exception as exc:
         logging.debug(f"[process_entry] ATR-based SL calc failed: {exc}")
 

--- a/backend/tests/test_higher_tf_tp.py
+++ b/backend/tests/test_higher_tf_tp.py
@@ -1,0 +1,103 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return self._data[idx]
+        if isinstance(idx, int) and idx < 0:
+            raise KeyError(idx)
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+class TestHigherTfTp(unittest.TestCase):
+    def setUp(self):
+        self._mods = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._mods.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        add("requests", types.ModuleType("requests"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.get_trade_plan = lambda *a, **k: {
+            "entry": {"side": "long", "mode": "market"},
+            "risk": {"tp_pips": None, "sl_pips": 5}
+        }
+        oa.should_convert_limit_to_market = lambda ctx: True
+        oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(action="HOLD", confidence=0.0, reason="")
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add("backend.strategy.openai_analysis", oa)
+
+        om = types.ModuleType("backend.orders.order_manager")
+        class DummyMgr:
+            def __init__(self):
+                self.last_params = None
+            def enter_trade(self, side, lot_size, market_data, strategy_params, force_limit_only=False):
+                self.last_params = strategy_params
+                return {"order_id": "1"}
+        om.OrderManager = DummyMgr
+        add("backend.orders.order_manager", om)
+
+        log_mod = types.ModuleType("backend.logs.log_manager")
+        log_mod.log_trade = lambda *a, **k: None
+        add("backend.logs.log_manager", log_mod)
+
+        os.environ["PIP_SIZE"] = "0.01"
+        os.environ["HIGHER_TF_ENABLED"] = "true"
+
+        import backend.strategy.entry_logic as el
+        importlib.reload(el)
+        self.el = el
+        self._mods.append("backend.strategy.entry_logic")
+
+    def tearDown(self):
+        for name in self._mods:
+            sys.modules.pop(name, None)
+        os.environ.pop("PIP_SIZE", None)
+        os.environ.pop("HIGHER_TF_ENABLED", None)
+        sys.modules.pop("backend.strategy.entry_logic", None)
+
+    def test_tp_uses_nearest_higher_tf_pivot(self):
+        indicators = {
+            "atr": FakeSeries([0.2]),
+            "bb_upper": FakeSeries([1.2]),
+            "bb_lower": FakeSeries([1.0]),
+            "pivot_r1": 1.20,
+            "n_wave_target": 1.20,
+        }
+        candles = []
+        market_data = {
+            "prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}]
+        }
+        higher_tf = {"pivot_h1": 1.03, "pivot_h4": 1.05, "pivot_d": 1.10}
+        result = self.el.process_entry(
+            indicators,
+            candles,
+            market_data,
+            higher_tf=higher_tf,
+            candles_dict={"M5": candles},
+        )
+        self.assertTrue(result)
+        self.assertAlmostEqual(self.el.order_manager.last_params["tp_pips"], 3.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- consider higher timeframe pivots when computing fallback TP
- document HIGHER_TF_ENABLED behaviour
- test TP calc with higher timeframe pivot

## Testing
- `pytest -q`