### PR TITLE
Add polarity-based exit logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ threshold passes.
 `REVERSAL_EXIT_ATR_MULT` and `REVERSAL_EXIT_ADX_MIN` define how far beyond the
 opposite Bollinger Band the close must be, and the minimum ADX, before a reversal
 exit is considered.
+`POLARITY_EXIT_THRESHOLD` sets the absolute polarity required to trigger a polarity-based early exit. The default is `0.4`.
 `PULLBACK_LIMIT_OFFSET_PIPS` is the base distance for a pullback LIMIT order when the AI proposes a market entry. The actual offset is derived from ATR and ADX, and if price runs away while the trend persists the order can be switched to a market order under AI control.
 `AI_LIMIT_CONVERT_MODEL` sets the OpenAI model used when asking whether a pending LIMIT should be switched to a market order. The default is `gpt-4.1-nano`.
 `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.

--- a/backend/indicators/calculate_indicators.py
+++ b/backend/indicators/calculate_indicators.py
@@ -17,6 +17,7 @@ from backend.indicators.bollinger import calculate_bollinger_bands
 from backend.indicators.adx import calculate_adx
 from backend.indicators.pivot import calculate_pivots
 from backend.indicators.n_wave import calculate_n_wave_target
+from backend.indicators.polarity import calculate_polarity
 from backend.market_data.candle_fetcher import fetch_candles
 
 
@@ -72,6 +73,7 @@ def calculate_indicators(
         'bb_lower': bb_df['lower_band'],
         'bb_middle': bb_df['middle_band'],
         'adx': adx_series,
+        'polarity': calculate_polarity(close_prices),
     }
 
     if high_prices and low_prices and close_prices:

--- a/backend/indicators/polarity.py
+++ b/backend/indicators/polarity.py
@@ -1,0 +1,29 @@
+import os
+from typing import Sequence
+
+try:
+    import pandas as pd
+except ImportError as e:
+    raise ImportError(
+        "Pandas is required for indicator calculations."
+        " Install it with 'pip install pandas'."
+    ) from e
+
+
+def calculate_polarity(prices: Sequence[float], *, period: int = None) -> pd.Series:
+    """Return rolling polarity score between -1 and 1."""
+    if period is None:
+        period = int(os.getenv("POLARITY_PERIOD", "10"))
+    series = pd.Series(prices)
+    diff = series.diff()
+
+    def _sign(val: float) -> int:
+        if val > 0:
+            return 1
+        if val < 0:
+            return -1
+        return 0
+
+    sign_series = diff.apply(_sign)
+    polarity = sign_series.rolling(window=period, min_periods=1).sum() / period
+    return polarity

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -34,6 +34,9 @@ STAGNANT_ATR_PIPS = float(os.getenv("STAGNANT_ATR_PIPS", "0"))
 REVERSAL_EXIT_ATR_MULT = float(os.getenv("REVERSAL_EXIT_ATR_MULT", "1.0"))
 REVERSAL_EXIT_ADX_MIN = float(os.getenv("REVERSAL_EXIT_ADX_MIN", "25"))
 
+# polarity-based exit threshold
+POLARITY_EXIT_THRESHOLD = float(os.getenv("POLARITY_EXIT_THRESHOLD", "0.4"))
+
 # Dynamic ATR‑based trailing‑stop (always enabled)
 TRAIL_TRIGGER_MULTIPLIER = float(os.getenv("TRAIL_TRIGGER_MULTIPLIER", "1.2"))
 TRAIL_DISTANCE_MULTIPLIER = float(os.getenv("TRAIL_DISTANCE_MULTIPLIER", "1.0"))
@@ -310,6 +313,18 @@ def process_exit(
                             early_exit = True
                     except Exception:
                         pass
+
+        # polarity check
+        if not early_exit:
+            polarity = indicators.get("polarity")
+            if hasattr(polarity, "iloc"):
+                polarity = float(polarity.iloc[-1])
+            if polarity is not None:
+                if (
+                    (position_side == "long" and polarity <= -POLARITY_EXIT_THRESHOLD)
+                    or (position_side == "short" and polarity >= POLARITY_EXIT_THRESHOLD)
+                ):
+                    early_exit = True
 
         if early_exit:
             logging.info("Early‑exit criteria met — consulting AI before action.")

--- a/backend/tests/test_polarity_exit.py
+++ b/backend/tests/test_polarity_exit.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+class TestPolarityExit(unittest.TestCase):
+    def setUp(self):
+        self._mods = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._mods.append(name)
+
+        os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")
+        os.environ.setdefault("OANDA_API_KEY", "dummy")
+        self._old_pair = os.environ.get("DEFAULT_PAIR")
+        os.environ["EARLY_EXIT_ENABLED"] = "true"
+        os.environ["POLARITY_EXIT_THRESHOLD"] = "0.4"
+        os.environ["DEFAULT_PAIR"] = "EUR_USD"
+
+        add("requests", types.ModuleType("requests"))
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+        add("numpy", types.ModuleType("numpy"))
+
+        log_stub = types.ModuleType("backend.logs.log_manager")
+        log_stub.log_trade = lambda *a, **k: None
+        log_stub.log_error = lambda *a, **k: None
+        add("backend.logs.log_manager", log_stub)
+
+        pm = types.ModuleType("backend.orders.position_manager")
+        self.position = {}
+        pm.get_position_details = lambda *a, **k: self.position
+        add("backend.orders.position_manager", pm)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(
+            action="EXIT", reason="polarity", as_dict=lambda: {"action": "EXIT", "reason": "polarity"}
+        )
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add("backend.strategy.openai_analysis", oa)
+
+        import backend.orders.order_manager as om
+        importlib.reload(om)
+        class DummyOM(om.OrderManager):
+            def __init__(self):
+                self.calls = []
+            def exit_trade(self, pos):
+                self.calls.append(pos)
+        self.DummyOM = DummyOM
+
+        import backend.strategy.exit_logic as el
+        importlib.reload(el)
+        el.order_manager = DummyOM()
+        self.el = el
+
+    def tearDown(self):
+        for n in self._mods:
+            sys.modules.pop(n, None)
+        sys.modules.pop("backend.strategy.exit_logic", None)
+        os.environ.pop("POLARITY_EXIT_THRESHOLD", None)
+        if self._old_pair is None:
+            os.environ.pop("DEFAULT_PAIR", None)
+        else:
+            os.environ["DEFAULT_PAIR"] = self._old_pair
+
+    def test_exit_triggered_on_polarity(self):
+        self.position.update({
+            "instrument": "EUR_USD",
+            "long": {"units": "1", "averagePrice": "1.2350", "tradeIDs": ["t1"]},
+            "pl": "0",
+            "entry_time": "2024-01-01T00:00:00Z"
+        })
+        indicators = {
+            "ema_fast": FakeSeries([1.2340]),
+            "atr": FakeSeries([0.0020]),
+            "bb_lower": FakeSeries([1.2300]),
+            "bb_upper": FakeSeries([1.2400]),
+            "adx": FakeSeries([30]),
+            "polarity": FakeSeries([-0.6]),
+        }
+        market = {"prices": [{"bids": [{"price": "1.2240"}], "asks": [{"price": "1.2241"}]}]}
+        self.el.process_exit(indicators, market)
+        self.assertEqual(len(self.el.order_manager.calls), 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `calculate_polarity` indicator for sentiment of recent candles
- include polarity in `calculate_indicators`
- implement polarity-triggered early exit in `exit_logic`
- document `POLARITY_EXIT_THRESHOLD`
- test polarity-based exit

## Testing
- `pytest -q`