### PR TITLE
Add allow_incomplete option for candle fetcher

### DIFF
--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -183,7 +183,12 @@ def pass_entry_filter(
                 from backend.indicators.calculate_indicators import calculate_indicators
 
                 pair = os.getenv("DEFAULT_PAIR", "USD_JPY")
-                candles_m1 = fetch_candles(pair, granularity="M1", count=10)
+                candles_m1 = fetch_candles(
+                    pair,
+                    granularity="M1",
+                    count=10,
+                    allow_incomplete=True,
+                )
                 indicators_m1 = calculate_indicators(candles_m1, pair=pair)
             except Exception as exc:
                 logger.warning("Failed to fetch M1 indicators: %s", exc)


### PR DESCRIPTION
## Summary
- allow fetching incomplete candles when needed
- use latest incomplete M1 data in signal filter
- include incomplete candles when fetching multiple timeframes

## Testing
- `pytest -q`