### PR TITLE
Fix debug level log in calculate_indicators

### DIFF
--- a/backend/indicators/calculate_indicators.py
+++ b/backend/indicators/calculate_indicators.py
@@ -44,7 +44,8 @@ def calculate_indicators(
 
     import logging
     logger = logging.getLogger(__name__)
-    logger.info(f"Latest close prices: {close_prices[-15:]}")
+    # 最近の終値をデバッグレベルで出力
+    logger.debug(f"Latest close prices: {close_prices[-15:]}")
 
     ema_fast_period = int(os.getenv("EMA_FAST_PERIOD", "9"))
     ema_slow_period = int(os.getenv("EMA_SLOW_PERIOD", "21"))


### PR DESCRIPTION
## Summary
- set debug level for latest close prices log

## Testing
- `pytest backend/tests/test_entry_filter_rsi.py::TestEntryFilterRSICross::test_pass_entry_filter_allows_with_cross_up -q`