### PR TITLE
Add dynamic SL logic using pivot and N-wave

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -303,6 +303,13 @@ def process_entry(
             tp_ratio = float(env_loader.get_env("SHORT_TP_ATR_RATIO", "0.6"))
             fallback_tp = atr_val / pip_size * tp_ratio
         price_ref = bid if side == "long" else ask
+        # SL用ピボットレベル
+        pivot_sl_key = "pivot_s1" if side == "long" else "pivot_r1"
+        pivot_sl_val = indicators.get(pivot_sl_key)
+        if pivot_sl_val is not None and price_ref is not None:
+            dist_sl = abs(price_ref - pivot_sl_val) / pip_size
+            if fallback_sl is None or dist_sl > fallback_sl:
+                fallback_sl = dist_sl
         pivot_key = "pivot_r1" if side == "long" else "pivot_s1"
         pivot_val = indicators.get(pivot_key)
         if pivot_val is not None and price_ref is not None:
@@ -314,6 +321,9 @@ def process_entry(
             dist = abs(n_target - price_ref) / pip_size
             if fallback_tp is None or dist < fallback_tp:
                 fallback_tp = dist
+            # N波ターゲットをSL候補として利用
+            if fallback_sl is None or dist > fallback_sl:
+                fallback_sl = dist
         bb_upper = indicators.get("bb_upper")
         bb_lower = indicators.get("bb_lower")
         if (

--- a/backend/tests/test_dynamic_sl.py
+++ b/backend/tests/test_dynamic_sl.py
@@ -1,0 +1,100 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return self._data[idx]
+        if isinstance(idx, int) and idx < 0:
+            raise KeyError(idx)
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+class TestDynamicSL(unittest.TestCase):
+    def setUp(self):
+        self._mods = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._mods.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        add("requests", types.ModuleType("requests"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.get_trade_plan = lambda *a, **k: {
+            "entry": {"side": "long", "mode": "market"},
+            "risk": {"tp_pips": 10, "sl_pips": None}
+        }
+        oa.should_convert_limit_to_market = lambda ctx: True
+        oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(action="HOLD", confidence=0.0, reason="")
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add("backend.strategy.openai_analysis", oa)
+
+        om = types.ModuleType("backend.orders.order_manager")
+        class DummyMgr:
+            def __init__(self):
+                self.last_params = None
+            def enter_trade(self, side, lot_size, market_data, strategy_params, force_limit_only=False):
+                self.last_params = strategy_params
+                return {"order_id": "1"}
+        om.OrderManager = DummyMgr
+        add("backend.orders.order_manager", om)
+
+        log_mod = types.ModuleType("backend.logs.log_manager")
+        log_mod.log_trade = lambda *a, **k: None
+        add("backend.logs.log_manager", log_mod)
+
+        os.environ["PIP_SIZE"] = "0.01"
+        os.environ["ATR_SL_MULTIPLIER"] = "2.0"
+
+        import backend.strategy.entry_logic as el
+        importlib.reload(el)
+        self.el = el
+        self._mods.append("backend.strategy.entry_logic")
+
+    def tearDown(self):
+        for name in self._mods:
+            sys.modules.pop(name, None)
+        os.environ.pop("PIP_SIZE", None)
+        os.environ.pop("ATR_SL_MULTIPLIER", None)
+        sys.modules.pop("backend.strategy.entry_logic", None)
+
+    def test_fallback_sl_uses_pivot_and_nwave(self):
+        indicators = {
+            "atr": FakeSeries([0.05]),
+            "pivot_s1": 0.8,
+            "n_wave_target": 0.75
+        }
+        candles = []
+        market_data = {
+            "prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}]
+        }
+        result = self.el.process_entry(
+            indicators,
+            candles,
+            market_data,
+            candles_dict={"M5": candles},
+            tf_align=None,
+        )
+        self.assertTrue(result)
+        self.assertAlmostEqual(self.el.order_manager.last_params["sl_pips"], 25.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adjust `entry_logic` to extend fallback stop-loss using pivot S1/R1 and N-wave target distances
- add unit test verifying the new dynamic stop-loss calculation

## Testing
- `pytest -q`