### PR TITLE
Add TP/SL logging columns

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -38,8 +38,12 @@ def init_db():
                 exit_price REAL,
                 units INTEGER NOT NULL,
                 profit_loss REAL,
+                tp_pips REAL,
+                sl_pips REAL,
+                rrr REAL,
                 ai_reason TEXT,
-                ai_response TEXT
+                ai_response TEXT,
+                entry_regime TEXT
             )
         ''')
 
@@ -48,6 +52,12 @@ def init_db():
         columns = [row[1] for row in cursor.fetchall()]
         if 'ai_response' not in columns:
             cursor.execute('ALTER TABLE trades ADD COLUMN ai_response TEXT')
+        if 'tp_pips' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN tp_pips REAL')
+        if 'sl_pips' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN sl_pips REAL')
+        if 'rrr' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN rrr REAL')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS ai_decisions (
@@ -89,21 +99,44 @@ def init_db():
             )
         ''')
 
-def log_trade(instrument, entry_time, entry_price, units, ai_reason,
-              ai_response=None, entry_regime=None,
-              exit_time=None, exit_price=None, profit_loss=None):
+def log_trade(
+    instrument,
+    entry_time,
+    entry_price,
+    units,
+    ai_reason,
+    ai_response=None,
+    entry_regime=None,
+    exit_time=None,
+    exit_price=None,
+    profit_loss=None,
+    tp_pips=None,
+    sl_pips=None,
+    rrr=None,
+):
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute('''
             INSERT INTO trades (
                 instrument, entry_time, entry_price, units,
                 ai_reason, ai_response, entry_regime,
-                exit_time, exit_price, profit_loss
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                exit_time, exit_price, profit_loss,
+                tp_pips, sl_pips, rrr
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''', (
-            instrument, entry_time, entry_price, units,
-            ai_reason, ai_response, entry_regime,
-            exit_time, exit_price, profit_loss
+            instrument,
+            entry_time,
+            entry_price,
+            units,
+            ai_reason,
+            ai_response,
+            entry_regime,
+            exit_time,
+            exit_price,
+            profit_loss,
+            tp_pips,
+            sl_pips,
+            rrr,
         ))
 
 def log_ai_decision(decision_type, instrument, ai_response):

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -302,6 +302,13 @@ class OrderManager:
         units = int(lot_size * 1000) if side == "long" else -int(lot_size * 1000)
         entry_time = datetime.utcnow().isoformat()
 
+        rrr = None
+        try:
+            if tp_pips is not None and sl_pips not in (None, 0):
+                rrr = float(tp_pips) / float(sl_pips)
+        except Exception:
+            rrr = None
+
         # ---- LIMIT order path ----
         if mode == "limit":
             return self.place_limit_order(
@@ -390,7 +397,10 @@ class OrderManager:
             units=units,
             ai_reason=strategy_params.get("ai_reason", "manual"),
             ai_response=strategy_params.get("ai_response"),
-            entry_regime=entry_regime
+            entry_regime=entry_regime,
+            tp_pips=tp_pips,
+            sl_pips=sl_pips,
+            rrr=rrr,
         )
         return result
 

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -455,13 +455,22 @@ def process_entry(
         units = int(lot_size * 1000) if side == "long" else -int(lot_size * 1000)
         entry_price = float(market_data['prices'][0]['bids'][0]['price'])
         entry_time = datetime.utcnow().isoformat()
+        rrr = None
+        try:
+            if tp_pips is not None and sl_pips not in (None, 0):
+                rrr = float(tp_pips) / float(sl_pips)
+        except Exception:
+            rrr = None
         log_trade(
             instrument,
             entry_time=entry_time,
             entry_price=entry_price,
             units=units,
             ai_reason=ai_raw,
-            ai_response=ai_raw
+            ai_response=ai_raw,
+            tp_pips=tp_pips,
+            sl_pips=sl_pips,
+            rrr=rrr,
         )
 
     return True

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -1,7 +1,9 @@
 # Database Migration
 
 The `trades` table now stores the full AI response for each entry or exit.
-A new column `ai_response` has been added.
+A new column `ai_response` has been added.  
+Additionally the table tracks take‑profit and stop‑loss distances (`tp_pips`,
+`sl_pips`) and the calculated risk‑reward ratio (`rrr`).
 
 ## Updating an existing `trades.db`
 
@@ -15,9 +17,12 @@ init_db()
 PY
 ```
 
-This will create the `ai_response` column when missing.  Alternatively you can
-execute the SQL below manually:
+This will create any missing columns (`ai_response`, `tp_pips`, `sl_pips`,
+`rrr`).  Alternatively you can execute the SQL below manually:
 
 ```sql
 ALTER TABLE trades ADD COLUMN ai_response TEXT;
+ALTER TABLE trades ADD COLUMN tp_pips REAL;
+ALTER TABLE trades ADD COLUMN sl_pips REAL;
+ALTER TABLE trades ADD COLUMN rrr REAL;
 ```


### PR DESCRIPTION
## Summary
- extend `trades` schema with TP/SL columns and risk reward ratio
- log TP/SL info when entering a trade
- record TP/SL info for manual market orders
- document database migration steps

## Testing
- `pytest -q`