### PR TITLE
Implement scale-in action

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
    contracting*.
 `AI_PROFIT_TRIGGER_RATIO` defines what portion of the take-profit target must
 be reached before an AI exit check occurs. The default value is `0.5` (50%).
+`SCALE_LOT_SIZE` sets how many lots are added when the AI exit decision is `SCALE`.
 `MIN_RRR` sets the minimum reward-to-risk ratio allowed when selecting a
 take-profit. The TP level is now chosen to maximise expected value while
 keeping the ratio at or above this threshold.
@@ -251,3 +252,9 @@ plan = get_trade_plan({}, {}, candles_dict,
 `follow_breakout()` 関数はレンジをブレイクした直後の押し戻しが十分小さいかどうかを判定します。ADX が設定値以上であることを確認し、ブレイクアウト足と直近足の終値差を ATR と比較します。押し戻し幅が `FOLLOW_PULLBACK_ATR_RATIO` × ATR 以下であれば `True` を返します。
 
 詳しいロジックは `docs/momentum_follow.md` を参照してください。
+
+## 分割エントリー (Scaling)
+
+The job runner can add to an existing position when the AI exit evaluator
+returns `SCALE`. Set `SCALE_LOT_SIZE` in `settings.env` to control the lot
+size of each additional entry (default `0.5`).

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -27,6 +27,9 @@ ATR（ボラティリティ指標）の計算期間。
 ■ TRADE_LOT_SIZE
 1トレードで使用するロットサイズ（1 = 1000通貨）
 
+■ SCALE_LOT_SIZE
+AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
+
 ■ フィルター設定（AI呼び出し制御用）
 
 - RSI_ENTRY_LOWER / RSI_ENTRY_UPPER:

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -31,6 +31,7 @@ AI_COOLDOWN_SEC_OPEN=60
 # --- ロット制限 (1 lot = 100 00 units) ---
 MIN_TRADE_LOT=30.0
 MAX_TRADE_LOT=30.0
+SCALE_LOT_SIZE=0.5
 
 # ローソク足の粒度（OANDA のフォーマット）
 CANDLE_GRANULARITY=M5

--- a/backend/tests/test_scale_entry.py
+++ b/backend/tests/test_scale_entry.py
@@ -1,0 +1,138 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+from datetime import datetime
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+class TestScaleEntry(unittest.TestCase):
+    def setUp(self):
+        self._added = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._added.append(name)
+
+        os.environ['SCALE_LOT_SIZE'] = '0.7'
+        os.environ['AI_PROFIT_TRIGGER_RATIO'] = '0'
+        os.environ['PIP_SIZE'] = '0.01'
+        os.environ.pop('OANDA_API_KEY', None)
+        os.environ.pop('OANDA_ACCOUNT_ID', None)
+
+        pandas_stub = types.ModuleType('pandas')
+        pandas_stub.Series = FakeSeries
+        add('pandas', pandas_stub)
+        add('requests', types.ModuleType('requests'))
+        add('numpy', types.ModuleType('numpy'))
+        dotenv_stub = types.ModuleType('dotenv')
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add('dotenv', dotenv_stub)
+
+        ead = types.ModuleType('backend.strategy.exit_ai_decision')
+        ead.evaluate = lambda *a, **k: types.SimpleNamespace(action='SCALE', confidence=0.9, reason='')
+        add('backend.strategy.exit_ai_decision', ead)
+
+        oa = types.ModuleType('backend.strategy.openai_analysis')
+        oa.get_market_condition = lambda *a, **k: {}
+        oa.get_trade_plan = lambda *a, **k: {'entry': {'side': 'no'}, 'risk': {}}
+        oa.should_convert_limit_to_market = lambda ctx: False
+        oa.evaluate_exit = ead.evaluate
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add('backend.strategy.openai_analysis', oa)
+
+        om = types.ModuleType('backend.orders.order_manager')
+        class DummyMgr:
+            def __init__(self):
+                self.calls = []
+            def enter_trade(self, side, lot_size, market_data, strategy_params, force_limit_only=False):
+                self.calls.append((side, lot_size, strategy_params))
+                return {'order_id': '1'}
+            def update_trade_sl(self, *a, **k):
+                return {}
+            def cancel_order(self, *a, **k):
+                pass
+            def place_market_order(self, *a, **k):
+                pass
+        om.OrderManager = DummyMgr
+        add('backend.orders.order_manager', om)
+
+        upd = types.ModuleType('backend.logs.update_oanda_trades')
+        upd.update_oanda_trades = lambda *a, **k: (_ for _ in ()).throw(SystemExit())
+        upd.fetch_trade_details = lambda *a, **k: {}
+        add('backend.logs.update_oanda_trades', upd)
+
+        stub_names = [
+            'backend.market_data.tick_fetcher',
+            'backend.market_data.candle_fetcher',
+            'backend.indicators.calculate_indicators',
+            'backend.strategy.exit_logic',
+            'backend.orders.position_manager',
+            'backend.strategy.signal_filter',
+            'backend.strategy.higher_tf_analysis',
+            'backend.utils.notification',
+        ]
+        for name in stub_names:
+            mod = types.ModuleType(name)
+            add(name, mod)
+
+        sys.modules['backend.market_data.tick_fetcher'].fetch_tick_data = lambda *a, **k: {
+            'prices': [{'bids': [{'price': '1.0'}], 'asks': [{'price': '1.01'}], 'tradeable': True}]
+        }
+        sys.modules['backend.market_data.candle_fetcher'].fetch_multiple_timeframes = lambda *a, **k: {'M5': [], 'M1': [], 'H1': [], 'H4': [], 'D': []}
+        sys.modules['backend.indicators.calculate_indicators'].calculate_indicators = lambda *a, **k: {'atr': FakeSeries([0.1]), 'rsi': FakeSeries([50]), 'ema_slope': FakeSeries([0.1])}
+        sys.modules['backend.indicators.calculate_indicators'].calculate_indicators_multi = lambda *a, **k: {
+            'M5': {'atr': FakeSeries([0.1]), 'rsi': FakeSeries([50]), 'ema_slope': FakeSeries([0.1])},
+            'M1': {}, 'H1': {}, 'H4': {}, 'D': {}
+        }
+        sys.modules['backend.strategy.exit_logic'].process_exit = lambda *a, **k: False
+        now_str = datetime.utcnow().isoformat() + 'Z'
+        sys.modules['backend.orders.position_manager'].check_current_position = lambda *a, **k: {
+            'instrument': 'USD_JPY',
+            'long': {'units': '1', 'averagePrice': '1.0000', 'tradeIDs': ['t1']},
+            'entry_time': now_str
+        }
+        sys.modules['backend.orders.position_manager'].get_margin_used = lambda *a, **k: 0
+        sys.modules['backend.strategy.signal_filter'].pass_entry_filter = lambda *a, **k: True
+        sys.modules['backend.strategy.signal_filter'].pass_exit_filter = lambda *a, **k: True
+        sys.modules['backend.strategy.higher_tf_analysis'].analyze_higher_tf = lambda *a, **k: {}
+        sys.modules['backend.utils.notification'].send_line_message = lambda *a, **k: None
+
+        import backend.scheduler.job_runner as jr
+        importlib.reload(jr)
+        jr.instrument_is_tradeable = lambda instrument: True
+        self.jr = jr
+        self.runner = jr.JobRunner(interval_seconds=1)
+        self.runner._manage_pending_limits = lambda *a, **k: None
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+        os.environ.pop('SCALE_LOT_SIZE', None)
+        os.environ.pop('AI_PROFIT_TRIGGER_RATIO', None)
+        os.environ.pop('PIP_SIZE', None)
+
+    def test_scale_order_sent(self):
+        with self.assertRaises(SystemExit):
+            self.runner.run()
+        calls = self.runner.order_mgr.calls
+        self.assertEqual(len(calls), 1)
+        side, lot, params = calls[0]
+        self.assertEqual(side, 'long')
+        self.assertAlmostEqual(lot, 0.7)
+        self.assertEqual(params['instrument'], 'USD_JPY')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- detect SCALE action from exit AI decision
- place additional trades when scaling in
- expose `SCALE_LOT_SIZE` environment variable
- document the new scaling option
- test that scaling triggers an extra order

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after run)*