### PR TITLE
Fix README and Dockerfile regarding trades.db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend /app/backend
 
+# create an empty SQLite database if not provided
+RUN touch /app/trades.db
+
 ENV PYTHONUNBUFFERED=1
 ENV TZ=Asia/Tokyo
 

--- a/README.md
+++ b/README.md
@@ -107,18 +107,12 @@ as on native x86 hardware.
 
 ## Database
 
-Trade history is stored in `trades.db` (SQLite) at the repository root. This file is no longer tracked in Git. A pre-populated example is available in `backend/logs/` and is copied to `/app/trades.db` when running inside Docker.
+Trade history is stored in `trades.db` (SQLite) at the repository root. This file is no longer tracked in Git. No sample database is included, so the Docker image simply creates an empty file at `/app/trades.db` during build.
 
 The table now includes an `ai_response` column which stores the full text returned
 by the AI when opening or closing a trade.
 
-If you need a clean database locally, either copy the example file:
-
-```bash
-cp backend/logs/trades.db trades.db
-```
-
-or create a fresh one using the helper in `backend.logs.log_manager`:
+If you need a clean database locally, create a fresh one using the helper in `backend.logs.log_manager`:
 
 ```bash
 python - <<'EOF'


### PR DESCRIPTION
## Summary
- clarify that no sample `trades.db` is included and Docker creates an empty one
- create `/app/trades.db` when building the generic Dockerfile

## Testing
- `pytest backend/tests/test_price_format.py -q`