### PR TITLE
Support AI reason logging for parameter changes

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -85,9 +85,15 @@ def init_db():
                 timestamp TEXT NOT NULL,
                 param_name TEXT NOT NULL,
                 old_value TEXT,
-                new_value TEXT
+                new_value TEXT,
+                ai_reason TEXT
             )
         ''')
+
+        cursor.execute("PRAGMA table_info(param_changes)")
+        param_cols = [row[1] for row in cursor.fetchall()]
+        if 'ai_reason' not in param_cols:
+            cursor.execute('ALTER TABLE param_changes ADD COLUMN ai_reason TEXT')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS user_actions (
@@ -164,7 +170,7 @@ def log_error(module, error_message, additional_info=None):
             (datetime.utcnow().isoformat(), module, error_message, additional_info),
         )
 
-def log_param_change(param_name, old_value, new_value):
+def log_param_change(param_name, old_value, new_value, ai_reason):
     """
     Record a parameter change into the param_changes table.
 
@@ -172,13 +178,21 @@ def log_param_change(param_name, old_value, new_value):
         param_name (str): Name of the parameter adjusted.
         old_value (Any): Original value (stored as string, may be None).
         new_value (Any): New value (stored as string).
+        ai_reason (str): Reason provided by the AI or subsystem.
     """
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute('''
-            INSERT INTO param_changes (timestamp, param_name, old_value, new_value)
-            VALUES (?, ?, ?, ?)
-        ''', (datetime.utcnow().isoformat(), str(param_name), str(old_value), str(new_value)))
+            INSERT INTO param_changes (
+                timestamp, param_name, old_value, new_value, ai_reason
+            ) VALUES (?, ?, ?, ?, ?)
+        ''', (
+            datetime.utcnow().isoformat(),
+            str(param_name),
+            str(old_value),
+            str(new_value),
+            str(ai_reason),
+        ))
 
 
 # OANDAトレードの記録

--- a/backend/strategy/strategy_analyzer.py
+++ b/backend/strategy/strategy_analyzer.py
@@ -47,7 +47,8 @@ def ensure_param_change_table():
                 timestamp TEXT,
                 param_key TEXT,
                 old_value TEXT,
-                new_value TEXT
+                new_value TEXT,
+                ai_reason TEXT
             )
         """)
 

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -26,3 +26,11 @@ ALTER TABLE trades ADD COLUMN tp_pips REAL;
 ALTER TABLE trades ADD COLUMN sl_pips REAL;
 ALTER TABLE trades ADD COLUMN rrr REAL;
 ```
+
+The `param_changes` table now stores the reason returned by the AI in the
+`ai_reason` column. To add this column to an older database run `init_db()`
+again or execute:
+
+```sql
+ALTER TABLE param_changes ADD COLUMN ai_reason TEXT;
+```


### PR DESCRIPTION
## Summary
- store AI reason in `param_changes` table
- migrate existing DBs in `init_db()`
- update analyzer table creation
- document new column in migration guide

## Testing
- `python -m py_compile backend/logs/log_manager.py backend/strategy/strategy_analyzer.py`
- `pytest -k "log_param_change" -q`