### PR TITLE
Add reason column to param_changes table

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -86,14 +86,14 @@ def init_db():
                 param_name TEXT NOT NULL,
                 old_value TEXT,
                 new_value TEXT,
-                ai_reason TEXT
+                reason TEXT
             )
         ''')
 
         cursor.execute("PRAGMA table_info(param_changes)")
         param_cols = [row[1] for row in cursor.fetchall()]
-        if 'ai_reason' not in param_cols:
-            cursor.execute('ALTER TABLE param_changes ADD COLUMN ai_reason TEXT')
+        if 'reason' not in param_cols:
+            cursor.execute('ALTER TABLE param_changes ADD COLUMN reason TEXT')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS user_actions (
@@ -184,7 +184,7 @@ def log_param_change(param_name, old_value, new_value, ai_reason):
         cursor = conn.cursor()
         cursor.execute('''
             INSERT INTO param_changes (
-                timestamp, param_name, old_value, new_value, ai_reason
+                timestamp, param_name, old_value, new_value, reason
             ) VALUES (?, ?, ?, ?, ?)
         ''', (
             datetime.utcnow().isoformat(),

--- a/backend/strategy/strategy_analyzer.py
+++ b/backend/strategy/strategy_analyzer.py
@@ -48,9 +48,13 @@ def ensure_param_change_table():
                 param_key TEXT,
                 old_value TEXT,
                 new_value TEXT,
-                ai_reason TEXT
+                reason TEXT
             )
         """)
+        cur = conn.execute(f"PRAGMA table_info({PARAM_CHANGE_DB_TABLE})")
+        cols = [r[1] for r in cur.fetchall()]
+        if 'reason' not in cols:
+            conn.execute(f'ALTER TABLE {PARAM_CHANGE_DB_TABLE} ADD COLUMN reason TEXT')
 
 def backup_settings():
     """Create a timestamped backup of the current settings.env file."""

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -27,10 +27,10 @@ ALTER TABLE trades ADD COLUMN sl_pips REAL;
 ALTER TABLE trades ADD COLUMN rrr REAL;
 ```
 
-The `param_changes` table now stores the reason returned by the AI in the
-`ai_reason` column. To add this column to an older database run `init_db()`
+The `param_changes` table now records the reason for each change in the
+`reason` column. To add this column to an older database run `init_db()`
 again or execute:
 
 ```sql
-ALTER TABLE param_changes ADD COLUMN ai_reason TEXT;
+ALTER TABLE param_changes ADD COLUMN reason TEXT;
 ```


### PR DESCRIPTION
## Summary
- allow storing the reason for parameter adjustments
- handle DB migration for the new column
- document the new `reason` field

## Testing
- `pytest -q`