### PR TITLE
Add analysis copy step to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend /app/backend
+COPY analysis /app/analysis
 
 # create an empty SQLite database if not provided
 RUN touch /app/trades.db

--- a/backend/Dockerfile.api
+++ b/backend/Dockerfile.api
@@ -14,6 +14,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the backend source code into the image
 COPY . /app/backend
+COPY analysis /app/analysis
 
 # Create an empty SQLite DB placeholder so the path exists at runtime
 RUN touch /app/trades.db

--- a/backend/Dockerfile.job
+++ b/backend/Dockerfile.job
@@ -15,6 +15,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # backendごと/appにコピー
 COPY backend /app/backend
+COPY analysis /app/analysis
 
 ENV PYTHONUNBUFFERED=1
 ENV TZ=Asia/Tokyo


### PR DESCRIPTION
## Summary
- ensure analysis package is included during container builds
- update Dockerfile, backend/Dockerfile.job, and backend/Dockerfile.api

## Testing
- `docker build -f backend/Dockerfile.job -t jobtest .` *(fails: `docker: command not found`)*