### PR TITLE
Add WAL mode info and error table docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Trade history is stored in `trades.db` (SQLite) at the repository root by defaul
 You can override the path with the environment variable `TRADES_DB_PATH`.
 When running inside Docker this defaults to `/app/trades.db`.
 
+SQLite uses WAL (Write-Ahead Logging) mode. For existing databases run:
+```bash
+sqlite3 trades.db "PRAGMA journal_mode=WAL;"
+```
+
+
 The table now includes an `ai_response` column which stores the full text returned
 by the AI when opening or closing a trade.
 
@@ -131,8 +137,7 @@ from backend.logs.log_manager import init_db
 init_db()
 EOF
 ```
-This helper also upgrades older databases to include the new `ai_response`
-column. See `docs/db_migration.md` for details.
+This helper also upgrades older databases to include new columns and tables (e.g. `errors`) and ensures WAL mode is enabled. See `docs/db_migration.md` for details.
 
 To inspect parameter adjustments logged by the strategy analyzer, run
 `backend/logs/show_param_history.py`. Filter by parameter name or period:

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -34,3 +34,15 @@ again or execute:
 ```sql
 ALTER TABLE param_changes ADD COLUMN reason TEXT;
 ```
+
+The database now also includes an `errors` table to store module errors. If your existing `trades.db` lacks this table, run `init_db()` once or execute the SQL below:
+
+```sql
+CREATE TABLE errors (
+    error_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    module TEXT NOT NULL,
+    error_message TEXT NOT NULL,
+    additional_info TEXT
+);
+```


### PR DESCRIPTION
## Summary
- document enabling SQLite WAL mode
- explain upgrading existing DB
- add instructions for new `errors` table in migrations

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after tests finished)*