### PR TITLE
LINE通知設定の追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,27 @@ The API exposes endpoints for status checks, a simple dashboard and runtime sett
 uvicorn backend.api.main:app --host 0.0.0.0 --port 8080
 ```
 
+## LINE 通知設定
+
+API から LINE にメッセージを送信するには、まず `.env` に以下の環境変数を設定します。
+
+```bash
+LINE_CHANNEL_TOKEN=<your_line_token>
+LINE_USER_ID=<your_line_user_id>
+```
+
+次のコマンドで API を起動してください。
+
+```bash
+uvicorn backend.api.main:app --host 0.0.0.0 --port 8080
+```
+
+テスト用エンドポイント `/notifications/send` を利用すると送信確認ができます。
+
+```bash
+curl -X POST http://localhost:8080/notifications/send
+```
+
 ## Running the Job Scheduler
 
 The job runner performs market data collection, indicator calculation and trading decisions. Run it directly with Python:

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -120,6 +120,9 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 - STRICT_ENTRY_FILTER: M1 RSI クロス必須判定のオン/オフ
 - HIGHER_TF_ENABLED: 上位足ピボットをTP計算に利用するか
 
+- LINE_CHANNEL_TOKEN: LINE 通知に使用するチャンネルアクセストークン
+- LINE_USER_ID: 通知を送るユーザーのLINE ID
+
 # 分割エントリー関連設定
 
 - SCALE_LOT_SIZE: 追加エントリー時のロット数


### PR DESCRIPTION
## 変更内容
- README に LINE 通知設定の手順を追加
- backend/config/ENV_README.txt に `LINE_CHANNEL_TOKEN` と `LINE_USER_ID` の説明を追加

## テスト結果
- `pytest -q` 実行済み: 44 件成功
