### PR TITLE
Enable WAL mode and retry on DB lock

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -11,10 +11,11 @@ _BASE_DIR = Path(__file__).resolve().parents[2]
 DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", str(_BASE_DIR / "trades.db")))
 
 def get_db_connection():
-    return sqlite3.connect(DB_PATH)
+    return sqlite3.connect(DB_PATH, timeout=30)
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
         cursor = conn.cursor()
 
         cursor.execute('''


### PR DESCRIPTION
## Summary
- enable SQLite WAL mode in `init_db`
- increase DB connect timeout
- retry database operations on `database is locked` errors in `update_oanda_trades.py`

## Testing
- `pytest -q` *(fails: 44 passed, 1058 warnings in 347.93s)*