### PR TITLE
Add DB logging for OANDA trade update errors

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -167,7 +167,7 @@ def log_error(module, error_message, additional_info=None):
     later inspection.
     """
     try:
-        with sqlite3.connect(DB_PATH) as conn:
+        with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
                 '''
@@ -180,7 +180,7 @@ def log_error(module, error_message, additional_info=None):
         if "no such table" in str(exc):
             try:
                 init_db()
-                with sqlite3.connect(DB_PATH) as conn:
+                with get_db_connection() as conn:
                     cursor = conn.cursor()
                     cursor.execute(
                         '''

--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -1,7 +1,12 @@
 import logging
 import requests
 from backend.utils import env_loader
-from backend.logs.log_manager import get_db_connection, init_db, log_oanda_trade
+from backend.logs.log_manager import (
+    get_db_connection,
+    init_db,
+    log_oanda_trade,
+    log_error,
+)
 
 # env_loader automatically loads default env files at import time
 
@@ -138,6 +143,7 @@ def update_oanda_trades():
         logger.info(f"Successfully updated {updated_count} new trades.")
     except Exception as e:
         logger.error(f"Error updating trades: {e}")
+        log_error("update_oanda_trades", str(e))
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
- record errors in `update_oanda_trades` via `log_error`
- use `get_db_connection` inside `log_error`

## Testing
- `pytest -q`