### PR TITLE
Expand limit conversion context

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -244,11 +244,37 @@ class JobRunner:
             threshold_ratio = float(env_loader.get_env("LIMIT_THRESHOLD_ATR_RATIO", "0.3"))
             adx_series = indicators.get("adx")
             adx_val = adx_series.iloc[-1] if adx_series is not None and len(adx_series) else 0.0
+
+            # --- gather additional indicators for AI decision -----------------
+            rsi_series = indicators.get("rsi")
+            rsi_val = rsi_series.iloc[-1] if rsi_series is not None and len(rsi_series) else None
+
+            ema_slope_series = indicators.get("ema_slope")
+            ema_slope_val = (
+                ema_slope_series.iloc[-1]
+                if ema_slope_series is not None and len(ema_slope_series)
+                else None
+            )
+
+            bb_upper = indicators.get("bb_upper")
+            bb_lower = indicators.get("bb_lower")
+            bb_width_pips = None
+            if (
+                bb_upper is not None
+                and bb_lower is not None
+                and len(bb_upper)
+                and len(bb_lower)
+            ):
+                bb_width_pips = (bb_upper.iloc[-1] - bb_lower.iloc[-1]) / pip_size
+
             if atr_pips and diff_pips >= atr_pips * threshold_ratio and adx_val >= 25:
                 ctx = {
                     "diff_pips": diff_pips,
                     "atr_pips": atr_pips,
                     "adx": adx_val,
+                    "rsi": rsi_val,
+                    "ema_slope": ema_slope_val,
+                    "bb_width_pips": bb_width_pips,
                     "side": local_info.get("side"),
                 }
                 try:

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -997,9 +997,16 @@ Respond with **one-line valid JSON** exactly as:
 
 
 def should_convert_limit_to_market(context: dict) -> bool:
-    """Use OpenAI to decide whether to convert a pending LIMIT to a market order."""
+    """
+    OpenAI に問い合わせてリミット注文を成行に変更すべきか判断する。
+
+    context には ATR や ADX のほか、RSI、EMA 傾き、ボリンジャーバンド幅
+    などを含めることができる。
+    """
     prompt = (
         "We placed a limit order that has not filled and price is moving away.\n"
+        "Use ATR, ADX, RSI, EMA slope and Bollinger band width from the context "
+        "below to decide if switching to a market order is reasonable.\n\n"
         f"Context: {json.dumps(context, ensure_ascii=False)}\n\n"
         "Should we cancel the limit order and place a market order instead?\n"
         "Respond with YES or NO."


### PR DESCRIPTION
## Summary
- include RSI, EMA slope, and Bollinger width in the pending limit context
- mention the new indicators in `should_convert_limit_to_market`

## Testing
- `pytest -q`