### PR TITLE
Fix DB lock warnings

### DIFF
--- a/backend/logs/initial_fetch_oanda_trades.py
+++ b/backend/logs/initial_fetch_oanda_trades.py
@@ -61,6 +61,7 @@ def initial_fetch_oanda_trades():
                     "OPEN",
                     0.0,
                     float(transaction.get('pl', 0.0)),
+                    conn=conn,
                 )
                 updated_count += 1
 

--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -120,6 +120,7 @@ def update_oanda_trades():
                     "OPEN",
                     0.0,
                     realized_pl,
+                    conn=conn,
                 )
                 logger.debug("Debug AFTER INSERT rowcount: 1")
                 updated_count += 1


### PR DESCRIPTION
## Summary
- allow DB helper functions to share a connection
- extend timeout usage in log functions
- inject DB connection into trade loggers

## Testing
- `pytest -q`