### PR TITLE
Add account_id tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ init_db()
 EOF
 ```
 This helper also upgrades older databases to include new columns and tables (e.g. `errors`) and ensures WAL mode is enabled. See `docs/db_migration.md` for details.
+If you upgrade from a version before the `account_id` column was added to `oanda_trades`, running `init_db()` once will create it automatically.
 
 To inspect parameter adjustments logged by the strategy analyzer, run
 `backend/logs/show_param_history.py`. Filter by parameter name or period:

--- a/backend/logs/daily_summary.py
+++ b/backend/logs/daily_summary.py
@@ -7,6 +7,7 @@ from backend.utils import env_loader
 
 _BASE_DIR = Path(__file__).resolve().parents[2]
 DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", str(_BASE_DIR / "trades.db")))
+ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
 
 
 def fetch_diffs(days: int = 1) -> list[float]:
@@ -17,9 +18,9 @@ def fetch_diffs(days: int = 1) -> list[float]:
             """
             SELECT instrument, close_price, tp_price, units, close_time
             FROM oanda_trades
-            WHERE close_time IS NOT NULL AND tp_price IS NOT NULL AND close_time >= ?
+            WHERE account_id = ? AND close_time IS NOT NULL AND tp_price IS NOT NULL AND close_time >= ?
             """,
-            (since.isoformat(),),
+            (ACCOUNT_ID, since.isoformat()),
         )
         rows = cursor.fetchall()
     diffs: list[float] = []

--- a/backend/logs/initial_fetch_oanda_trades.py
+++ b/backend/logs/initial_fetch_oanda_trades.py
@@ -54,6 +54,7 @@ def initial_fetch_oanda_trades():
                 price = float(transaction.get('price', 0.0))
                 log_oanda_trade(
                     trade_id,
+                    OANDA_ACCOUNT_ID,
                     instrument,
                     open_time,
                     price,

--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -21,6 +21,7 @@ def init_db():
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS oanda_trades (
                 trade_id INTEGER PRIMARY KEY,
+                account_id TEXT,
                 instrument TEXT NOT NULL,
                 open_time TEXT NOT NULL,
                 close_time TEXT,
@@ -34,6 +35,11 @@ def init_db():
                 sl_price REAL
             )
         ''')
+
+        cursor.execute("PRAGMA table_info(oanda_trades)")
+        oanda_cols = [row[1] for row in cursor.fetchall()]
+        if 'account_id' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN account_id TEXT')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS trades (
@@ -225,6 +231,7 @@ def log_param_change(param_name, old_value, new_value, ai_reason):
 # OANDAトレードの記録
 def log_oanda_trade(
     trade_id,
+    account_id,
     instrument,
     open_time,
     open_price,
@@ -246,11 +253,12 @@ def log_oanda_trade(
     cursor.execute(
         '''
             INSERT OR REPLACE INTO oanda_trades (
-                trade_id, instrument, open_time, open_price, units, state, unrealized_pl, realized_pl, close_time, close_price, tp_price, sl_price
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                trade_id, account_id, instrument, open_time, open_price, units, state, unrealized_pl, realized_pl, close_time, close_price, tp_price, sl_price
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''',
         (
             trade_id,
+            account_id,
             instrument,
             open_time,
             open_price,

--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -51,7 +51,10 @@ def get_last_transaction_id():
     init_db()
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute("SELECT MAX(CAST(trade_id AS INTEGER)) FROM oanda_trades")
+    cursor.execute(
+        "SELECT MAX(CAST(trade_id AS INTEGER)) FROM oanda_trades WHERE account_id = ?",
+        (OANDA_ACCOUNT_ID,),
+    )
     last_id = cursor.fetchone()[0]
     conn.close()
     return last_id if last_id else '0'
@@ -113,6 +116,7 @@ def update_oanda_trades():
                 execute_with_retry(
                     log_oanda_trade,
                     trade_id,
+                    OANDA_ACCOUNT_ID,
                     instrument,
                     open_time,
                     price,

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -46,3 +46,9 @@ CREATE TABLE errors (
     additional_info TEXT
 );
 ```
+
+If you run an older database without the `account_id` column in `oanda_trades`, execute `init_db()` to add it automatically or run:
+
+```sql
+ALTER TABLE oanda_trades ADD COLUMN account_id TEXT;
+```


### PR DESCRIPTION
## Summary
- store OANDA account_id in oanda_trades
- migrate older DBs to include account_id
- log account_id when updating trades
- filter API and analytics queries by account_id
- document DB upgrade steps

## Testing
- `pytest -q`