### PR TITLE
Fix DI cross detection with scalar inputs

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -215,15 +215,24 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
     plus_di = indicators.get("plus_di")
     minus_di = indicators.get("minus_di")
     di_cross = False
-    if plus_di is not None and minus_di is not None and len(plus_di) >= 2:
-        try:
-            p_prev = float(plus_di.iloc[-2]) if hasattr(plus_di, "iloc") else float(plus_di[-2])
-            p_cur = float(plus_di.iloc[-1]) if hasattr(plus_di, "iloc") else float(plus_di[-1])
-            m_prev = float(minus_di.iloc[-2]) if hasattr(minus_di, "iloc") else float(minus_di[-2])
-            m_cur = float(minus_di.iloc[-1]) if hasattr(minus_di, "iloc") else float(minus_di[-1])
+    try:
+        def _tail2(series):
+            if series is None:
+                return []
+            if hasattr(series, "iloc"):
+                return [float(v) for v in series.iloc[-2:]]
+            if isinstance(series, (list, tuple)):
+                return [float(v) for v in series[-2:]]
+            return [float(series)]
+
+        p_vals = _tail2(plus_di)
+        m_vals = _tail2(minus_di)
+        if len(p_vals) >= 2 and len(m_vals) >= 2:
+            p_prev, p_cur = p_vals[-2], p_vals[-1]
+            m_prev, m_cur = m_vals[-2], m_vals[-1]
             di_cross = (p_prev > m_prev and p_cur < m_cur) or (p_prev < m_prev and p_cur > m_cur)
-        except Exception:
-            di_cross = False
+    except Exception:
+        di_cross = False
 
     def _extract_latest(series, n: int = 3):
         if series is None:

--- a/backend/tests/test_market_di_cross_float.py
+++ b/backend/tests/test_market_di_cross_float.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class TestMarketDiCrossFloat(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ["LOCAL_WEIGHT_THRESHOLD"] = "0.6"
+        self._mods = []
+        def add(name, mod):
+            if name not in sys.modules:
+                sys.modules[name] = mod
+                self._mods.append(name)
+        add("pandas", types.ModuleType("pandas"))
+        openai_stub = types.ModuleType("openai")
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add("openai", openai_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+        add("requests", types.ModuleType("requests"))
+        add("numpy", types.ModuleType("numpy"))
+        import backend.strategy.openai_analysis as oa
+        importlib.reload(oa)
+        self.oa = oa
+
+    def tearDown(self):
+        for name in self._mods:
+            sys.modules.pop(name, None)
+
+    def test_float_values_handled(self):
+        self.oa.ask_openai = lambda *a, **k: {"market_condition": "range"}
+        ctx = {"indicators": {"plus_di": 20.0, "minus_di": 30.0}}
+        res = self.oa.get_market_condition(ctx)
+        self.assertIn("market_condition", res)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle scalar DI values in `get_market_condition`
- add regression test for float `plus_di` and `minus_di`

## Testing
- `pytest -q`