### PR TITLE
Update DB migration docs for open_price

### DIFF
--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -4,6 +4,7 @@ The `trades` table now stores the full AI response for each entry or exit.
 A new column `ai_response` has been added.  
 Additionally the table tracks take‑profit and stop‑loss distances (`tp_pips`,
 `sl_pips`) and the calculated risk‑reward ratio (`rrr`).
+The `oanda_trades` table now stores the opening price in `open_price`.
 
 ## Updating an existing `trades.db`
 
@@ -51,4 +52,10 @@ If you run an older database without the `account_id` column in `oanda_trades`, 
 
 ```sql
 ALTER TABLE oanda_trades ADD COLUMN account_id TEXT;
+```
+
+The `open_price` column has been added to `oanda_trades`. Running `init_db()` will add this column automatically or execute:
+
+```sql
+ALTER TABLE oanda_trades ADD COLUMN open_price REAL;
 ```


### PR DESCRIPTION
## Summary
- document `open_price` column in `oanda_trades`
- add SQL example to migrate older DBs
- note that `init_db()` adds the column automatically

## Testing
- `pytest -q` *(fails: ImportError: module backend.strategy.signal_filter not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_683a8b5aa590833383643e15a139635e