### PR TITLE
Implement minimum hold filter and exit reason logging

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -59,7 +59,8 @@ def init_db():
                 rrr REAL,
                 ai_reason TEXT,
                 ai_response TEXT,
-                entry_regime TEXT
+                entry_regime TEXT,
+                exit_reason TEXT
             )
         ''')
 
@@ -74,6 +75,8 @@ def init_db():
             cursor.execute('ALTER TABLE trades ADD COLUMN sl_pips REAL')
         if 'rrr' not in columns:
             cursor.execute('ALTER TABLE trades ADD COLUMN rrr REAL')
+        if 'exit_reason' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN exit_reason TEXT')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS ai_decisions (
@@ -135,6 +138,7 @@ def log_trade(
     tp_pips=None,
     sl_pips=None,
     rrr=None,
+    exit_reason=None,
 ):
     with get_db_connection() as conn:
         cursor = conn.cursor()
@@ -143,8 +147,8 @@ def log_trade(
                 instrument, entry_time, entry_price, units,
                 ai_reason, ai_response, entry_regime,
                 exit_time, exit_price, profit_loss,
-                tp_pips, sl_pips, rrr
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tp_pips, sl_pips, rrr, exit_reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''', (
             instrument,
             entry_time,
@@ -159,6 +163,7 @@ def log_trade(
             tp_pips,
             sl_pips,
             rrr,
+            exit_reason,
         ))
 
 def log_ai_decision(decision_type, instrument, ai_response):

--- a/backend/logs/trade_logger.py
+++ b/backend/logs/trade_logger.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from .log_manager import log_trade as _log_trade
+
+
+class ExitReason(Enum):
+    AI = "AI"
+    RISK = "RISK"
+    DUPLICATION = "DUPLICATION"
+    MANUAL = "MANUAL"
+    OTHER = "OTHER"
+
+
+def log_trade(*, exit_reason: ExitReason | None = None, **kwargs: Any) -> None:
+    """Wrapper for log_trade allowing ``ExitReason`` enumeration."""
+    if exit_reason is not None:
+        kwargs["exit_reason"] = exit_reason.value
+    _log_trade(**kwargs)

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -1,6 +1,7 @@
 import os
 import requests
 from backend.logs.log_manager import log_trade, log_error
+from backend.logs.trade_logger import ExitReason
 from backend.utils.price import format_price
 from datetime import datetime, timedelta
 import time
@@ -503,7 +504,8 @@ class OrderManager:
             entry_price=entry_price,
             units=units,
             ai_reason="exit",
-            exit_time=datetime.utcnow().isoformat()
+            exit_time=datetime.utcnow().isoformat(),
+            exit_reason=ExitReason.MANUAL,
         )
         return result
 

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -4,6 +4,7 @@ openai_analysis = importlib.import_module("backend.strategy.openai_analysis")
 EXIT_BIAS_FACTOR = getattr(openai_analysis, "EXIT_BIAS_FACTOR", 1.0)
 from backend.orders.order_manager import OrderManager
 from backend.logs.log_manager import log_trade
+from backend.logs.trade_logger import ExitReason
 from backend.logs.exit_logger import append_exit_log
 from datetime import datetime
 import logging
@@ -218,6 +219,7 @@ def process_exit(
             units=units,
             profit_loss=float(position.get("pl_corrected", position.get("pl", 0))),
             ai_reason="regime shift exit",
+            exit_reason=ExitReason.AI,
         )
         return True
     elif regime_action == "HOLD":
@@ -362,6 +364,7 @@ def process_exit(
                     profit_loss=float(position.get("pl_corrected", position.get("pl", 0))),
                     ai_reason=f"AI‑confirmed early‑exit: {exit_decision['reason']}",
                     ai_response=exit_decision.get("raw"),
+                    exit_reason=ExitReason.AI,
                 )
                 return True
             else:
@@ -419,6 +422,7 @@ def process_exit(
             profit_loss=float(position.get("pl_corrected", position.get("pl", 0))),
             ai_reason=exit_decision["reason"],
             ai_response=exit_decision.get("raw"),
+            exit_reason=ExitReason.AI,
         )
         return True
     else:
@@ -461,6 +465,7 @@ def process_exit(
                             ai_reason="partial close",
                             exit_time=datetime.utcnow().isoformat(),
                             exit_price=current_price,
+                            exit_reason=ExitReason.RISK,
                         )
                         units -= close_units
 

--- a/backend/tests/test_exit_reason_logging.py
+++ b/backend/tests/test_exit_reason_logging.py
@@ -1,0 +1,61 @@
+import unittest
+import sys
+import types
+import importlib
+
+class DummyConn:
+    def __init__(self):
+        self.params = None
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+    def cursor(self):
+        return self
+    def execute(self, sql, params=None):
+        self.params = params
+    def commit(self):
+        pass
+    def close(self):
+        pass
+
+class TestExitReasonLogging(unittest.TestCase):
+    def setUp(self):
+        self._mods = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._mods.append(name)
+        add('pandas', types.ModuleType('pandas'))
+        add('requests', types.ModuleType('requests'))
+        add('numpy', types.ModuleType('numpy'))
+        dotenv = types.ModuleType('dotenv')
+        dotenv.load_dotenv = lambda *a, **k: None
+        add('dotenv', dotenv)
+        conn = DummyConn()
+        log_mod = importlib.import_module('backend.logs.log_manager')
+        log_mod.get_db_connection = lambda: conn
+        self.conn = conn
+        import backend.logs.trade_logger as tl
+        importlib.reload(tl)
+        self.tl = tl
+
+    def tearDown(self):
+        for n in self._mods:
+            sys.modules.pop(n, None)
+
+    def test_exit_reason_value_logged(self):
+        self.tl.log_trade(
+            instrument='EUR_USD',
+            entry_time='2024-01-01T00:00:00',
+            entry_price=1.0,
+            units=1,
+            ai_reason='test',
+            exit_time='2024-01-01T01:00:00',
+            exit_price=1.1,
+            exit_reason=self.tl.ExitReason.AI,
+        )
+        self.assertIsNotNone(self.conn.params)
+        self.assertEqual(self.conn.params[-1], 'AI')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_min_hold_exit.py
+++ b/backend/tests/test_min_hold_exit.py
@@ -15,6 +15,7 @@ class TestMinHoldExit(unittest.TestCase):
         os.environ['MIN_HOLD_SEC'] = '60'
         os.environ['AI_PROFIT_TRIGGER_RATIO'] = '0'
         os.environ['PIP_SIZE'] = '0.0001'
+        os.environ['OPENAI_API_KEY'] = 'dummy'
         os.environ.pop('OANDA_API_KEY', None)
         os.environ.pop('OANDA_ACCOUNT_ID', None)
 
@@ -24,6 +25,13 @@ class TestMinHoldExit(unittest.TestCase):
         dotenv = types.ModuleType('dotenv')
         dotenv.load_dotenv = lambda *a, **k: None
         add('dotenv', dotenv)
+        openai_stub = types.ModuleType('openai')
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add('openai', openai_stub)
 
         oa = types.ModuleType('backend.strategy.openai_analysis')
         oa.get_market_condition = lambda *a, **k: {}


### PR DESCRIPTION
## Summary
- add `ExitReason` enum and wrapper in `trade_logger`
- store `exit_reason` in trades table
- log exit reasons when exiting positions
- fix unit tests to avoid missing OpenAI client
- test logging of exit reasons

## Testing
- `pytest backend/tests/test_exit_reason_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ce5834e8c833380d0b312758eb9d0