### PR TITLE
Fix env loader fallback

### DIFF
--- a/backend/utils/env_loader.py
+++ b/backend/utils/env_loader.py
@@ -6,7 +6,11 @@ import os
 from pathlib import Path
 from typing import Iterable, Optional
 
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # ランタイムに dotenv がなくても動作させる
+    def load_dotenv(*_args, **_kwargs) -> None:
+        pass
 
 _BASE_DIR = Path(__file__).resolve().parents[1]
 _DEFAULT_FILES = [


### PR DESCRIPTION
## Summary
- add runtime fallback in `env_loader` when `python-dotenv` is unavailable

## Testing
- `python3 -m py_compile backend/utils/env_loader.py`
- `PYTHONPATH=. python3 backend/logs/show_tables.py | head -n 20`
- manual execution of `update_oanda_trades` with stubbed `requests`

------
https://chatgpt.com/codex/tasks/task_e_683d0f1b3d048333a99aaa5c2dac01e2