### PR TITLE
Update README for local pattern flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The system derives a dynamic pullback requirement from ATR, ADX and recent price
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
 `NOISE_SL_MULT` は AI が算出した SL をこの倍率で拡大します (default `1.5`).
 `PATTERN_NAMES` lists chart pattern names passed to the AI or local scanner for detection, e.g. `double_bottom,double_top,doji`.
-`LOCAL_WEIGHT_THRESHOLD` は 0〜1 の値で、ローカル判定と AI 判定の整合度スコアがこの値以上ならローカルを、未満なら AI を優先します。旧 `USE_LOCAL_PATTERN` は廃止されました。
+`LOCAL_WEIGHT_THRESHOLD` は 0〜1 の値で、ローカル判定と AI 判定の整合度スコアがこの値以上ならローカルを、未満なら AI を優先します。`USE_LOCAL_PATTERN` を `true` にすると常にローカル検出のみを使用し、`settings.env` のデフォルト値も `true` です。
 `PATTERN_MIN_BARS` でパターン完成に必要なローソク足の本数を、`PATTERN_TOLERANCE` で高値・安値の許容誤差を調整できます。
 `PATTERN_EXCLUDE_TFS` に `M1` などを指定すると、その時間足ではパターン検出を行いません。
 `PATTERN_TFS` を `M1,M5` のように設定すると、指定した時間足のみをスキャンします。
@@ -288,8 +288,8 @@ print(result)
 
 返り値は `{"pattern": "<一致したパターン名>"}` もしくは `{"pattern": None}` の形式です。
 
-`LOCAL_WEIGHT_THRESHOLD` を調整することで、AI 判定とローカル判定のどちらを優先するかを決められます。ローカルの結果だけを使いたい場合は `1.0` に設定してください。
-ローカル判定を行うには `pattern_scanner.scan()` を利用します。
+`LOCAL_WEIGHT_THRESHOLD` を調整することで、AI 判定とローカル判定のどちらを優先するかを決められます。ローカルの結果だけを使いたい場合は `1.0` に設定してください。`USE_LOCAL_PATTERN` を使えば AI を経由せずローカル検出のみを行うこともできます。
+ローカル判定を直接呼び出すには `pattern_scanner.scan()` を利用します。
 
 対応パターン例:
 - `double_bottom`


### PR DESCRIPTION
## Summary
- clarify that `USE_LOCAL_PATTERN` is still available
- describe interaction with `LOCAL_WEIGHT_THRESHOLD`
- note the default value in `settings.env`

## Testing
- `pytest -q` *(fails: ImportError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_683d10da36908333a761294a82e32d77