### PR TITLE
Fix DB migration for close columns

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -43,6 +43,20 @@ def init_db():
         # 旧バージョンのDBに open_price が無い場合に追加
         if 'open_price' not in oanda_cols:
             cursor.execute('ALTER TABLE oanda_trades ADD COLUMN open_price REAL')
+        if 'close_time' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN close_time TEXT')
+        if 'close_price' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN close_price REAL')
+        if 'realized_pl' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN realized_pl REAL')
+        if 'unrealized_pl' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN unrealized_pl REAL')
+        if 'state' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN state TEXT')
+        if 'tp_price' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN tp_price REAL')
+        if 'sl_price' not in oanda_cols:
+            cursor.execute('ALTER TABLE oanda_trades ADD COLUMN sl_price REAL')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS trades (


### PR DESCRIPTION
## Summary
- ensure `close_time`, `close_price`, `realized_pl`, `unrealized_pl`, `state`, `tp_price`, and `sl_price` columns are added to `oanda_trades`

## Testing
- `pytest backend/tests/test_entry_filter_rsi.py::TestEntryFilterRSICross::test_bandwidth_block_logs -q`
- `pytest backend/tests/test_entry_break_override.py::TestEntryBreakOverride::test_break_overrides_side -q` *(fails: AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_683d12490cac833380e98b570c115c1c