### PR TITLE
Implement RSI reversal block

### DIFF
--- a/backend/tests/test_atr_tp_sl_mult.py
+++ b/backend/tests/test_atr_tp_sl_mult.py
@@ -47,6 +47,8 @@ class TestAtrTpSlMult(unittest.TestCase):
             def enter_trade(self, side, lot_size, market_data, strategy_params, force_limit_only=False):
                 self.last_params = strategy_params
                 return {"order_id": "1"}
+            def get_open_orders(self, instrument, side):
+                return []
         om.OrderManager = DummyMgr
         add("backend.orders.order_manager", om)
 


### PR DESCRIPTION
## Summary
- prevent counter-trend entries based on RSI extremes
- adjust test stub for order checks

## Testing
- `pytest backend/tests/test_atr_tp_sl_mult.py backend/tests/test_entry_filter_rsi.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683d1390a3548333bdc6e7c30aa8ec96