### PR TITLE
Fix open_price migration

### DIFF
--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -60,3 +60,7 @@ ALTER TABLE oanda_trades ADD COLUMN account_id TEXT;
 ```sql
 ALTER TABLE oanda_trades ADD COLUMN open_price REAL;
 ```
+
+古いデータベースで `price` 列が残っている場合、`init_db()` を実行すると
+`open_price` 列にその値がコピーされます。`price` 列は削除されませんが、
+更新処理で値がセットされるためエラーは発生しなくなります。


### PR DESCRIPTION
## Summary
- handle legacy `price` column when initializing the trades DB
- update `log_oanda_trade()` to populate `price` column if present
- clarify DB migration docs

## Testing
- `pytest -q` *(fails: module backend.strategy.signal_filter not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_683d16da59948333b70b8519eff040ee