### PR TITLE
Enhance indicator set for AI decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The system derives a dynamic pullback requirement from ATR, ADX and recent price
 `TP_BB_RATIO` scales the Bollinger band width when deriving a fallback take-profit target. For example, `0.6` uses 60% of the band width.
 `RANGE_ENTRY_OFFSET_PIPS` determines how far from the Bollinger band center price must be (in pips) before keeping a market entry. When closer, the entry switches to a LIMIT at the band high or low. The default is `3`.
 `想定ノイズ` is automatically computed from ATR and Bollinger Band width and included in the AI prompt to help choose wider stop-loss levels.
+The indicators module also calculates `adx_bb_score`, a composite value derived from ADX changes and Bollinger Band width. This score is passed to the AI so it can gauge momentum strength from multiple angles.
 `NOISE_SL_MULT` は AI が算出した SL をこの倍率で拡大します (default `1.5`).
 `PATTERN_NAMES` lists chart pattern names passed to the AI or local scanner for detection, e.g. `double_bottom,double_top,doji`.
 `LOCAL_WEIGHT_THRESHOLD` は 0〜1 の値で、ローカル判定と AI 判定の整合度スコアがこの値以上ならローカルを、未満なら AI を優先します。`USE_LOCAL_PATTERN` を `true` にすると常にローカル検出のみを使用し、`settings.env` のデフォルト値も `true` です。

--- a/backend/indicators/adx.py
+++ b/backend/indicators/adx.py
@@ -123,3 +123,40 @@ def calculate_adx_slope(adx_values: Sequence[float], lookback: int = 5) -> float
 
     slope = num / den
     return float(slope)
+
+
+def calculate_adx_bb_score(
+    adx: Sequence[float],
+    bb_upper: Sequence[float],
+    bb_lower: Sequence[float],
+    lookback: int = 3,
+    width_period: int = 20,
+) -> float:
+    """Return composite score from ADX change and Bollinger Band width."""
+    try:
+        adx_vals = [float(v) for v in adx]
+        up_vals = [float(v) for v in bb_upper]
+        low_vals = [float(v) for v in bb_lower]
+    except Exception:
+        return 0.0
+
+    if len(adx_vals) <= lookback or len(up_vals) < width_period or len(low_vals) < width_period:
+        return 0.0
+
+    adx_delta = adx_vals[-1] - adx_vals[-lookback]
+    cur_width = up_vals[-1] - low_vals[-1]
+    widths = [u - l for u, l in zip(up_vals[-width_period:], low_vals[-width_period:])]
+    avg_width = sum(widths) / len(widths) if widths else 0.0
+    if avg_width == 0:
+        return 0.0
+    width_ratio = cur_width / avg_width
+
+    return float(adx_delta * width_ratio)
+
+
+__all__ = [
+    "calculate_adx",
+    "calculate_di",
+    "calculate_adx_slope",
+    "calculate_adx_bb_score",
+]

--- a/backend/indicators/calculate_indicators.py
+++ b/backend/indicators/calculate_indicators.py
@@ -16,6 +16,10 @@ from backend.indicators.atr import calculate_atr
 from backend.indicators.bollinger import calculate_bollinger_bands
 from backend.indicators.adx import calculate_adx
 try:
+    from backend.indicators.adx import calculate_adx_bb_score
+except Exception:  # pragma: no cover - fallback when stub lacks function
+    calculate_adx_bb_score = lambda *_a, **_k: 0.0
+try:
     from backend.indicators.adx import calculate_di
 except Exception:  # pragma: no cover - fallback for older stubs
     calculate_di = None
@@ -107,6 +111,16 @@ def calculate_indicators(
         'minus_di': minus_di,
         'polarity': calculate_polarity(close_prices),
     }
+
+    try:
+        score = calculate_adx_bb_score(
+            adx_series,
+            bb_df['upper_band'],
+            bb_df['lower_band'],
+        )
+    except Exception:
+        score = 0.0
+    indicators['adx_bb_score'] = score
 
     if high_prices and low_prices and close_prices:
         piv = calculate_pivots(high_prices[-1], low_prices[-1], close_prices[-1])

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -906,6 +906,17 @@ def get_trade_plan(
         noise_pips = None
 
     noise_val = f"{noise_pips:.1f}" if noise_pips is not None else "N/A"
+    tv_score = "N/A"
+    try:
+        adx_series = ind_m5.get("adx")
+        bb_upper = ind_m5.get("bb_upper")
+        bb_lower = ind_m5.get("bb_lower")
+        if adx_series is not None and bb_upper is not None and bb_lower is not None:
+            from backend.indicators.adx import calculate_adx_bb_score
+            val = calculate_adx_bb_score(adx_series, bb_upper, bb_lower)
+            tv_score = f"{val:.2f}"
+    except Exception:
+        tv_score = "N/A"
     # --- calculate dynamic pullback threshold ----------------------------
     recent_high = None
     recent_low = None
@@ -1025,6 +1036,9 @@ EMA_s: {_series_tail_list(ind_d1.get('ema_slow'), 20)}
 {noise_val} pips is the approximate short-term market noise.
 Use this as a baseline for setting wider stop-loss levels.
 After calculating TP hit probability, widen the SL by at least {env_loader.get_env("NOISE_SL_MULT", "1.5")} times.
+
+### Composite Trend Score
+{tv_score}
 
 ### Pivot Levels
 Pivot: {ind_m5.get('pivot')}, R1: {ind_m5.get('pivot_r1')}, S1: {ind_m5.get('pivot_s1')}

--- a/backend/tests/test_adx_bb_score.py
+++ b/backend/tests/test_adx_bb_score.py
@@ -1,0 +1,41 @@
+import sys
+import types
+import unittest
+
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return self._data[idx]
+        if isinstance(idx, int) and idx < 0:
+            raise KeyError(idx)
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+pandas_stub = types.ModuleType("pandas")
+pandas_stub.Series = FakeSeries
+sys.modules["pandas"] = pandas_stub
+
+from backend.indicators.adx import calculate_adx_bb_score
+
+
+class TestAdxBbScore(unittest.TestCase):
+    def test_basic_score(self):
+        adx = [20, 22, 25, 28]
+        bb_u = [1.1, 1.2, 1.3, 1.4]
+        bb_l = [1.0, 1.1, 1.2, 1.2]
+        res = calculate_adx_bb_score(adx, bb_u, bb_l, lookback=3, width_period=4)
+        self.assertAlmostEqual(res, 9.6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute new `adx_bb_score` from ADX change and Bollinger Band width
- expose the composite score in `calculate_indicators`
- surface the score to the LLM prompt in `openai_analysis`
- document the indicator in README
- add tests for `calculate_adx_bb_score`

## Testing
- `pytest backend/tests/test_adx_bb_score.py::TestAdxBbScore::test_basic_score -q`
- `pytest -q` *(fails: ImportError / AttributeError in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_683d17eb7d748333bce6dac95953ba1f