### PR TITLE
Fix openai optional import

### DIFF
--- a/backend/utils/openai_client.py
+++ b/backend/utils/openai_client.py
@@ -1,4 +1,9 @@
-from openai import OpenAI, APIError
+try:
+    from openai import OpenAI, APIError
+except ModuleNotFoundError as exc:
+    raise RuntimeError(
+        "openai package is required. Install via 'pip install openai'."
+    ) from exc
 from backend.utils import env_loader
 import json
 import logging


### PR DESCRIPTION
## Summary
- handle missing `openai` dependency gracefully in `openai_client`

## Testing
- `pytest -q` *(fails: AttributeError, ImportError, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683d4b080d0883338c36797f057870f0