### PR TITLE
Add trailing stop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,3 +366,11 @@ plan = get_trade_plan({}, {}, candles_dict,
 The job runner can add to an existing position when the AI exit evaluator
 returns `SCALE`. Set `SCALE_LOT_SIZE` in `settings.env` to control the lot
 size of each additional entry (default `0.5`).
+
+## Trailing Stop Updates
+
+The trailing stop distance is recalculated on every loop when a position is in
+profit. The job runner calls `order_manager.place_trailing_stop()` to update the
+stop on the first trade ID, which replaces the previous order. OANDA cancels the
+old trailing stop automatically once the new one is applied. See
+`backend/strategy/exit_logic.py` lines 510-525 for the exact logic.


### PR DESCRIPTION
## Summary
- document how trailing stops are updated

## Testing
- `pytest -q` *(fails: ImportError: module backend.strategy.signal_filter not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_683ef113d51083338777986e3a7f1dff