### PR TITLE
Implement peak reversal entry option

### DIFF
--- a/backend/tests/test_peak_entry.py
+++ b/backend/tests/test_peak_entry.py
@@ -1,0 +1,118 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+
+        self.iloc = _ILoc(self)
+
+    def __getitem__(self, idx):
+        return self._data[idx]
+
+    def __len__(self):
+        return len(self._data)
+
+
+class TestPeakEntry(unittest.TestCase):
+    def setUp(self):
+        self._mods = []
+
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._mods.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        add("requests", types.ModuleType("requests"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.get_trade_plan = lambda *a, **k: {
+            "entry": {"side": "long", "mode": "market"},
+            "risk": {"tp_pips": 10, "sl_pips": 5},
+        }
+        oa.should_convert_limit_to_market = lambda ctx: True
+        oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(action="HOLD", confidence=0.0, reason="")
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add("backend.strategy.openai_analysis", oa)
+
+        om = types.ModuleType("backend.orders.order_manager")
+
+        class DummyMgr:
+            def __init__(self):
+                self.last_params = None
+
+            def enter_trade(self, side, lot_size, market_data, strategy_params, force_limit_only=False):
+                self.last_params = strategy_params
+                return {"order_id": "1"}
+
+            def get_open_orders(self, instrument, side):
+                return []
+
+        om.OrderManager = DummyMgr
+        add("backend.orders.order_manager", om)
+
+        log_mod = types.ModuleType("backend.logs.log_manager")
+        log_mod.log_trade = lambda *a, **k: None
+        add("backend.logs.log_manager", log_mod)
+
+        import backend.strategy.signal_filter as sf
+        self._orig_detect = sf.detect_peak_reversal
+        sf.detect_peak_reversal = lambda candles, side: True
+        self._sf = sf
+
+        os.environ["PIP_SIZE"] = "0.01"
+        os.environ["PEAK_ENTRY_ENABLED"] = "true"
+
+        import backend.strategy.entry_logic as el
+        importlib.reload(el)
+        self.el = el
+
+    def tearDown(self):
+        for name in self._mods:
+            sys.modules.pop(name, None)
+        os.environ.pop("PIP_SIZE", None)
+        os.environ.pop("PEAK_ENTRY_ENABLED", None)
+        if hasattr(self, "_sf"):
+            self._sf.detect_peak_reversal = self._orig_detect
+
+    def test_peak_reversal_flips_side(self):
+        indicators = {"atr": FakeSeries([0.1])}
+        candle = {"mid": {"o": "1", "h": "2", "l": "0", "c": "1"}}
+        candles = [candle, candle, candle]
+        market_data = {
+            "prices": [
+                {"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}
+            ]
+        }
+        res = self.el.process_entry(
+            indicators,
+            candles,
+            market_data,
+            candles_dict={"M5": candles},
+            tf_align=None,
+        )
+        self.assertTrue(res)
+        params = self.el.order_manager.last_params
+        self.assertIsNotNone(params)
+        self.assertEqual(params["side"], "short")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- support peak reversal entry via `detect_peak_reversal`
- use env var `PEAK_ENTRY_ENABLED` to toggle feature
- add unit test for peak reversal entry logic

## Testing
- `pytest backend/tests/test_peak_entry.py -q`
- `pytest -k peak_entry -q`

------
https://chatgpt.com/codex/tasks/task_e_683f828b952483338fc6889b5ac641f9