### PR TITLE
Add consecutive higher highs filter and tests

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -40,6 +40,7 @@ from backend.strategy.signal_filter import (
         detect_climax_reversal,
         counter_trend_block,
         consecutive_lower_lows,
+        consecutive_higher_highs,
     )
 except Exception:  # pragma: no cover - test stubs may lack filter_pre_ai
     from backend.strategy.signal_filter import pass_entry_filter
@@ -1315,6 +1316,14 @@ class JobRunner:
 
                             if side == "long" and consecutive_lower_lows(candles_m5):
                                 logger.info("Entry blocked: consecutive lower lows detected")
+                                self.last_run = now
+                                update_oanda_trades()
+                                time.sleep(self.interval_seconds)
+                                timer.stop()
+                                continue
+
+                            if side == "short" and consecutive_higher_highs(candles_m5):
+                                logger.info("Entry blocked: consecutive higher highs detected")
                                 self.last_run = now
                                 update_oanda_trades()
                                 time.sleep(self.interval_seconds)

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -149,6 +149,17 @@ def consecutive_lower_lows(candles: list[dict], count: int = 3) -> bool:
         return False
     return all(lows[i] < lows[i - 1] for i in range(1, len(lows)))
 
+
+def consecutive_higher_highs(candles: list[dict], count: int = 3) -> bool:
+    """Return True if there are ``count`` consecutive higher highs."""
+    if len(candles) < count + 1:
+        return False
+    try:
+        highs = [float(c.get("mid", c).get("h")) for c in candles[-(count + 1):]]
+    except Exception:
+        return False
+    return all(highs[i] > highs[i - 1] for i in range(1, len(highs)))
+
 # ────────────────────────────────────────────────
 #  Trend追随前フィルター
 # ────────────────────────────────────────────────

--- a/backend/tests/test_consecutive_high_low.py
+++ b/backend/tests/test_consecutive_high_low.py
@@ -1,0 +1,58 @@
+import sys
+import types
+import importlib
+import unittest
+
+
+class TestConsecutiveHighLow(unittest.TestCase):
+    def setUp(self):
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = lambda *a, **k: None
+        sys.modules["pandas"] = pandas_stub
+        sys.modules.setdefault("requests", types.ModuleType("requests"))
+        import backend.strategy.signal_filter as sf
+        importlib.reload(sf)
+        self.sf = sf
+
+    def tearDown(self):
+        sys.modules.pop("pandas", None)
+
+    def test_lower_lows_true(self):
+        candles = [
+            {"mid": {"l": 3}},
+            {"mid": {"l": 2}},
+            {"mid": {"l": 1}},
+            {"mid": {"l": 0}},
+        ]
+        self.assertTrue(self.sf.consecutive_lower_lows(candles, count=3))
+
+    def test_lower_lows_false(self):
+        candles = [
+            {"mid": {"l": 3}},
+            {"mid": {"l": 2}},
+            {"mid": {"l": 2.5}},
+            {"mid": {"l": 1}},
+        ]
+        self.assertFalse(self.sf.consecutive_lower_lows(candles, count=3))
+
+    def test_higher_highs_true(self):
+        candles = [
+            {"mid": {"h": 0}},
+            {"mid": {"h": 1}},
+            {"mid": {"h": 2}},
+            {"mid": {"h": 3}},
+        ]
+        self.assertTrue(self.sf.consecutive_higher_highs(candles, count=3))
+
+    def test_higher_highs_false(self):
+        candles = [
+            {"mid": {"h": 0}},
+            {"mid": {"h": 1}},
+            {"mid": {"h": 0.5}},
+            {"mid": {"h": 2}},
+        ]
+        self.assertFalse(self.sf.consecutive_higher_highs(candles, count=3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `consecutive_higher_highs` helper
- block entries on short side when highs climb
- cover `consecutive_lower_lows` and new `consecutive_higher_highs` with unit tests

## Testing
- `pytest backend/tests/test_consecutive_high_low.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffb20aaec833381bad5335538d41d