### PR TITLE
Add short block in counter trend

### DIFF
--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -67,6 +67,13 @@ def counter_trend_block(side: str, ind_m5: dict, ind_m15: dict | None = None, in
                 and cur_val >= adx_thresh
             ):
                 return True
+            # 強い上昇トレンド時のショート抑制
+            if (
+                side == "short"
+                and dir_m5 == "long"
+                and cur_val >= adx_thresh
+            ):
+                return True
     except Exception:
         pass
     return False

--- a/backend/tests/test_counter_trend_block.py
+++ b/backend/tests/test_counter_trend_block.py
@@ -40,5 +40,21 @@ class TestCounterTrendBlock(unittest.TestCase):
         m5 = {"adx": FakeSeries([24, 26]), "ema_fast": FakeSeries([1, 1.1]), "ema_slow": FakeSeries([1, 1.05])}
         self.assertTrue(self.sf.counter_trend_block("short", m5))
 
+    def test_downtrend_blocks_long(self):
+        m5 = {
+            "adx": FakeSeries([26, 26]),
+            "ema_fast": FakeSeries([1.1, 1.0]),
+            "ema_slow": FakeSeries([1.05, 1.05]),
+        }
+        self.assertTrue(self.sf.counter_trend_block("long", m5))
+
+    def test_uptrend_blocks_short(self):
+        m5 = {
+            "adx": FakeSeries([26, 26]),
+            "ema_fast": FakeSeries([1.0, 1.1]),
+            "ema_slow": FakeSeries([1.0, 1.05]),
+        }
+        self.assertTrue(self.sf.counter_trend_block("short", m5))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enforce short blocking in strong uptrends
- add tests for long and short blocking in counter_trend_block

## Testing
- `pytest backend/tests/test_counter_trend_block.py -q`
- `pytest -q` *(fails: module import errors in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_683ffb22cfd08333947023fb632b48bd