### PR TITLE
Add OANDA_MATCH_SEC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The indicators module also calculates `adx_bb_score`, a composite value derived 
 
 `ALLOW_DELAYED_ENTRY` set to `true` lets the AI return `"mode":"wait"` when a trend is overextended. The job runner will keep polling and enter once the pullback depth is satisfied.
 
+`OANDA_MATCH_SEC` はローカルトレードと OANDA 取引を照合するときの許容秒数です。デフォルトは `60` です。
+
 ## パラメータ変更履歴の確認
 
 `init_db()` でデータベースを作成または更新した後、`log_param_change()` と `log_trade()` を

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -159,3 +159,6 @@ SCALE_TRIGGER_ATR=0.5
 - CLIMAX_TP_PIPS / CLIMAX_SL_PIPS: クライマックス時に使用する TP/SL
 - ALLOW_DELAYED_ENTRY: トレンドが過熱している場合に "wait" を返させ、押し目到来で再問い合わせする
 
+■ OANDA_MATCH_SEC
+  ローカルトレードと OANDA 取引を照合するときの許容秒数。デフォルトは60秒。
+


### PR DESCRIPTION
## Summary
- document `OANDA_MATCH_SEC` environment variable
- explain trade reconciliation tolerance in README

## Testing
- `pytest -q` *(fails: ImportError: module backend.orders.order_manager not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe6da28c83338ef541c05f5769ed