### PR TITLE
Fix indentation in job_runner

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -34,7 +34,7 @@ except ImportError:  # tests may stub position_manager without helpers
         return None
 from backend.orders.order_manager import OrderManager
 try:
-from backend.strategy.signal_filter import (
+    from backend.strategy.signal_filter import (
         pass_entry_filter,
         filter_pre_ai,
         detect_climax_reversal,


### PR DESCRIPTION
## Summary
- fix indentation for the signal filter import block

## Testing
- `pytest backend/tests/test_job_runner_handles_none_indicators.py backend/tests/test_job_runner_tp_flags.py -q` *(fails: openai package missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe5553e483338a4ace52a28c45fe