### PR TITLE
Fix indentation in job runner imports

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -34,7 +34,7 @@ except ImportError:  # tests may stub position_manager without helpers
         return None
 from backend.orders.order_manager import OrderManager
 try:
-from backend.strategy.signal_filter import (
+    from backend.strategy.signal_filter import (
         pass_entry_filter,
         filter_pre_ai,
         detect_climax_reversal,


### PR DESCRIPTION
## Summary
- adjust indentation for the `try` block importing `signal_filter`

## Testing
- `pytest -q` *(fails: cannot import modules, but IndentationError resolved)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe6b72a88333be1ef193d67e26d5