### PR TITLE
Add risk manager and integrate validation

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -3,6 +3,7 @@ import requests
 from backend.logs.log_manager import log_trade, log_error
 from backend.logs.trade_logger import ExitReason
 from backend.utils.price import format_price
+from backend.risk_manager import validate_rrr, validate_sl
 from datetime import datetime, timedelta
 import time
 import json
@@ -42,11 +43,6 @@ PIP_SIZES: dict[str, float] = {
 def get_pip_size(instrument: str) -> float:
     """Return pip size for the instrument; fallback to DEFAULT_PAIR mapping."""
     return PIP_SIZES.get(instrument, PIP_SIZES.get(DEFAULT_PAIR, 0.01))
-
-
-def validate_rrr(tp_pips: float, sl_pips: float, min_rrr: float) -> bool:
-    """Return True if tp_pips / sl_pips meets or exceeds min_rrr."""
-    return sl_pips > 0 and (tp_pips / sl_pips) >= min_rrr
 
 
 class OrderManager:

--- a/backend/risk_manager.py
+++ b/backend/risk_manager.py
@@ -1,0 +1,23 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def validate_sl(tp_pips: float, sl_pips: float, atr: float, min_atr_mult: float) -> bool:
+    """ATRとの比較に基づきSLが適切か検証する。"""
+    try:
+        if sl_pips < atr * min_atr_mult:
+            logger.warning("SL too tight (%.1fpips < %.1f)", sl_pips, atr * min_atr_mult)
+            return False
+    except Exception:
+        return False
+    return True
+
+
+def validate_rrr(tp_pips: float, sl_pips: float, min_rrr: float) -> bool:
+    """Return True if tp_pips / sl_pips meets or exceeds min_rrr."""
+    try:
+        return sl_pips > 0 and (tp_pips / sl_pips) >= min_rrr
+    except Exception:
+        return False
+

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -1,6 +1,7 @@
 from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
 from backend.orders.order_manager import OrderManager
 from backend.logs.log_manager import log_trade
+from backend.risk_manager import validate_rrr, validate_sl
 from datetime import datetime
 from backend.utils import env_loader
 import logging
@@ -358,6 +359,7 @@ def process_entry(
 
     min_sl = float(env_loader.get_env("MIN_SL_PIPS", "0"))
     fallback_sl = None
+    atr_pips = None
     try:
         atr_series = indicators.get("atr")
         if atr_series is not None and len(atr_series):
@@ -366,10 +368,11 @@ def process_entry(
             else:
                 atr_val = float(atr_series[-1])
             pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+            atr_pips = atr_val / pip_size
             mult_sl = float(env_loader.get_env("ATR_MULT_SL", env_loader.get_env("ATR_SL_MULTIPLIER", "2.0")))
-            fallback_sl = atr_val / pip_size * mult_sl
+            fallback_sl = atr_pips * mult_sl
             mult_tp = float(env_loader.get_env("ATR_MULT_TP", env_loader.get_env("SHORT_TP_ATR_RATIO", "0.6")))
-            fallback_tp = atr_val / pip_size * mult_tp
+            fallback_tp = atr_pips * mult_tp
         price_ref = bid if side == "long" else ask
         # SL用ピボットレベル
         pivot_sl_key = "pivot_s1" if side == "long" else "pivot_r1"
@@ -467,8 +470,14 @@ def process_entry(
     try:
         if env_loader.get_env("ENFORCE_RRR", "false").lower() == "true":
             min_rrr = float(env_loader.get_env("MIN_RRR", "0.8"))
-            if sl_pips > 0 and tp_pips / sl_pips < min_rrr:
+            if not validate_rrr(tp_pips, sl_pips, min_rrr):
                 tp_pips = sl_pips * min_rrr
+    except Exception:
+        pass
+    try:
+        min_atr_mult = float(env_loader.get_env("MIN_ATR_MULT", "1.0"))
+        if atr_pips is not None:
+            validate_sl(tp_pips, sl_pips, atr_pips, min_atr_mult)
     except Exception:
         pass
     logging.info(f"AI Entry {side} – tp={tp_pips}  sl={sl_pips} (pips)")

--- a/backend/tests/test_risk_manager.py
+++ b/backend/tests/test_risk_manager.py
@@ -1,0 +1,22 @@
+import unittest
+import logging
+from backend.risk_manager import validate_rrr, validate_sl
+
+
+class TestRiskManager(unittest.TestCase):
+    def test_validate_rrr(self):
+        self.assertTrue(validate_rrr(20, 10, 1.5))
+        self.assertFalse(validate_rrr(10, 20, 2))
+
+    def test_validate_sl_logs(self):
+        logger = logging.getLogger('backend.risk_manager')
+        with self.assertLogs(logger, level='WARNING') as cm:
+            result = validate_sl(30, 5, 10, 1.0)
+        self.assertFalse(result)
+        self.assertTrue(any('SL too tight' in m for m in cm.output))
+        self.assertTrue(validate_sl(30, 15, 10, 1.0))
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- introduce `risk_manager` with `validate_sl` and `validate_rrr`
- use risk manager helpers in order manager and entry logic
- test new validation functions

## Testing
- `pytest backend/tests/test_risk_manager.py -q`
- `pytest -q` *(fails: 42 failed, 67 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68400099e6648333aca63445892a564b