### PR TITLE
Improve early exit logic

### DIFF
--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -158,6 +158,7 @@ SCALE_TRIGGER_ATR=0.5
 - CLIMAX_ZSCORE: ATR Z スコアの閾値
 - CLIMAX_TP_PIPS / CLIMAX_SL_PIPS: クライマックス時に使用する TP/SL
 - ALLOW_DELAYED_ENTRY: トレンドが過熱している場合に "wait" を返させ、押し目到来で再問い合わせする
+- MIN_EARLY_EXIT_PROFIT_PIPS: 早期撤退を検討する際に必要な最低利益幅
 
 ■ OANDA_MATCH_SEC
   ローカルトレードと OANDA 取引を照合するときの許容秒数。デフォルトは60秒。

--- a/backend/config/default_settings.json
+++ b/backend/config/default_settings.json
@@ -41,6 +41,7 @@
     "BE_VOL_SL_MULT": 2.0,
     "EARLY_EXIT_ENABLED": true,
     "BREAKEVEN_BUFFER_PIPS": 2,
+    "MIN_EARLY_EXIT_PROFIT_PIPS": 5,
     "ATR_SL_MULTIPLIER": 2.0,
     "_ATR_SL_NOTE": "If AI omits sl_pips, use ATR(M5) * ATR_SL_MULTIPLIER",
     "ATR_MULT_TP": 0.8,

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -77,6 +77,8 @@ EARLY_EXIT_ENABLED=true
 
 # 建値付近とみなす許容バッファ (pips)
 BREAKEVEN_BUFFER_PIPS=2
+# 早期撤退を行う際の最低利益幅(pips)
+MIN_EARLY_EXIT_PROFIT_PIPS=5
 
 # If the AI plan has no sl_pips, use latest M5 ATR × ATR_SL_MULTIPLIER
 ATR_SL_MULTIPLIER=3.0

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -38,6 +38,11 @@ REVERSAL_EXIT_ADX_MIN = float(os.getenv("REVERSAL_EXIT_ADX_MIN", "25"))
 # polarity-based exit threshold
 POLARITY_EXIT_THRESHOLD = float(os.getenv("POLARITY_EXIT_THRESHOLD", "0.4"))
 
+# 早期撤退を行う際の最低利益幅（pips）
+MIN_EARLY_EXIT_PROFIT_PIPS = float(
+    os.getenv("MIN_EARLY_EXIT_PROFIT_PIPS", "5")
+)
+
 # Dynamic ATR‑based trailing‑stop (always enabled)
 TRAIL_TRIGGER_MULTIPLIER = float(os.getenv("TRAIL_TRIGGER_MULTIPLIER", "1.2"))
 TRAIL_DISTANCE_MULTIPLIER = float(os.getenv("TRAIL_DISTANCE_MULTIPLIER", "1.0"))
@@ -254,19 +259,21 @@ def process_exit(
         be_buffer = BREAKEVEN_BUFFER_PIPS * pip_size
 
         early_exit = False
-        if ema_fast is not None and atr_val is not None:
+        if (
+            ema_fast is not None
+            and atr_val is not None
+            and profit_pips >= MIN_EARLY_EXIT_PROFIT_PIPS
+        ):
             if position_side == "long":
                 if (
-                    (current_price < ema_fast)
-                    and (profit_pips > 0)
-                    and (current_price <= entry_price + be_buffer)
+                    current_price < ema_fast
+                    and current_price <= entry_price + be_buffer
                 ):
                     early_exit = True
             else:  # short
                 if (
-                    (current_price > ema_fast)
-                    and (profit_pips > 0)
-                    and (current_price >= entry_price - be_buffer)
+                    current_price > ema_fast
+                    and current_price >= entry_price - be_buffer
                 ):
                     early_exit = True
 

--- a/backend/tests/test_early_exit_threshold.py
+++ b/backend/tests/test_early_exit_threshold.py
@@ -1,0 +1,103 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+class TestEarlyExitThreshold(unittest.TestCase):
+    def setUp(self):
+        self._mods = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._mods.append(name)
+
+        os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")
+        os.environ.setdefault("OANDA_API_KEY", "dummy")
+        self._old_pair = os.environ.get("DEFAULT_PAIR")
+        os.environ["EARLY_EXIT_ENABLED"] = "true"
+        os.environ["MIN_EARLY_EXIT_PROFIT_PIPS"] = "5"
+        os.environ["DEFAULT_PAIR"] = "EUR_USD"
+
+        add("requests", types.ModuleType("requests"))
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+        add("numpy", types.ModuleType("numpy"))
+
+        log_stub = types.ModuleType("backend.logs.log_manager")
+        log_stub.log_trade = lambda *a, **k: None
+        log_stub.log_error = lambda *a, **k: None
+        add("backend.logs.log_manager", log_stub)
+
+        pm = types.ModuleType("backend.orders.position_manager")
+        self.position = {}
+        pm.get_position_details = lambda *a, **k: self.position
+        add("backend.orders.position_manager", pm)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(action="HOLD", reason="test", as_dict=lambda: {"action": "HOLD"})
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add("backend.strategy.openai_analysis", oa)
+
+        import backend.orders.order_manager as om
+        importlib.reload(om)
+        class DummyOM(om.OrderManager):
+            def __init__(self):
+                self.calls = []
+            def exit_trade(self, pos):
+                self.calls.append(pos)
+        self.DummyOM = DummyOM
+
+        import backend.strategy.exit_logic as el
+        importlib.reload(el)
+        el.order_manager = DummyOM()
+        self.el = el
+
+    def tearDown(self):
+        for n in self._mods:
+            sys.modules.pop(n, None)
+        sys.modules.pop("backend.strategy.exit_logic", None)
+        os.environ.pop("MIN_EARLY_EXIT_PROFIT_PIPS", None)
+        if self._old_pair is None:
+            os.environ.pop("DEFAULT_PAIR", None)
+        else:
+            os.environ["DEFAULT_PAIR"] = self._old_pair
+
+    def test_no_exit_when_profit_below_threshold(self):
+        self.position.update({
+            "instrument": "EUR_USD",
+            "long": {"units": "1", "averagePrice": "1.2350", "tradeIDs": ["t1"]},
+            "pl": "0",
+            "entry_time": "2024-01-01T00:00:00Z"
+        })
+        indicators = {
+            "ema_fast": FakeSeries([1.2360]),
+            "atr": FakeSeries([0.0010]),
+            "bb_lower": FakeSeries([1.2300]),
+            "bb_upper": FakeSeries([1.2400]),
+            "adx": FakeSeries([30]),
+            "polarity": FakeSeries([0.0]),
+        }
+        market = {"prices": [{"bids": [{"price": "1.2352"}], "asks": [{"price": "1.2353"}]}]}
+        self.el.process_exit(indicators, market)
+        self.assertEqual(len(self.el.order_manager.calls), 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MIN_EARLY_EXIT_PROFIT_PIPS` configuration
- apply threshold in early-exit logic
- document new variable in settings files
- test early exit profit threshold

## Testing
- `pytest backend/tests/test_early_exit_threshold.py -q`
- `pytest -q` *(fails: ImportError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68403788deac8333bfbd1412ff208c5a