### PR TITLE
Implement basic regime & trend filters

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -73,6 +73,9 @@ def init_db():
                 tp_pips REAL,
                 sl_pips REAL,
                 rrr REAL,
+                ai_dir TEXT,
+                local_dir TEXT,
+                final_side TEXT,
                 ai_reason TEXT,
                 ai_response TEXT,
                 entry_regime TEXT,
@@ -91,6 +94,12 @@ def init_db():
             cursor.execute('ALTER TABLE trades ADD COLUMN sl_pips REAL')
         if 'rrr' not in columns:
             cursor.execute('ALTER TABLE trades ADD COLUMN rrr REAL')
+        if 'ai_dir' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN ai_dir TEXT')
+        if 'local_dir' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN local_dir TEXT')
+        if 'final_side' not in columns:
+            cursor.execute('ALTER TABLE trades ADD COLUMN final_side TEXT')
         if 'exit_reason' not in columns:
             cursor.execute('ALTER TABLE trades ADD COLUMN exit_reason TEXT')
 
@@ -165,6 +174,9 @@ def log_trade(
     tp_pips=None,
     sl_pips=None,
     rrr=None,
+    ai_dir=None,
+    local_dir=None,
+    final_side=None,
     exit_reason=None,
 ):
     with get_db_connection() as conn:
@@ -174,8 +186,10 @@ def log_trade(
                 instrument, entry_time, entry_price, units,
                 ai_reason, ai_response, entry_regime,
                 exit_time, exit_price, profit_loss,
-                tp_pips, sl_pips, rrr, exit_reason
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tp_pips, sl_pips, rrr,
+                ai_dir, local_dir, final_side,
+                exit_reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''', (
             instrument,
             entry_time,
@@ -190,6 +204,9 @@ def log_trade(
             tp_pips,
             sl_pips,
             rrr,
+            ai_dir,
+            local_dir,
+            final_side,
             exit_reason,
         ))
 

--- a/backend/logs/trade_logger.py
+++ b/backend/logs/trade_logger.py
@@ -15,7 +15,7 @@ class ExitReason(Enum):
 
 
 def log_trade(*, exit_reason: ExitReason | None = None, **kwargs: Any) -> None:
-    """Wrapper for log_trade allowing ``ExitReason`` enumeration."""
+"""Wrapper for log_trade allowing ``ExitReason`` enumeration."""
     if exit_reason is not None:
         kwargs["exit_reason"] = exit_reason.value
     _log_trade(**kwargs)

--- a/config/params_loader.py
+++ b/config/params_loader.py
@@ -76,6 +76,7 @@ def load_params(
     path: str | Path = Path(__file__).resolve().parent / "params.yaml",
     strategy_path: str | Path | None = Path(__file__).resolve().parent
     / "strategy.yml",
+    settings_path: str | Path | None = Path(__file__).resolve().parent / "settings.yaml",
 ):
     """Load YAML parameters and export them as environment variables."""
 
@@ -89,6 +90,11 @@ def load_params(
         sp = Path(strategy_path)
         if sp.exists():
             env_params.update(_flatten(_parse_yaml_file(sp)))
+
+    if settings_path is not None:
+        se = Path(settings_path)
+        if se.exists():
+            env_params.update(_flatten(_parse_yaml_file(se)))
 
     for k, v in env_params.items():
         os.environ[k] = str(v)

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,0 +1,3 @@
+risk:
+  atr_sl_multiplier: 1.2
+  fixed_rrr: 1.5

--- a/risk/trade_guard.py
+++ b/risk/trade_guard.py
@@ -1,0 +1,21 @@
+"""Simple losing streak guard."""
+from __future__ import annotations
+
+
+class TradeGuard:
+    """Track consecutive losses to pause trading."""
+
+    def __init__(self, max_losses: int = 3) -> None:
+        self.max_losses = max_losses
+        self.loss_streak = 0
+
+    def record_result(self, profit_loss: float) -> None:
+        if profit_loss < 0:
+            self.loss_streak += 1
+        else:
+            self.loss_streak = 0
+
+    def can_trade(self) -> bool:
+        return self.loss_streak < self.max_losses
+
+__all__ = ["TradeGuard"]

--- a/signals/regime_filter.py
+++ b/signals/regime_filter.py
@@ -1,0 +1,13 @@
+"""Regime conflict blocker."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+def pass_regime_filter(local_dir: Optional[str], ai_dir: Optional[str]) -> bool:
+    """Return False when local_dir and ai_dir are both present and differ."""
+    if local_dir and ai_dir and local_dir != ai_dir:
+        return False
+    return True
+
+__all__ = ["pass_regime_filter"]

--- a/signals/trend_filter.py
+++ b/signals/trend_filter.py
@@ -1,0 +1,21 @@
+"""Multi timeframe EMA trend filter."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+def trend_direction_allowed(side: str, price: float, ema_h1: Optional[float], ema_h4: Optional[float]) -> bool:
+    """Return True if order side is allowed based on higher timeframe EMAs."""
+    if side == "long":
+        if ema_h1 is not None and price < ema_h1:
+            return False
+        if ema_h4 is not None and price < ema_h4:
+            return False
+    elif side == "short":
+        if ema_h1 is not None and price > ema_h1:
+            return False
+        if ema_h4 is not None and price > ema_h4:
+            return False
+    return True
+
+__all__ = ["trend_direction_allowed"]


### PR DESCRIPTION
## Summary
- add regime conflict check
- add multi-timeframe trend filter
- extend params loader to read new `settings.yaml`
- log AI/local direction and final side of trades
- provide simple losing-streak guard

## Testing
- `pytest backend/tests/test_risk_manager.py::TestRiskManager::test_calc_min_sl -q`

------
https://chatgpt.com/codex/tasks/task_e_6840463fd4188333a5d15a659e734975