### PR TITLE
Improve AI/local alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The indicators module also calculates `adx_bb_score`, a composite value derived 
 `STRICT_TF_ALIGN` enforces multi-timeframe EMA alignment before entering.
 
 `TF_EMA_WEIGHTS` specifies the weight of each timeframe when evaluating EMA alignment, e.g. `M5:0.4,H1:0.3,H4:0.3`.
+`AI_ALIGN_WEIGHT` adds the AI's suggested direction to the multi-timeframe alignment check.
 
 `ALLOW_DELAYED_ENTRY` set to `true` lets the AI return `"mode":"wait"` when a trend is overextended. The job runner will keep polling and enter once the pullback depth is satisfied.
 

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -131,6 +131,7 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 - OVERSHOOT_ATR_MULT: BB下限をATR×この倍率だけ割り込むとエントリーをブロック
 - STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
 - TF_EMA_WEIGHTS: 上位足EMA整合の重み付け (例 `M5:0.4,H1:0.3,H4:0.3`)
+- AI_ALIGN_WEIGHT: AIの方向性をEMA整合に加味する重み
 
 - LINE_CHANNEL_TOKEN: LINE 通知に使用するチャンネルアクセストークン
 - LINE_USER_ID: 通知を送るユーザーのLINE ID

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -224,6 +224,7 @@ CLIMAX_SL_PIPS=10
 
 # Multi-timeframe EMA weights
 TF_EMA_WEIGHTS=M5:0.4,H1:0.3,H4:0.3
+AI_ALIGN_WEIGHT=0.2
 
 # マルチTF整合が取れない場合にエントリーを見送るかどうか
 STRICT_TF_ALIGN=false

--- a/backend/logs/trade_logger.py
+++ b/backend/logs/trade_logger.py
@@ -15,7 +15,7 @@ class ExitReason(Enum):
 
 
 def log_trade(*, exit_reason: ExitReason | None = None, **kwargs: Any) -> None:
-"""Wrapper for log_trade allowing ``ExitReason`` enumeration."""
+    """Wrapper for log_trade allowing ``ExitReason`` enumeration."""
     if exit_reason is not None:
         kwargs["exit_reason"] = exit_reason.value
     _log_trade(**kwargs)

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1357,10 +1357,15 @@ class JobRunner:
                                 market_cond,
                                 higher_tf=higher_tf,
                                 patterns=PATTERN_NAMES,
-                                candles_dict={"M1": candles_m1, "M5": candles_m5},
-                                pattern_names=self.patterns_by_tf,
-                                tf_align=align,
-                            )
+                            candles_dict={"M1": candles_m1, "M5": candles_m5},
+                            pattern_names=self.patterns_by_tf,
+                            tf_align=align,
+                            indicators_multi={
+                                "M1": self.indicators_M1 or {},
+                                "M5": self.indicators_M5 or {},
+                                "H1": self.indicators_H1 or {},
+                            },
+                        )
                             if not result:
                                 pend = get_pending_entry_order(DEFAULT_PAIR)
                                 if pend and pend.get("order_id"):


### PR DESCRIPTION
## Summary
- blend AI side into multi-timeframe EMA alignment
- let entry logic realign the AI side using the new helper
- expose `AI_ALIGN_WEIGHT` variable
- document new variable
- fix trade_logger indentation

## Testing
- `pytest backend/tests/test_pattern_detection.py::TestPatternDetection::test_detect_double_top_bottom -q`
- `pytest -q` *(fails: module backend.strategy.openai_analysis not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_684053fb1de883338bd04e05ba23c6d3