### PR TITLE
Add volume spike and reversal block parameters

### DIFF
--- a/backend/config/default_settings.json
+++ b/backend/config/default_settings.json
@@ -59,6 +59,7 @@
     "VOL_MA_PERIOD": 10,
     "MIN_VOL_MA": 80,
     "MIN_VOL_M1": 60,
+    "VOL_SPIKE_PERIOD": 5,
     "QUIET_START_HOUR_JST": 3,
     "QUIET_END_HOUR_JST": 7.5,
     "QUIET2_START_HOUR_JST": 23,
@@ -105,5 +106,7 @@
     "CLIMAX_ENABLED": true,
     "CLIMAX_ZSCORE": 1.5,
     "CLIMAX_TP_PIPS": 7,
-    "CLIMAX_SL_PIPS": 10
+    "CLIMAX_SL_PIPS": 10,
+    "REV_BLOCK_BARS": 3,
+    "TAIL_RATIO_BLOCK": 2.0
   }


### PR DESCRIPTION
## Summary
- keep settings.env synced with default settings
- add REV_BLOCK_BARS, TAIL_RATIO_BLOCK and VOL_SPIKE_PERIOD defaults

## Testing
- `pytest -q` *(fails: 40 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68405bb63ed48333bccf4c0f018665cd