### PR TITLE
Fix duplicate config key

### DIFF
--- a/backend/config/default_settings.json
+++ b/backend/config/default_settings.json
@@ -61,6 +61,7 @@
     "MIN_VOL_MA": 80,
     "MIN_VOL_M1": 60,
     "VOL_SPIKE_PERIOD": 5,
+    "_VOL_SPIKE_NOTE": "Duplicate entry removed",
     "QUIET_START_HOUR_JST": 3,
     "QUIET_END_HOUR_JST": 7.5,
     "QUIET2_START_HOUR_JST": 23,
@@ -109,6 +110,5 @@
     "CLIMAX_TP_PIPS": 7,
     "CLIMAX_SL_PIPS": 10,
     "REV_BLOCK_BARS": 3,
-    "TAIL_RATIO_BLOCK": 2.0,
-    "VOL_SPIKE_PERIOD": 5
+    "TAIL_RATIO_BLOCK": 2.0
   }


### PR DESCRIPTION
## Summary
- remove duplicate `VOL_SPIKE_PERIOD` key in `default_settings.json`
- add `_VOL_SPIKE_NOTE` to document duplicate removal

## Testing
- `python -m json.tool backend/config/default_settings.json > /tmp/validate.json`

------
https://chatgpt.com/codex/tasks/task_e_68405fec4ec08333a2bda7d8ca57b907