### PR TITLE
Add regime condition caching

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -193,6 +193,14 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
 
     logger = logging.getLogger(__name__)
     global _last_di_cross_ts
+    global _last_regime_ai_call_time, _cached_regime_result
+    now = time.time()
+    if (
+        now - _last_regime_ai_call_time < AI_REGIME_COOLDOWN_SEC
+        and _cached_regime_result is not None
+    ):
+        logger.info("Market condition cached (cooldown)")
+        return _cached_regime_result
     indicators = context.get("indicators", {})
     ema_trend = None
     try:
@@ -565,13 +573,17 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
             final_regime = "break"
             range_break = atr_break
 
-    return {
+    result = {
         "market_condition": final_regime,
         "range_break": range_break,
         "break_direction": range_break,
         "break_class": break_class,
         "trend_direction": trend_dir,
     }
+
+    _cached_regime_result = result
+    _last_regime_ai_call_time = time.time()
+    return result
 
 
 

--- a/backend/tests/test_market_condition_cooldown.py
+++ b/backend/tests/test_market_condition_cooldown.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class TestMarketConditionCooldown(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ["AI_REGIME_COOLDOWN_SEC"] = "60"
+        self._added_modules = []
+
+        def add_module(name: str, module: types.ModuleType):
+            if name not in sys.modules:
+                sys.modules[name] = module
+                self._added_modules.append(name)
+
+        add_module("pandas", types.ModuleType("pandas"))
+        openai_stub = types.ModuleType("openai")
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add_module("openai", openai_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add_module("dotenv", dotenv_stub)
+        add_module("requests", types.ModuleType("requests"))
+        add_module("numpy", types.ModuleType("numpy"))
+
+        oc = types.ModuleType("backend.utils.openai_client")
+        self.calls = []
+        def dummy_ask(prompt, **kwargs):
+            self.calls.append(prompt)
+            return {"market_condition": "trend"}
+        oc.ask_openai = dummy_ask
+        oc.AI_MODEL = "gpt"
+        add_module("backend.utils.openai_client", oc)
+
+        import backend.strategy.openai_analysis as oa
+        importlib.reload(oa)
+        self.oa = oa
+        self.oa._last_regime_ai_call_time = 0.0
+        self.oa._cached_regime_result = None
+
+    def tearDown(self):
+        for name in getattr(self, "_added_modules", []):
+            sys.modules.pop(name, None)
+        os.environ.pop("AI_REGIME_COOLDOWN_SEC", None)
+
+    def test_cached_result_returned_during_cooldown(self):
+        ctx = {"indicators": {"adx": [30], "ema_slope": [0.1, 0.2]}}
+        res1 = self.oa.get_market_condition(ctx)
+        self.assertEqual(res1["market_condition"], "trend")
+        res2 = self.oa.get_market_condition(ctx)
+        self.assertEqual(res2, res1)
+        self.assertEqual(len(self.calls), 1, "ask_openai should not be called twice")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cache market condition result for AI regimen checks
- return cached data while AI_REGIME_COOLDOWN_SEC is active
- test cooldown logic for market condition calls

## Testing
- `pytest backend/tests/test_market_condition_cooldown.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840602c94388333aba94f4f43e35143