### PR TITLE
Implement trend pullback filter

### DIFF
--- a/backend/filters/trend_pullback.py
+++ b/backend/filters/trend_pullback.py
@@ -1,0 +1,67 @@
+"""Trend pullback entry filter."""
+
+from typing import List, Dict
+from backend.utils import env_loader
+
+
+def _get_val(candle: Dict, key: str) -> float:
+    """Return float value from candle or its 'mid' subdict."""
+    base = candle.get("mid", candle)
+    return float(base.get(key))
+
+
+def _last_val(series):
+    if series is None:
+        return None
+    try:
+        if hasattr(series, "iloc"):
+            return float(series.iloc[-1])
+        if isinstance(series, (list, tuple)):
+            return float(series[-1])
+        return float(series)
+    except Exception:
+        return None
+
+
+def should_enter_long(candles: List[Dict], indicators: dict) -> bool:
+    """Return True if long pullback conditions are met."""
+    if len(candles) < 2:
+        return False
+
+    adx_val = _last_val(indicators.get("adx"))
+    ema_fast = _last_val(indicators.get("ema_fast"))
+    ema_slow = _last_val(indicators.get("ema_slow"))
+    atr_val = _last_val(indicators.get("atr"))
+
+    if adx_val is None or ema_fast is None or ema_slow is None or atr_val is None:
+        return False
+
+    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+    adx_thresh = float(env_loader.get_env("TREND_PB_ADX", "25"))
+    min_atr_pips = float(env_loader.get_env("TREND_PB_MIN_ATR_PIPS", "0"))
+
+    # --- ADX と ATR によるフィルタ ---
+    if adx_val < adx_thresh or atr_val / pip_size < min_atr_pips:
+        return False
+
+    # --- EMA の並びを確認し上昇トレンドかを判断 ---
+    if ema_fast <= ema_slow:
+        return False
+
+    last = candles[-1]
+    prev = candles[-2]
+    last_open = _get_val(last, "o")
+    last_close = _get_val(last, "c")
+    last_low = _get_val(last, "l")
+    prev_open = _get_val(prev, "o")
+    prev_close = _get_val(prev, "c")
+
+    # --- 押し目形成を確認（前足陰線 → 最新足陽線） ---
+    if prev_close >= prev_open or last_close <= last_open:
+        return False
+
+    # --- EMA 付近から反発しているか判定 ---
+    if last_low > ema_fast and last_low > ema_slow:
+        return False
+
+    return True

--- a/backend/tests/test_trend_pullback.py
+++ b/backend/tests/test_trend_pullback.py
@@ -1,0 +1,82 @@
+import os
+import importlib
+import unittest
+
+from typing import List
+
+
+class FakeSeries:
+    def __init__(self, data: List[float]):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+
+def _c(o, h, l, c):
+    return {"mid": {"o": str(o), "h": str(h), "l": str(l), "c": str(c)}}
+
+
+class TestTrendPullback(unittest.TestCase):
+    def setUp(self):
+        os.environ["PIP_SIZE"] = "0.01"
+        os.environ["TREND_PB_ADX"] = "25"
+        os.environ["TREND_PB_MIN_ATR_PIPS"] = "5"
+        import backend.filters.trend_pullback as tp
+        importlib.reload(tp)
+        self.tp = tp
+
+    def tearDown(self):
+        os.environ.pop("PIP_SIZE", None)
+        os.environ.pop("TREND_PB_ADX", None)
+        os.environ.pop("TREND_PB_MIN_ATR_PIPS", None)
+
+    def test_should_enter_true(self):
+        indicators = {
+            "adx": FakeSeries([20, 30]),
+            "ema_fast": FakeSeries([1.0, 1.05]),
+            "ema_slow": FakeSeries([0.99, 1.02]),
+            "atr": FakeSeries([0.1]),
+        }
+        candles = [
+            _c(1.05, 1.06, 1.02, 1.03),
+            _c(1.03, 1.07, 0.99, 1.06),
+        ]
+        self.assertTrue(self.tp.should_enter_long(candles, indicators))
+
+    def test_adx_below_threshold(self):
+        indicators = {
+            "adx": FakeSeries([10]),
+            "ema_fast": FakeSeries([1.0, 1.05]),
+            "ema_slow": FakeSeries([0.99, 1.02]),
+            "atr": FakeSeries([0.1]),
+        }
+        candles = [
+            _c(1.05, 1.06, 1.02, 1.03),
+            _c(1.03, 1.07, 0.99, 1.06),
+        ]
+        self.assertFalse(self.tp.should_enter_long(candles, indicators))
+
+    def test_atr_below_min(self):
+        indicators = {
+            "adx": FakeSeries([30]),
+            "ema_fast": FakeSeries([1.0, 1.05]),
+            "ema_slow": FakeSeries([0.99, 1.02]),
+            "atr": FakeSeries([0.02]),
+        }
+        candles = [
+            _c(1.05, 1.06, 1.02, 1.03),
+            _c(1.03, 1.07, 0.99, 1.06),
+        ]
+        self.assertFalse(self.tp.should_enter_long(candles, indicators))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add trend pullback entry filter using ADX/EMA/ATR
- provide helper to read candle values
- test trend pullback logic

## Testing
- `pytest -q backend/tests/test_trend_pullback.py`
- `pytest -q backend/tests` *(fails: KeyboardInterrupt after multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_684063d6dadc8333be45e56dbc8c21f6