### PR TITLE
Update env params and add alias for TF alignment

### DIFF
--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -32,7 +32,7 @@ ATR（ボラティリティ指標）の計算期間。
 AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 
 ■ AI_COOLDOWN_SEC_OPEN / AI_COOLDOWN_SEC_FLAT / AI_REGIME_COOLDOWN_SEC
-AI呼び出しの最小間隔（秒）を設定する。OPENはポジション保有時、FLATはノーポジ時、REGIMEはトレンド判定用。デフォルトは OPEN=60、FLAT=30、REGIME=60。
+ AI呼び出しの最小間隔（秒）を設定する。OPENはポジション保有時、FLATはノーポジ時、REGIMEはトレンド判定用。デフォルトは OPEN=60、FLAT=30、REGIME=20。
 
 ■ フィルター設定（AI呼び出し制御用）
 
@@ -135,7 +135,8 @@ AI呼び出しの最小間隔（秒）を設定する。OPENはポジション�
 - REV_BLOCK_BARS / TAIL_RATIO_BLOCK / VOL_SPIKE_PERIOD:
   Recent Candle Bias フィルターで参照する設定。直近のローソク足本数、ヒゲ比率、出来高急増判定期間を指定する。
   デフォルトは 3 / 2.0 / 5。
-- STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
+ - STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
+ - ALIGN_STRICT: 上記と同義のエイリアス
 - TF_EMA_WEIGHTS: 上位足EMA整合の重み付け (例 `M5:0.4,H1:0.3,H4:0.3`)
 - AI_ALIGN_WEIGHT: AIの方向性をEMA整合に加味する重み
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -108,7 +108,7 @@ AI_LIMIT_CONVERT_MODEL=gpt-4.1-nano  # 指値→成行判断モデル
 AI_MODEL=gpt-4.1-nano            # 汎用モデル
 AI_PATTERN_MODEL=gpt-4.1-nano    # パターン検出モデル
 AI_PATTERN_MAX_TOKENS=256        # パターン用トークン数
-AI_REGIME_COOLDOWN_SEC=15        # トレンド判定呼び出し間隔
+AI_REGIME_COOLDOWN_SEC=20        # トレンド判定呼び出し間隔
 
 # === チャートパターン検出 ===
 PATTERN_NAMES=double_bottom,double_top,doji,hammer,bullish_engulfing,bearish_engulfing,morning_star,evening_star
@@ -194,6 +194,7 @@ CLIMAX_SL_PIPS=10                # クライマックスSL
 TF_EMA_WEIGHTS=M5:0.4,H1:0.3,H4:0.3  # EMA整合重み
 AI_ALIGN_WEIGHT=0.2                 # AI方向性の重み
 STRICT_TF_ALIGN=false               # 整合取れない場合のキャンセル
+ALIGN_STRICT=false                  # STRICT_TF_ALIGN のエイリアス
 
 # === その他パラメータ ===
 ATR_RATIO=1.8                      # ATR比の過熱判定
@@ -215,7 +216,7 @@ POLARITY_PERIOD=10                 # ポラリティ計算期間
 REV_BLOCK_BARS=3                   # 急反転ブロック確認本数
 RSI_CROSS_LOOKBACK=1               # RSIクロス判定本数
 RSI_OVERBOUGHT_BLOCK=65            # RSI売られ過ぎブロック
-RSI_OVERSOLD_BLOCK=35              # RSI買われ過ぎブロック
+RSI_OVERSOLD_BLOCK=30              # RSI買われ過ぎブロック
 TAIL_RATIO_BLOCK=2.0               # ヒゲ比率ブロック
 TRADE_LOT_SIZE=1.0                 # デフォルトロット数
 USE_INCOMPLETE_BARS=false          # 未確定足の利用可否

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -726,7 +726,9 @@ class JobRunner:
                             "H1": self.indicators_H1 or {},
                         }
                     )
-                    if align is None and env_loader.get_env("STRICT_TF_ALIGN", "false").lower() == "true":
+                    if align is None and env_loader.get_env(
+                        "ALIGN_STRICT", env_loader.get_env("STRICT_TF_ALIGN", "false")
+                    ).lower() == "true":
                         logger.info("Multi‑TF alignment missing → skip entry")
                         log_entry_skip(DEFAULT_PAIR, None, "tf_align")
                         self.last_run = now

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -211,12 +211,16 @@ def process_entry(
                     f"AI side {side} realigned to {align} by multi‑TF check"
                 )
                 side = align
-            elif align is None and env_loader.get_env("STRICT_TF_ALIGN", "false").lower() == "true":
+            elif align is None and env_loader.get_env(
+                "ALIGN_STRICT", env_loader.get_env("STRICT_TF_ALIGN", "false")
+            ).lower() == "true":
                 logging.info("Multi‑TF alignment missing → skip entry")
                 return False
         except Exception as exc:
             logging.debug(f"alignment adjust failed: {exc}")
-            if env_loader.get_env("STRICT_TF_ALIGN", "false").lower() == "true":
+            if env_loader.get_env(
+                "ALIGN_STRICT", env_loader.get_env("STRICT_TF_ALIGN", "false")
+            ).lower() == "true":
                 return False
 
     try:


### PR DESCRIPTION
## Summary
- tweak AI regime cooldown and RSI oversold threshold
- add `ALIGN_STRICT` alias for multi-timeframe alignment check
- document new option in ENV README

## Testing
- `pytest -q` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684067770b0483339e62793c5045e28f