### PR TITLE
Add ALIGN_BYPASS_ADX with ADX bypass logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The indicators module also calculates `adx_bb_score`, a composite value derived 
 
 `TF_EMA_WEIGHTS` specifies the weight of each timeframe when evaluating EMA alignment, e.g. `M5:0.4,H1:0.3,H4:0.3`.
 `AI_ALIGN_WEIGHT` adds the AI's suggested direction to the multi-timeframe alignment check.
+`ALIGN_BYPASS_ADX` bypasses the alignment logic and returns the AI side when the latest M5 ADX meets or exceeds this value.
 
 `ALLOW_DELAYED_ENTRY` set to `true` lets the AI return `"mode":"wait"` when a trend is overextended. The job runner will keep polling and enter once the pullback depth is satisfied.
 

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -136,9 +136,10 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
   Recent Candle Bias フィルターで参照する設定。直近のローソク足本数、ヒゲ比率、出来高急増判定期間を指定する。
   デフォルトは 3 / 2.0 / 5。
  - STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
- - ALIGN_STRICT: 上記と同義のエイリアス
+- ALIGN_STRICT: 上記と同義のエイリアス
 - TF_EMA_WEIGHTS: 上位足EMA整合の重み付け (例 `M5:0.4,H1:0.3,H4:0.3`)
 - AI_ALIGN_WEIGHT: AIの方向性をEMA整合に加味する重み
+- ALIGN_BYPASS_ADX: M5 ADXがこの値以上でAI方向が設定されている場合、整合チェックをスキップ
 
 - LINE_CHANNEL_TOKEN: LINE 通知に使用するチャンネルアクセストークン
 - LINE_USER_ID: 通知を送るユーザーのLINE ID

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -193,6 +193,7 @@ CLIMAX_SL_PIPS=10                # クライマックスSL
 # === マルチTF整合 ===
 TF_EMA_WEIGHTS=M5:0.4,H1:0.3,H4:0.3  # EMA整合重み
 AI_ALIGN_WEIGHT=0.2                 # AI方向性の重み
+ALIGN_BYPASS_ADX=0                  # AIサイド方向保持用ADXしきい値
 STRICT_TF_ALIGN=false               # 整合取れない場合のキャンセル
 ALIGN_STRICT=false                  # STRICT_TF_ALIGN のエイリアス
 

--- a/backend/tests/test_align_bypass.py
+++ b/backend/tests/test_align_bypass.py
@@ -1,0 +1,55 @@
+import os
+import importlib
+import unittest
+
+
+class FakeSeries:
+    def __init__(self, data=None):
+        self._data = list(data or [])
+
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+
+    def __getitem__(self, idx):
+        return self._data[idx]
+
+    def __len__(self):
+        return len(self._data)
+
+
+class TestAlignBypass(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ["ALIGN_BYPASS_ADX"] = "25"
+        import analysis.signal_filter as sf
+        importlib.reload(sf)
+        self.sf = sf
+        self.logger = sf.logger
+
+    def tearDown(self):
+        os.environ.pop("ALIGN_BYPASS_ADX", None)
+
+    def test_high_adx_bypasses_alignment(self):
+        indicators = {
+            "M5": {
+                "adx": FakeSeries([20, 30]),
+                "ema_fast": FakeSeries([1.0, 0.9]),
+                "ema_slow": FakeSeries([1.0, 1.1]),
+            },
+            "H1": {
+                "ema_fast": FakeSeries([1.0, 0.9]),
+                "ema_slow": FakeSeries([1.0, 1.1]),
+            },
+        }
+        with self.assertLogs(self.logger, level="DEBUG") as cm:
+            res = self.sf.is_multi_tf_aligned(indicators, ai_side="long")
+        self.assertEqual(res, "long")
+        self.assertTrue(any("bypass" in m.lower() for m in cm.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `ALIGN_BYPASS_ADX` to settings
- document the new variable
- bypass multi-timeframe alignment when M5 ADX is high
- test the bypass behaviour

## Testing
- `pytest backend/tests/test_align_bypass.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68406e533f98833389e9e12e18e56614