### PR TITLE
Fix test import reload issue

### DIFF
--- a/backend/tests/test_atr_tp_sl_mult.py
+++ b/backend/tests/test_atr_tp_sl_mult.py
@@ -56,9 +56,15 @@ class TestAtrTpSlMult(unittest.TestCase):
         log_mod.log_trade = lambda *a, **k: None
         add("backend.logs.log_manager", log_mod)
 
+        # trend_pullback フィルターを常に True を返すスタブに置き換え
+        tp_mod = types.ModuleType("backend.filters.trend_pullback")
+        tp_mod.should_enter_long = lambda *a, **k: True
+        add("backend.filters.trend_pullback", tp_mod)
+
         os.environ["PIP_SIZE"] = "0.01"
         os.environ["ATR_MULT_TP"] = "0.8"
         os.environ["ATR_MULT_SL"] = "1.1"
+        os.environ["MIN_ATR_MULT"] = "1.1"
 
         import backend.strategy.entry_logic as el
         importlib.reload(el)
@@ -71,6 +77,7 @@ class TestAtrTpSlMult(unittest.TestCase):
         os.environ.pop("PIP_SIZE", None)
         os.environ.pop("ATR_MULT_TP", None)
         os.environ.pop("ATR_MULT_SL", None)
+        os.environ.pop("MIN_ATR_MULT", None)
         sys.modules.pop("backend.strategy.entry_logic", None)
 
     def test_atr_based_tp_sl(self):

--- a/backend/tests/test_entry_filter_rsi.py
+++ b/backend/tests/test_entry_filter_rsi.py
@@ -58,8 +58,9 @@ class TestEntryFilterRSICross(unittest.TestCase):
 
         global pass_entry_filter, _rsi_cross_up_or_down
         import importlib
-        from backend.strategy import signal_filter as sf
-        importlib.reload(sf)
+        # テスト間でモジュールが置き換えられている可能性があるので削除してからインポート
+        sys.modules.pop("backend.strategy.signal_filter", None)
+        sf = importlib.import_module("backend.strategy.signal_filter")
         pass_entry_filter = sf.pass_entry_filter
         _rsi_cross_up_or_down = sf._rsi_cross_up_or_down
         self.sf_logger = sf.logger


### PR DESCRIPTION
## Summary
- remove leftover stub modules before importing `signal_filter`
- stub `trend_pullback` filter and specify `MIN_ATR_MULT` in ATR TP/SL test

## Testing
- `pytest backend/tests/test_entry_filter_rsi.py -q`
- `pytest backend/tests/test_atr_tp_sl_mult.py::TestAtrTpSlMult::test_atr_based_tp_sl -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b028c74c8333a6b4296a0bb973ab