### PR TITLE
Use ATR ratio for drawdown guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ threshold passes.
 opposite Bollinger Band the close must be, and the minimum ADX, before a reversal
 exit is considered.
 `POLARITY_EXIT_THRESHOLD` sets the absolute polarity required to trigger a polarity-based early exit. The default is `0.4`.
+`MM_DRAW_MAX_ATR_RATIO` controls how much drawdown from the peak is allowed before the peak exit guard triggers. The value is multiplied by ATR to derive the threshold.
 `PULLBACK_LIMIT_OFFSET_PIPS` is the base distance for a pullback LIMIT order when the AI proposes a market entry. The actual offset is derived from ATR and ADX, and if price runs away while the trend persists the order can be switched to a market order under AI control.
 `AI_LIMIT_CONVERT_MODEL` sets the OpenAI model used when asking whether a pending LIMIT should be switched to a market order. The default is `gpt-4.1-nano`.
 `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -149,7 +149,7 @@ MIN_HOLD_SEC=60                  # 最低保有時間
 INVERT_ENTRY_SIDE=false          # 売買方向反転
 PEAK_ENTRY_ENABLED=true          # ピークエントリー有効
 PEAK_EXIT_ENABLED=true           # ピーク利確有効
-PEAK_EXIT_RETRACE_PIPS=2         # ピーク利確の戻り幅
+MM_DRAW_MAX_ATR_RATIO=2.0        # ATR倍率によるドローダウン許容幅
 
 # === TP/SL確率フィルター ===
 MIN_TP_PROB=0.8                  # TP達成確率しきい値


### PR DESCRIPTION
## Summary
- replace `PEAK_EXIT_RETRACE_PIPS` with `MM_DRAW_MAX_ATR_RATIO`
- compute peak-exit drawdown using ATR * ratio
- document `MM_DRAW_MAX_ATR_RATIO` in settings and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c708b2a88333987044ea469727b4