### PR TITLE
Implement H1 bounce block

### DIFF
--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -171,6 +171,7 @@ SCALE_TRIGGER_ATR=0.5
 - CLIMAX_TP_PIPS / CLIMAX_SL_PIPS: クライマックス時に使用する TP/SL
 - ALLOW_DELAYED_ENTRY: トレンドが過熱している場合に "wait" を返させ、押し目到来で再問い合わせする
 - MIN_EARLY_EXIT_PROFIT_PIPS: 早期撤退を検討する際に必要な最低利益幅
+- H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
 
 ■ OANDA_MATCH_SEC
   ローカルトレードと OANDA 取引を照合するときの許容秒数。デフォルトは60秒。

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -224,3 +224,4 @@ TAIL_RATIO_BLOCK=2.0               # ヒゲ比率ブロック
 TRADE_LOT_SIZE=1.0                 # デフォルトロット数
 USE_INCOMPLETE_BARS=false          # 未確定足の利用可否
 
+H1_BOUNCE_RANGE_PIPS=3           # H1安値/高値付近をブロックする範囲

--- a/backend/filters/h1_level_block.py
+++ b/backend/filters/h1_level_block.py
@@ -1,0 +1,75 @@
+"""H1 support/resistance level block filter."""
+
+from backend.utils import env_loader
+
+
+def _last_low(indicators: dict) -> float | None:
+    """Extract the last low price from H1 indicators."""
+    series = (
+        indicators.get("low")
+        or indicators.get("l")
+        or indicators.get("lows")
+    )
+    try:
+        if series is not None:
+            if hasattr(series, "iloc"):
+                return float(series.iloc[-1])
+            if isinstance(series, (list, tuple)):
+                return float(series[-1])
+            return float(series)
+        pivot = indicators.get("pivot")
+        r1 = indicators.get("pivot_r1")
+        if pivot is not None and r1 is not None:
+            return 2 * float(pivot) - float(r1)
+    except Exception:
+        return None
+    return None
+
+
+def _last_high(indicators: dict) -> float | None:
+    """Extract the last high price from H1 indicators."""
+    series = (
+        indicators.get("high")
+        or indicators.get("h")
+        or indicators.get("highs")
+    )
+    try:
+        if series is not None:
+            if hasattr(series, "iloc"):
+                return float(series.iloc[-1])
+            if isinstance(series, (list, tuple)):
+                return float(series[-1])
+            return float(series)
+        pivot = indicators.get("pivot")
+        s1 = indicators.get("pivot_s1")
+        if pivot is not None and s1 is not None:
+            return 2 * float(pivot) - float(s1)
+    except Exception:
+        return None
+    return None
+
+
+def is_near_h1_support(indicators_h1: dict, price: float, rng: float) -> bool:
+    """Return True if ``price`` is within ``rng`` pips of the last H1 low."""
+    if not indicators_h1 or rng <= 0 or price is None:
+        return False
+    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+    low = _last_low(indicators_h1)
+    if low is None or pip_size <= 0:
+        return False
+    diff_pips = abs(price - low) / pip_size
+    return diff_pips <= rng
+
+
+def is_near_h1_resistance(indicators_h1: dict, price: float, rng: float) -> bool:
+    """Return True if ``price`` is within ``rng`` pips of the last H1 high."""
+    if not indicators_h1 or rng <= 0 or price is None:
+        return False
+    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+    high = _last_high(indicators_h1)
+    if high is None or pip_size <= 0:
+        return False
+    diff_pips = abs(price - high) / pip_size
+    return diff_pips <= rng
+
+__all__ = ["is_near_h1_support", "is_near_h1_resistance"]

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -21,6 +21,17 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     def extension_block(*_a, **_k):
         return False
+try:
+    from backend.filters.h1_level_block import (
+        is_near_h1_support,
+        is_near_h1_resistance,
+    )
+except ModuleNotFoundError:  # pragma: no cover
+    def is_near_h1_support(*_a, **_k):
+        return False
+
+    def is_near_h1_resistance(*_a, **_k):
+        return False
 from backend.risk_manager import (
     validate_rrr,
     validate_sl,
@@ -341,6 +352,21 @@ def process_entry(
     else:
         instrument = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
         bid = ask = None
+
+    # H1 サポート/レジスタンス付近ではエントリーを見送る
+    try:
+        rng = float(env_loader.get_env("H1_BOUNCE_RANGE_PIPS", "0"))
+        ind_h1 = indicators_multi.get("H1") if indicators_multi else None
+        price_chk = bid if side == "long" else ask
+        if rng > 0 and price_chk is not None and ind_h1:
+            if side == "short" and is_near_h1_support(ind_h1, price_chk, rng):
+                logging.info("Price near H1 support → skip short entry")
+                return False
+            if side == "long" and is_near_h1_resistance(ind_h1, price_chk, rng):
+                logging.info("Price near H1 resistance → skip long entry")
+                return False
+    except Exception as exc:
+        logging.debug(f"[process_entry] H1 level check failed: {exc}")
 
     if mode == "market" and not is_break:
         price_ref = bid if side == "long" else ask

--- a/backend/tests/test_h1_level_block.py
+++ b/backend/tests/test_h1_level_block.py
@@ -1,0 +1,124 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+
+class TestH1LevelBlock(unittest.TestCase):
+    def setUp(self):
+        self._mods = []
+
+        def add(name: str, mod: types.ModuleType):
+            sys.modules[name] = mod
+            self._mods.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        add("pandas", pandas_stub)
+        add("requests", types.ModuleType("requests"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        oa = types.ModuleType("backend.strategy.openai_analysis")
+        oa.get_trade_plan = lambda *a, **k: {
+            "entry": {"side": "short", "mode": "market"},
+            "risk": {"tp_pips": 10, "sl_pips": 5},
+        }
+        oa.should_convert_limit_to_market = lambda ctx: True
+        oa.evaluate_exit = lambda *a, **k: types.SimpleNamespace(action="HOLD", confidence=0.0, reason="")
+        oa.EXIT_BIAS_FACTOR = 1.0
+        add("backend.strategy.openai_analysis", oa)
+
+        om = types.ModuleType("backend.orders.order_manager")
+        class DummyMgr:
+            def __init__(self):
+                self.calls = 0
+            def enter_trade(self, *a, **k):
+                self.calls += 1
+                return {"order_id": "1"}
+            def get_open_orders(self, instrument, side):
+                return []
+        om.OrderManager = DummyMgr
+        add("backend.orders.order_manager", om)
+
+        log_mod = types.ModuleType("backend.logs.log_manager")
+        log_mod.log_trade = lambda *a, **k: None
+        add("backend.logs.log_manager", log_mod)
+
+        os.environ["PIP_SIZE"] = "0.01"
+        os.environ["H1_BOUNCE_RANGE_PIPS"] = "3"
+
+        import backend.strategy.entry_logic as el
+        importlib.reload(el)
+        self.el = el
+        self._mods.append("backend.strategy.entry_logic")
+
+    def tearDown(self):
+        for m in self._mods:
+            sys.modules.pop(m, None)
+        os.environ.pop("PIP_SIZE", None)
+        os.environ.pop("H1_BOUNCE_RANGE_PIPS", None)
+        sys.modules.pop("backend.strategy.entry_logic", None)
+
+    def test_entry_blocked_near_h1_support(self):
+        indicators = {"atr": FakeSeries([0.1])}
+        candles = []
+        market_data = {
+            "prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.005"}], "asks": [{"price": "1.015"}]}]
+        }
+        h1_ind = {"pivot": 1.02, "pivot_r1": 1.04}
+        res = self.el.process_entry(
+            indicators,
+            candles,
+            market_data,
+            candles_dict={"M5": candles},
+            tf_align=None,
+            indicators_multi={"M5": indicators, "H1": h1_ind},
+        )
+        self.assertFalse(res)
+        self.assertEqual(self.el.order_manager.calls, 0)
+
+    def test_entry_blocked_near_h1_resistance(self):
+        indicators = {"atr": FakeSeries([0.1])}
+        candles = []
+        market_data = {
+            "prices": [{"instrument": "USD_JPY", "bids": [{"price": "1.035"}], "asks": [{"price": "1.045"}]}]
+        }
+        h1_ind = {"pivot": 1.02, "pivot_s1": 1.00}
+        oa = sys.modules["backend.strategy.openai_analysis"]
+        oa.get_trade_plan = lambda *a, **k: {
+            "entry": {"side": "long", "mode": "market"},
+            "risk": {"tp_pips": 10, "sl_pips": 5},
+        }
+        importlib.reload(self.el)
+        res = self.el.process_entry(
+            indicators,
+            candles,
+            market_data,
+            candles_dict={"M5": candles},
+            tf_align=None,
+            indicators_multi={"M5": indicators, "H1": h1_ind},
+        )
+        self.assertFalse(res)
+        self.assertEqual(self.el.order_manager.calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `is_near_h1_resistance` for detecting price near H1 highs
- block long entries near H1 resistance in `process_entry`
- document updated behaviour and tests
- verify both long and short cases

## Testing
- `pytest backend/tests/test_h1_level_block.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c6a3a5d88333963fcc16c9ca25ec