### PR TITLE
Fix missing risk validation helper

### DIFF
--- a/backend/risk_manager.py
+++ b/backend/risk_manager.py
@@ -22,6 +22,17 @@ def validate_rrr(tp_pips: float, sl_pips: float, min_rrr: float) -> bool:
         return False
 
 
+def validate_rrr_after_cost(
+    tp_pips: float, sl_pips: float, cost_pips: float, min_rrr: float
+) -> bool:
+    """Return True if (tp_pips - cost_pips) / sl_pips >= min_rrr."""
+    try:
+        net_tp = tp_pips - cost_pips
+        return sl_pips > 0 and (net_tp / sl_pips) >= min_rrr
+    except Exception:
+        return False
+
+
 def is_high_vol_session() -> bool:
     """ロンドン・NY序盤などボラティリティが高い時間帯か判定する。"""
     from datetime import datetime, timedelta


### PR DESCRIPTION
## Summary
- add `validate_rrr_after_cost` to `risk_manager`

## Testing
- `python -m py_compile backend/risk_manager.py`
- `python -m py_compile backend/orders/order_manager.py`
- `pytest backend/tests/test_price_formatting.py::TestPriceFormatting::test_format_price_function -q`
- `pytest backend/tests/test_rrr_enforcement.py::TestRRREnforcement::test_rrr_enforced -q`
- `pytest backend/tests/test_pullback_bypass.py::TestPullbackBypass::test_bypass_on_high_adx -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6840cbc43dbc8333a8a17141d72d7fa0