### PR TITLE
Implement rolling indicators and range break detection

### DIFF
--- a/analysis/regime_detector.py
+++ b/analysis/regime_detector.py
@@ -1,0 +1,57 @@
+"""Range からトレンドへの移行を検知するモジュール."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from backend.indicators.rolling import (
+    RollingATR,
+    RollingADX,
+    RollingBBWidth,
+    RollingKeltner,
+)
+
+
+class RegimeDetector:
+    """3 レイヤー判定でレンジ離れを検知するクラス."""
+
+    def __init__(
+        self,
+        len_fast: int = 14,
+        bw_mult: float = 1.5,
+        atr_mult: float = 1.3,
+        adx_threshold: float = 25.0,
+        adx_slope: float = 0.5,
+        bb_window: int = 20,
+        keltner_window: int = 20,
+    ) -> None:
+        self.adx = RollingADX(len_fast)
+        self.bbwidth = RollingBBWidth(window=bb_window)
+        self.atr = RollingATR(len_fast)
+        self.keltner = RollingKeltner(window=keltner_window)
+        self.state = "RANGE"
+        self.bw_mult = bw_mult
+        self.atr_mult = atr_mult
+        self.adx_threshold = adx_threshold
+        self.adx_slope = adx_slope
+
+    def update(self, tick: Dict[str, Any]) -> Dict[str, Any]:
+        """Tick データを処理して状態遷移を返す."""
+        adx, delta_adx = self.adx.update(tick)
+        bw_ratio = self.bbwidth.update(tick)
+        atr_ratio = self.atr.update(tick)
+        outside = self.keltner.close_outside(tick)
+
+        volatility_break = bw_ratio > self.bw_mult and atr_ratio > self.atr_mult
+        trend_confirm = adx > self.adx_threshold and delta_adx > self.adx_slope
+        direction_ok = outside
+
+        if volatility_break and trend_confirm and direction_ok:
+            self.state = "TREND"
+            return {"transition": True, "direction": self.adx.direction()}
+
+        self.state = "RANGE"
+        return {"transition": False}
+
+
+__all__ = ["RegimeDetector"]

--- a/backend/indicators/__init__.py
+++ b/backend/indicators/__init__.py
@@ -1,6 +1,13 @@
 from .candle_features import get_candle_features, compute_volume_sma
+from .keltner import calculate_keltner_bands
+from .rolling import RollingATR, RollingADX, RollingBBWidth, RollingKeltner
 
 __all__ = [
     "get_candle_features",
     "compute_volume_sma",
+    "calculate_keltner_bands",
+    "RollingATR",
+    "RollingADX",
+    "RollingBBWidth",
+    "RollingKeltner",
 ]

--- a/backend/indicators/keltner.py
+++ b/backend/indicators/keltner.py
@@ -1,0 +1,64 @@
+"""Simple Keltner Channel implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence, Dict, List
+
+
+def calculate_keltner_bands(
+    high: Sequence[float],
+    low: Sequence[float],
+    close: Sequence[float],
+    window: int | None = None,
+    atr_mult: float | None = None,
+) -> Dict[str, List[float]]:
+    """Return Keltner Channel bands.
+
+    Parameters
+    ----------
+    high, low, close : sequence of float
+        価格系列。
+    window : int, optional
+        EMA/ATR の期間。環境変数 ``KELTNER_WINDOW`` をデフォルト値とする。
+    atr_mult : float, optional
+        ATR 乗数。環境変数 ``KELTNER_ATR_MULT`` をデフォルト値とする。
+    """
+    if window is None:
+        window = int(os.getenv("KELTNER_WINDOW", 20))
+    if atr_mult is None:
+        atr_mult = float(os.getenv("KELTNER_ATR_MULT", 1.5))
+    highs = list(map(float, high))
+    lows = list(map(float, low))
+    closes = list(map(float, close))
+    typical_prices = [(h + l + c) / 3 for h, l, c in zip(highs, lows, closes)]
+    ema: List[float] = []
+    alpha = 2 / (window + 1)
+    prev = None
+    for tp in typical_prices:
+        prev = tp if prev is None else prev + alpha * (tp - prev)
+        ema.append(prev)
+    bands_upper: List[float] = []
+    bands_lower: List[float] = []
+    tr_values: List[float] = []
+    prev_close = None
+    for i, (h, l, c) in enumerate(zip(highs, lows, closes)):
+        if prev_close is None:
+            tr = h - l
+        else:
+            tr = max(h - l, abs(h - prev_close), abs(l - prev_close))
+        tr_values.append(tr)
+        if len(tr_values) > window:
+            tr_values.pop(0)
+        atr = sum(tr_values) / len(tr_values)
+        bands_upper.append(ema[i] + atr_mult * atr)
+        bands_lower.append(ema[i] - atr_mult * atr)
+        prev_close = c
+    return {
+        "middle_band": ema,
+        "upper_band": bands_upper,
+        "lower_band": bands_lower,
+    }
+
+
+__all__ = ["calculate_keltner_bands"]

--- a/backend/indicators/rolling.py
+++ b/backend/indicators/rolling.py
@@ -1,0 +1,164 @@
+"""Rolling indicator utilities using deque for efficiency."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Dict, Any
+
+
+class RollingATR:
+    """ATR をローリングで計算して EMA 比を返すクラス."""
+
+    def __init__(self, length: int = 14) -> None:
+        self.length = length
+        self.tr_values: Deque[float] = deque(maxlen=length)
+        self.prev_close: float | None = None
+        self.ema: float | None = None
+        self.alpha = 2 / (length + 1)
+
+    def update(self, tick: Dict[str, Any]) -> float:
+        """高値・安値・終値を含む tick データで更新する."""
+        high = float(tick["high"])
+        low = float(tick["low"])
+        close = float(tick["close"])
+        if self.prev_close is None:
+            tr = high - low
+        else:
+            tr = max(high - low, abs(high - self.prev_close), abs(low - self.prev_close))
+        self.tr_values.append(tr)
+        self.prev_close = close
+        atr = sum(self.tr_values) / len(self.tr_values)
+        self.ema = atr if self.ema is None else self.ema + self.alpha * (atr - self.ema)
+        if self.ema:
+            return atr / self.ema
+        return 1.0
+
+
+class RollingADX:
+    """ADX とその増減を算出するローリングクラス."""
+
+    def __init__(self, length: int = 14) -> None:
+        self.length = length
+        self.prev_high: float | None = None
+        self.prev_low: float | None = None
+        self.prev_close: float | None = None
+        self.tr_values: Deque[float] = deque(maxlen=length)
+        self.plus_dm: Deque[float] = deque(maxlen=length)
+        self.minus_dm: Deque[float] = deque(maxlen=length)
+        self.adx: float | None = None
+        self.prev_adx: float | None = None
+
+    def update(self, tick: Dict[str, Any]) -> tuple[float, float]:
+        high = float(tick["high"])
+        low = float(tick["low"])
+        close = float(tick["close"])
+        if self.prev_high is None:
+            self.prev_high = high
+            self.prev_low = low
+            self.prev_close = close
+            return 0.0, 0.0
+        tr = max(high - low, abs(high - self.prev_close), abs(low - self.prev_close))
+        up_move = high - self.prev_high
+        down_move = self.prev_low - low
+        plus_dm = up_move if up_move > down_move and up_move > 0 else 0.0
+        minus_dm = down_move if down_move > up_move and down_move > 0 else 0.0
+        self.tr_values.append(tr)
+        self.plus_dm.append(plus_dm)
+        self.minus_dm.append(minus_dm)
+        self.prev_high = high
+        self.prev_low = low
+        self.prev_close = close
+        if len(self.tr_values) < self.length:
+            return 0.0, 0.0
+        atr = sum(self.tr_values) / len(self.tr_values)
+        di_plus = 100 * (sum(self.plus_dm) / len(self.plus_dm)) / atr if atr else 0.0
+        di_minus = 100 * (sum(self.minus_dm) / len(self.minus_dm)) / atr if atr else 0.0
+        denom = di_plus + di_minus
+        dx = 100 * abs(di_plus - di_minus) / denom if denom else 0.0
+        if self.adx is None:
+            self.adx = dx
+        else:
+            self.adx = (self.adx * (self.length - 1) + dx) / self.length
+        delta = self.adx - self.prev_adx if self.prev_adx is not None else 0.0
+        self.prev_adx = self.adx
+        return self.adx, delta
+
+    def direction(self) -> str:
+        plus = sum(self.plus_dm) / len(self.plus_dm) if self.plus_dm else 0.0
+        minus = sum(self.minus_dm) / len(self.minus_dm) if self.minus_dm else 0.0
+        return "up" if plus >= minus else "down"
+
+
+class RollingBBWidth:
+    """BB 幅の変化率を計算するローリングクラス."""
+
+    def __init__(self, window: int = 20, avg_len: int = 50) -> None:
+        self.window = window
+        self.avg_len = avg_len
+        self.prices: Deque[float] = deque(maxlen=window)
+        self.widths: Deque[float] = deque(maxlen=avg_len)
+
+    def update(self, tick_or_price: Any) -> float:
+        price = float(tick_or_price["close"] if isinstance(tick_or_price, dict) else tick_or_price)
+        self.prices.append(price)
+        if len(self.prices) < self.window:
+            width = 0.0
+        else:
+            mean = sum(self.prices) / len(self.prices)
+            var = sum((p - mean) ** 2 for p in self.prices) / len(self.prices)
+            std = var ** 0.5
+            width = 4 * std
+        self.widths.append(width)
+        avg = sum(self.widths) / len(self.widths) if self.widths else 0.0
+        return width / avg if avg else 0.0
+
+
+class RollingKeltner:
+    """Keltner Channel をローリングで計算するクラス."""
+
+    def __init__(self, window: int = 20, atr_mult: float = 1.5) -> None:
+        self.window = window
+        self.atr_mult = atr_mult
+        self.alpha = 2 / (window + 1)
+        self.prev_close: float | None = None
+        self.ema: float | None = None
+        self.tr_values: Deque[float] = deque(maxlen=window)
+
+    def update(self, tick: Dict[str, Any]) -> Dict[str, float]:
+        high = float(tick["high"])
+        low = float(tick["low"])
+        close = float(tick["close"])
+        typical = (high + low + close) / 3
+        self.ema = typical if self.ema is None else self.ema + self.alpha * (typical - self.ema)
+        if self.prev_close is None:
+            tr = high - low
+        else:
+            tr = max(high - low, abs(high - self.prev_close), abs(low - self.prev_close))
+        self.tr_values.append(tr)
+        self.prev_close = close
+        atr = sum(self.tr_values) / len(self.tr_values)
+        upper = self.ema + self.atr_mult * atr
+        lower = self.ema - self.atr_mult * atr
+        return {"middle": self.ema, "upper": upper, "lower": lower}
+
+    def close_outside(self, tick: Dict[str, Any]) -> bool:
+        if self.ema is None:
+            bands = {"upper": float("inf"), "lower": float("-inf")}
+        else:
+            atr = sum(self.tr_values) / len(self.tr_values) if self.tr_values else 0.0
+            bands = {
+                "upper": self.ema + self.atr_mult * atr,
+                "lower": self.ema - self.atr_mult * atr,
+            }
+        close = float(tick["close"])
+        outside = close > bands["upper"] or close < bands["lower"]
+        self.update(tick)
+        return outside
+
+
+__all__ = [
+    "RollingATR",
+    "RollingADX",
+    "RollingBBWidth",
+    "RollingKeltner",
+]

--- a/backend/tests/test_keltner.py
+++ b/backend/tests/test_keltner.py
@@ -1,0 +1,39 @@
+import unittest
+
+from backend.indicators.keltner import calculate_keltner_bands
+from backend.indicators.rolling import RollingKeltner
+
+
+class DummyTick(dict):
+    """簡易 tick オブジェクト."""
+
+    def __getattr__(self, item):
+        return self[item]
+
+
+class TestKeltner(unittest.TestCase):
+    def test_calculate_bands(self):
+        high = [1, 2, 3, 4]
+        low = [0.5, 1.5, 2.5, 3.5]
+        close = [0.8, 1.8, 2.8, 3.8]
+        bands = calculate_keltner_bands(high, low, close, window=2, atr_mult=1)
+        self.assertEqual(len(bands["upper_band"]), 4)
+        self.assertGreater(bands["upper_band"][-1], bands["middle_band"][-1])
+
+    def test_rolling_keltner(self):
+        rk = RollingKeltner(window=2, atr_mult=1)
+        ticks = [
+            DummyTick(high=1, low=0.9, close=0.95),
+            DummyTick(high=1.1, low=1.0, close=1.05),
+            DummyTick(high=1.2, low=1.1, close=1.15),
+        ]
+        bands = None
+        for t in ticks:
+            bands = rk.update(t)
+        self.assertIsNotNone(bands)
+        self.assertIn("upper", bands)
+        self.assertTrue(bands["upper"] > bands["middle"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_range_break_alert.py
+++ b/backend/tests/test_range_break_alert.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+import types
+import unittest
+
+fastapi_stub = types.ModuleType("fastapi")
+fastapi_stub.HTTPException = Exception
+sys.modules["fastapi"] = fastapi_stub
+linebot_stub = types.ModuleType("linebot")
+linebot_models = types.ModuleType("linebot.models")
+linebot_stub.LineBotApi = lambda *a, **k: None
+linebot_models.TextSendMessage = lambda text: None
+sys.modules["linebot"] = linebot_stub
+sys.modules["linebot.models"] = linebot_models
+
+import backend.utils.notification as notif
+
+
+class TestRangeBreakAlert(unittest.TestCase):
+    def setUp(self):
+        self.sent = []
+        self._orig = notif.send_line_message
+        importlib.reload(notif)
+        notif.send_line_message = lambda text, token=None, user_id=None: self.sent.append(text)
+
+    def tearDown(self):
+        notif.send_line_message = self._orig
+        sys.modules.pop("fastapi", None)
+        sys.modules.pop("linebot", None)
+        sys.modules.pop("linebot.models", None)
+
+    def test_alert_message_contains_direction(self):
+        notif.send_range_break_alert("up")
+        self.assertEqual(len(self.sent), 1)
+        self.assertIn("⚡️Range Break!", self.sent[0])
+        self.assertIn("up", self.sent[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_regime_detector.py
+++ b/backend/tests/test_regime_detector.py
@@ -1,0 +1,35 @@
+import unittest
+
+from analysis.regime_detector import RegimeDetector
+
+
+class DummyTick(dict):
+    def __getattr__(self, item):
+        return self[item]
+
+
+def make_tick(price: float) -> DummyTick:
+    return DummyTick(high=price + 0.05, low=price - 0.05, close=price)
+
+
+class TestRegimeDetector(unittest.TestCase):
+    def test_transition_to_trend(self):
+        rd = RegimeDetector(
+            len_fast=3,
+            bw_mult=0.5,
+            atr_mult=0.5,
+            adx_threshold=1,
+            adx_slope=0,
+            bb_window=3,
+            keltner_window=3,
+        )
+        # 初期レンジ
+        for p in [1.0, 1.01, 1.02, 1.01]:
+            rd.update(make_tick(p))
+        res = rd.update(DummyTick(high=1.3, low=1.0, close=1.28))
+        self.assertTrue(res["transition"])
+        self.assertEqual(rd.state, "TREND")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/utils/notification.py
+++ b/backend/utils/notification.py
@@ -44,3 +44,8 @@ def send_line_message(text: str, token: str | None = None, user_id: str | None =
     except Exception as exc:  # noqa: BLE001
         logger.error("LINE API error: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+def send_range_break_alert(direction: str) -> None:
+    """Send a short Range Break notification."""
+    send_line_message(f"⚡️Range Break! {direction}")


### PR DESCRIPTION
## Summary
- add deque-based rolling indicators
- implement Keltner channel calculator
- create RegimeDetector class for 3-layer breakout detection
- extend notification utility with range break alert
- unit tests for new modules

## Testing
- `pytest backend/tests/test_keltner.py backend/tests/test_regime_detector.py backend/tests/test_range_break_alert.py -q`
- `pytest -q` *(fails: KeyboardInterrupt after long execution)*

------
https://chatgpt.com/codex/tasks/task_e_684105af74688333872d423d303dc8b3