### PR TITLE
Fix deprecation warnings

### DIFF
--- a/analysis/ai_strategy.py
+++ b/analysis/ai_strategy.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from backend.utils import env_loader
 
@@ -21,7 +21,7 @@ def _to_decimal(hm: str) -> float:
 
 def in_no_trade_period(ts: datetime | None = None) -> bool:
     """NO_TRADE の時間帯なら True."""
-    ts = ts or datetime.utcnow() + timedelta(hours=9)
+    ts = ts or datetime.now(timezone.utc) + timedelta(hours=9)
     ranges = env_loader.get_env("NO_TRADE", "")
     current = ts.hour + ts.minute / 60
     for block in ranges.split(','):

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -5,7 +5,7 @@ import os
 import logging
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.base import STATE_RUNNING
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pydantic import BaseModel
 
 from backend.utils.notification import send_line_message
@@ -123,7 +123,7 @@ def analyze(start_date: str | None = None, end_date: str | None = None, group_by
     return {f"by_{group_by}": by_group, "overall": overall}
 
 def send_hourly_summary():
-    end = datetime.utcnow()
+    end = datetime.now(timezone.utc)
     start = end - timedelta(hours=1)
     conn = sqlite3.connect(DATABASE_PATH)
     cur = conn.cursor()
@@ -164,7 +164,7 @@ def get_trade_summary():
     """
     Returns a summary of trades in the past hour for testing purposes.
     """
-    end = datetime.utcnow()
+    end = datetime.now(timezone.utc)
     start = end - timedelta(hours=1)
     conn = sqlite3.connect(DATABASE_PATH)
     cur = conn.cursor()

--- a/backend/logs/daily_summary.py
+++ b/backend/logs/daily_summary.py
@@ -1,5 +1,5 @@
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import matplotlib.pyplot as plt
 
@@ -11,7 +11,7 @@ ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
 
 
 def fetch_diffs(days: int = 1) -> list[float]:
-    since = datetime.utcnow() - timedelta(days=days)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute(

--- a/backend/logs/fetch_oanda_trades.py
+++ b/backend/logs/fetch_oanda_trades.py
@@ -6,7 +6,7 @@ from backend.utils import env_loader
 
 import requests
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import backend.logs.log_manager
 
@@ -20,8 +20,8 @@ def fetch_oanda_trades():
     url = f'https://api-fxtrade.oanda.com/v3/accounts/{account_id}/transactions'
     params = {
         'type': 'ORDER_FILL',
-        'from': (datetime.utcnow() - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        'to': datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        'from': (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        'to': datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         'pageSize': 1000
     }
     headers = {

--- a/backend/logs/initial_fetch_oanda_trades.py
+++ b/backend/logs/initial_fetch_oanda_trades.py
@@ -1,7 +1,7 @@
 import requests
 from backend.utils import env_loader
 from backend.logs.log_manager import get_db_connection, init_db, log_oanda_trade
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 
 # env_loader automatically loads default env files at import time
@@ -29,8 +29,8 @@ def initial_fetch_oanda_trades():
     base_url = f"{OANDA_API_URL}/v3/accounts/{OANDA_ACCOUNT_ID}/transactions"
     params = {
         "type": "ORDER_FILL,STOP_LOSS_ORDER,TAKE_PROFIT_ORDER,MARKET_ORDER",
-        "from": (datetime.utcnow() - timedelta(days=100)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "to": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "from": (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "to": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "pageSize": 1000
     }
 

--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -1,7 +1,7 @@
 import sqlite3
 import logging
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ def log_ai_decision(decision_type, instrument, ai_response):
         cursor.execute('''
             INSERT INTO ai_decisions (timestamp, decision_type, instrument, ai_response)
             VALUES (?, ?, ?, ?)
-        ''', (datetime.utcnow().isoformat(), decision_type, instrument, ai_response))
+        ''', (datetime.now(timezone.utc).isoformat(), decision_type, instrument, ai_response))
 
 def log_error(module, error_message, additional_info=None):
     """Record an error event.
@@ -233,7 +233,7 @@ def log_error(module, error_message, additional_info=None):
                 INSERT INTO errors (timestamp, module, error_message, additional_info)
                 VALUES (?, ?, ?, ?)
             ''',
-                (datetime.utcnow().isoformat(), module, error_message, additional_info),
+                (datetime.now(timezone.utc).isoformat(), module, error_message, additional_info),
             )
     except sqlite3.OperationalError as exc:
         if "no such table" in str(exc):
@@ -246,7 +246,7 @@ def log_error(module, error_message, additional_info=None):
                         INSERT INTO errors (timestamp, module, error_message, additional_info)
                         VALUES (?, ?, ?, ?)
                     ''',
-                        (datetime.utcnow().isoformat(), module, error_message, additional_info),
+                        (datetime.now(timezone.utc).isoformat(), module, error_message, additional_info),
                     )
             except Exception as retry_exc:
                 logger.warning("log_error retry failed: %s", retry_exc)
@@ -272,7 +272,7 @@ def log_param_change(param_name, old_value, new_value, ai_reason):
                 timestamp, param_name, old_value, new_value, reason
             ) VALUES (?, ?, ?, ?, ?)
         ''', (
-            datetime.utcnow().isoformat(),
+            datetime.now(timezone.utc).isoformat(),
             str(param_name),
             str(old_value),
             str(new_value),
@@ -291,7 +291,7 @@ def log_entry_skip(instrument, side, reason, details=None):
             ) VALUES (?, ?, ?, ?, ?)
             ''',
             (
-                datetime.utcnow().isoformat(),
+                datetime.now(timezone.utc).isoformat(),
                 instrument,
                 side,
                 reason,

--- a/backend/logs/perf_stats_logger.py
+++ b/backend/logs/perf_stats_logger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 LOG_PATH = Path(__file__).resolve().parent / "perf_stats.jsonl"
@@ -12,7 +12,7 @@ LOG_PATH = Path(__file__).resolve().parent / "perf_stats.jsonl"
 def log_perf(tag: str, start: float, end: float) -> None:
     """Append timing info as JSON line."""
     data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "tag": tag,
         "elapsed": end - start,
     }

--- a/backend/logs/reconcile_trades.py
+++ b/backend/logs/reconcile_trades.py
@@ -1,6 +1,6 @@
 import logging
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from backend.logs.log_manager import get_db_connection, init_db
 from backend.utils import env_loader

--- a/backend/logs/show_param_history.py
+++ b/backend/logs/show_param_history.py
@@ -1,6 +1,6 @@
 import sqlite3
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import argparse
 
 # パラメータ変更履歴を格納した SQLite DB のパス
@@ -43,7 +43,7 @@ def main() -> None:
     since: str | None = None
     until: str | None = None
     if args.days:
-        since = (datetime.utcnow() - timedelta(days=args.days)).isoformat()
+        since = (datetime.now(timezone.utc) - timedelta(days=args.days)).isoformat()
     if args.start:
         since = args.start
     if args.end:

--- a/backend/market_data/candle_fetcher.py
+++ b/backend/market_data/candle_fetcher.py
@@ -1,6 +1,6 @@
 import os
 import requests
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 OANDA_API_URL = "https://api-fxtrade.oanda.com/v3/instruments/{instrument}/candles"
 OANDA_API_KEY = os.getenv("OANDA_API_KEY")

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -8,7 +8,7 @@ from backend.risk_manager import (
     validate_rrr_after_cost,
     validate_sl,
 )
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import time
 import json
 import logging
@@ -105,7 +105,7 @@ class OrderManager:
                 "type": "LIMIT",
                 "positionFill": "DEFAULT",
                 "clientExtensions": {"comment": comment_json, "tag": tag},
-                "gtdTime": (datetime.utcnow() + timedelta(seconds=valid_sec)).isoformat(
+                "gtdTime": (datetime.now(timezone.utc) + timedelta(seconds=valid_sec)).isoformat(
                     "T"
                 )
                 + "Z",
@@ -151,7 +151,7 @@ class OrderManager:
         payload = {
             "order": {
                 "price": format_price(instrument, new_price),
-                "gtdTime": (datetime.utcnow() + timedelta(seconds=valid_sec)).isoformat(
+                "gtdTime": (datetime.now(timezone.utc) + timedelta(seconds=valid_sec)).isoformat(
                     "T"
                 )
                 + "Z",
@@ -425,7 +425,7 @@ class OrderManager:
                 pass
 
         units = int(lot_size * 1000) if side == "long" else -int(lot_size * 1000)
-        entry_time = datetime.utcnow().isoformat()
+        entry_time = datetime.now(timezone.utc).isoformat()
 
         rrr = None
         try:
@@ -579,11 +579,11 @@ class OrderManager:
 
         log_trade(
             instrument=instrument,
-            entry_time=position.get("entry_time", datetime.utcnow().isoformat()),
+            entry_time=position.get("entry_time", datetime.now(timezone.utc).isoformat()),
             entry_price=entry_price,
             units=units,
             ai_reason="exit",
-            exit_time=datetime.utcnow().isoformat(),
+            exit_time=datetime.now(timezone.utc).isoformat(),
             exit_reason=ExitReason.MANUAL,
         )
         return result
@@ -736,7 +736,7 @@ class OrderManager:
         result = response.json()
         log_trade(
             instrument,
-            datetime.utcnow().isoformat(),
+            datetime.now(timezone.utc).isoformat(),
             new_sl_price,
             0,
             "SL dynamically updated",

--- a/backend/reentry_manager.py
+++ b/backend/reentry_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from backend.utils import env_loader
 
 
@@ -19,7 +19,7 @@ class ReentryManager:
 
     def record_sl_hit(self, price: float, side: str) -> None:
         """SLが実行された価格と方向を記録する。"""
-        self.sl_hit_time = datetime.utcnow()
+        self.sl_hit_time = datetime.now(timezone.utc)
         self.sl_hit_price = float(price)
         self.side = side
 

--- a/backend/risk_manager.py
+++ b/backend/risk_manager.py
@@ -35,9 +35,9 @@ def validate_rrr_after_cost(
 
 def is_high_vol_session() -> bool:
     """ロンドン・NY序盤などボラティリティが高い時間帯か判定する。"""
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
-    now_jst = datetime.utcnow() + timedelta(hours=9)
+    now_jst = datetime.now(timezone.utc) + timedelta(hours=9)
     hour = now_jst.hour + now_jst.minute / 60.0
     return (15 <= hour < 17) or (22 <= hour < 24)
 

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -42,7 +42,7 @@ from backend.risk_manager import (
     get_recent_swing_diff,
     is_high_vol_session,
 )
-from datetime import datetime
+from datetime import datetime, timezone
 from backend.utils import env_loader
 import logging
 import json
@@ -704,7 +704,7 @@ def process_entry(
             _pending_limits[entry_uuid] = {
                 "instrument": instrument,
                 "order_id": result.get("order_id"),
-                "ts": int(datetime.utcnow().timestamp()),
+                "ts": int(datetime.now(timezone.utc).timestamp()),
                 "limit_price": limit_price,
                 "side": side,
                 "retry_count": 0,
@@ -740,7 +740,7 @@ def process_entry(
         lot_size = float(env_loader.get_env("TRADE_LOT_SIZE", "1.0"))
         units = int(lot_size * 1000) if side == "long" else -int(lot_size * 1000)
         entry_price = float(market_data['prices'][0]['bids'][0]['price'])
-        entry_time = datetime.utcnow().isoformat()
+        entry_time = datetime.now(timezone.utc).isoformat()
         rrr = None
         try:
             if tp_pips is not None and sl_pips not in (None, 0):

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -17,7 +17,7 @@ from backend.indicators import get_candle_features, compute_volume_sma
 # Consolidated exit decision helpers live in exit_ai_decision
 from backend.strategy.exit_ai_decision import AIDecision, evaluate as evaluate_exit
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 # ----------------------------------------------------------------------
 # Config – driven by environment variables
@@ -676,7 +676,7 @@ def get_exit_decision(
             entry_time_str = current_position.get("entry_time") or current_position.get("openTime")
             if entry_time_str:
                 entry_dt = datetime.fromisoformat(entry_time_str.replace("Z", "+00:00"))
-                secs_since_entry = (datetime.utcnow() - entry_dt).total_seconds()
+                secs_since_entry = (datetime.now(timezone.utc) - entry_dt).total_seconds()
         except Exception:
             secs_since_entry = None
 

--- a/backend/strategy/reentry_manager.py
+++ b/backend/strategy/reentry_manager.py
@@ -1,6 +1,6 @@
 """Manage cooldown after stop-loss exits."""
 from __future__ import annotations
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 class ReentryManager:
@@ -10,12 +10,12 @@ class ReentryManager:
 
     def record_stop(self, side: str, ts: datetime | None = None) -> None:
         """Register a stop-loss exit for the given side."""
-        self.last_exit[side] = ts or datetime.utcnow()
+        self.last_exit[side] = ts or datetime.now(timezone.utc)
 
     def can_enter(self, side: str, ts: datetime | None = None) -> bool:
         """Return True if enough time has passed since the last stop-loss."""
         last = self.last_exit.get(side)
         if not last:
             return True
-        now = ts or datetime.utcnow()
+        now = ts or datetime.now(timezone.utc)
         return now - last >= self.cooldown

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -13,6 +13,7 @@ import math
 import pandas as pd
 import logging
 import datetime
+from datetime import timezone
 from backend.strategy.higher_tf_analysis import analyze_higher_tf
 from backend.market_data.tick_fetcher import fetch_tick_data
 from backend.indicators.adx import calculate_adx_slope
@@ -364,7 +365,7 @@ def pass_entry_filter(
     else:
         quiet2_start = quiet2_end = None
 
-    now_jst = datetime.datetime.utcnow() + datetime.timedelta(hours=9)
+    now_jst = datetime.datetime.now(timezone.utc) + datetime.timedelta(hours=9)
     current_time = now_jst.hour + now_jst.minute / 60.0
 
     def _in_range(start: float | None, end: float | None) -> bool:

--- a/backend/strategy/strategy_analyzer.py
+++ b/backend/strategy/strategy_analyzer.py
@@ -1,5 +1,5 @@
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from backend.utils import env_loader
 import json
@@ -60,7 +60,7 @@ def ensure_param_change_table():
 
 def backup_settings():
     """Create a timestamped backup of the current settings.env file."""
-    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
     backup_path = f"{SETTINGS_PATH}.{ts}.bak"
     shutil.copy2(SETTINGS_PATH, backup_path)
     return backup_path
@@ -123,7 +123,7 @@ def suggest_parameter_adjustments(settings, summary_text: str):
         logger.info("[戦略分析AI] 有効な変更提案はありません。")
 
 def fetch_recent_trades(hours=1):
-    since = datetime.utcnow() - timedelta(hours=hours)
+    since = datetime.now(timezone.utc) - timedelta(hours=hours)
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute("""
@@ -133,7 +133,7 @@ def fetch_recent_trades(hours=1):
         return cursor.fetchall()
 
 def fetch_ai_decisions(hours=1):
-    since = datetime.utcnow() - timedelta(hours=hours)
+    since = datetime.now(timezone.utc) - timedelta(hours=hours)
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute("""
@@ -157,7 +157,7 @@ def analyze_performance(trades):
 
     logger.info(
         "[戦略分析AIレポート] %s UTC",
-        datetime.utcnow().isoformat(),
+        datetime.now(timezone.utc).isoformat(),
     )
     logger.info("トレード数: %s", total)
     logger.info("勝率: %.2f%%", win_rate)

--- a/backend/tests/test_be_volatility_sl.py
+++ b/backend/tests/test_be_volatility_sl.py
@@ -3,7 +3,7 @@ import sys
 import types
 import importlib
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 class FakeSeries:
     def __init__(self, data):
@@ -106,7 +106,7 @@ class TestBeVolatilitySL(unittest.TestCase):
             return {'M5': {'atr': FakeSeries([0.04]), 'adx': FakeSeries([40])}, 'M1': {}, 'H1': {}, 'H4': {}, 'D': {}}
         sys.modules['backend.indicators.calculate_indicators'].calculate_indicators_multi = calc_multi
         sys.modules['backend.strategy.exit_logic'].process_exit = lambda *a, **k: None
-        now_str = datetime.utcnow().isoformat() + 'Z'
+        now_str = datetime.now(timezone.utc).isoformat() + 'Z'
         sys.modules['backend.orders.position_manager'].check_current_position = lambda *a, **k: {
             'instrument': 'USD_JPY',
             'long': {'units': '1', 'averagePrice': '1.00', 'tradeIDs': ['t1']},

--- a/backend/tests/test_entry_filter_rsi.py
+++ b/backend/tests/test_entry_filter_rsi.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import datetime
+from datetime import timezone
 import types
 import sys
 
@@ -64,7 +65,7 @@ class TestEntryFilterRSICross(unittest.TestCase):
         pass_entry_filter = sf.pass_entry_filter
         _rsi_cross_up_or_down = sf._rsi_cross_up_or_down
         self.sf_logger = sf.logger
-        now = datetime.datetime.utcnow() + datetime.timedelta(hours=9)
+        now = datetime.datetime.now(timezone.utc) + datetime.timedelta(hours=9)
         start = (now.hour + 1) % 24
         end = (start + 1) % 24
         os.environ["QUIET_START_HOUR_JST"] = str(start)

--- a/backend/tests/test_min_hold_exit.py
+++ b/backend/tests/test_min_hold_exit.py
@@ -3,7 +3,7 @@ import sys
 import types
 import importlib
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 class TestMinHoldExit(unittest.TestCase):
     def setUp(self):
@@ -83,7 +83,7 @@ class TestMinHoldExit(unittest.TestCase):
         sys.modules['backend.indicators.calculate_indicators'].calculate_indicators_multi = lambda *a, **k: {'M5': {}, 'M1': {}, 'H1': {}, 'H4': {}, 'D': {}}
         self.exit_called = []
         sys.modules['backend.strategy.exit_logic'].process_exit = lambda *a, **k: self.exit_called.append(True)
-        now_str = datetime.utcnow().isoformat() + 'Z'
+        now_str = datetime.now(timezone.utc).isoformat() + 'Z'
         sys.modules['backend.orders.position_manager'].check_current_position = lambda *a, **k: {
             'instrument': 'EUR_USD',
             'long': {'units': '1', 'averagePrice': '1.0000', 'tradeIDs': ['t1']},

--- a/backend/tests/test_pivot_suppression.py
+++ b/backend/tests/test_pivot_suppression.py
@@ -4,6 +4,7 @@ import types
 import importlib
 import unittest
 import datetime
+from datetime import timezone
 
 class FakeSeries:
     def __init__(self, data):
@@ -59,7 +60,7 @@ class TestPivotSuppression(unittest.TestCase):
         }
         sys.modules["backend.strategy.higher_tf_analysis"].analyze_higher_tf = lambda *a, **k: {"pivot_d": 1.0, "pivot_h4": 1.0}
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(hours=9)
+        now = datetime.datetime.now(timezone.utc) + datetime.timedelta(hours=9)
         start = (now.hour + 1) % 24
         end = (start + 1) % 24
         os.environ["QUIET_START_HOUR_JST"] = str(start)

--- a/backend/tests/test_reentry_manager.py
+++ b/backend/tests/test_reentry_manager.py
@@ -25,13 +25,13 @@ class TestReentryManager(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from backend.strategy.reentry_manager import ReentryManager
 
 
 def test_reentry_cooldown():
     rm = ReentryManager(cooldown_sec=60)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     rm.record_stop("long", now)
     assert not rm.can_enter("long", now + timedelta(seconds=30))
     assert rm.can_enter("long", now + timedelta(seconds=61))

--- a/backend/tests/test_regime_filters.py
+++ b/backend/tests/test_regime_filters.py
@@ -5,6 +5,7 @@ import importlib
 import unittest
 import csv
 import datetime
+from datetime import timezone
 
 class FakeSeries:
     def __init__(self, data):

--- a/backend/tests/test_scale_constraints.py
+++ b/backend/tests/test_scale_constraints.py
@@ -3,7 +3,7 @@ import sys
 import types
 import importlib
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 class FakeSeries:
     def __init__(self, data):
@@ -98,7 +98,7 @@ class BaseScaleTest(unittest.TestCase):
             'M1': {}, 'H1': {}, 'H4': {}, 'D': {}
         }
         sys.modules['backend.strategy.exit_logic'].process_exit = lambda *a, **k: False
-        now_str = datetime.utcnow().isoformat() + 'Z'
+        now_str = datetime.now(timezone.utc).isoformat() + 'Z'
         sys.modules['backend.orders.position_manager'].check_current_position = lambda *a, **k: {
             'instrument': 'USD_JPY',
             'long': {'units': '1', 'averagePrice': '1.0000', 'tradeIDs': ['t1']},

--- a/backend/tests/test_scale_entry.py
+++ b/backend/tests/test_scale_entry.py
@@ -3,7 +3,7 @@ import sys
 import types
 import importlib
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 class FakeSeries:
     def __init__(self, data):
@@ -98,7 +98,7 @@ class TestScaleEntry(unittest.TestCase):
             'M1': {}, 'H1': {}, 'H4': {}, 'D': {}
         }
         sys.modules['backend.strategy.exit_logic'].process_exit = lambda *a, **k: False
-        now_str = datetime.utcnow().isoformat() + 'Z'
+        now_str = datetime.now(timezone.utc).isoformat() + 'Z'
         sys.modules['backend.orders.position_manager'].check_current_position = lambda *a, **k: {
             'instrument': 'USD_JPY',
             'long': {'units': '1', 'averagePrice': '1.0000', 'tradeIDs': ['t1']},

--- a/backend/tests/test_trailing_calendar.py
+++ b/backend/tests/test_trailing_calendar.py
@@ -4,6 +4,7 @@ import types
 import importlib
 import unittest
 import datetime
+from datetime import timezone
 
 class FakeSeries:
     def __init__(self, data):
@@ -116,7 +117,7 @@ class TestTrailingCalendar(unittest.TestCase):
             sys.modules.pop(name, None)
 
     def test_trailing_disabled_during_event(self):
-        now = datetime.datetime.utcnow() + datetime.timedelta(hours=9)
+        now = datetime.datetime.now(timezone.utc) + datetime.timedelta(hours=9)
         start = (now.hour + 1) % 24
         end = (start + 1) % 24
         os.environ["QUIET_START_HOUR_JST"] = str(start)

--- a/backend/utils/trade_time.py
+++ b/backend/utils/trade_time.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Utility helper for trade timestamps."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 
@@ -15,6 +15,6 @@ def trade_age_seconds(trade: dict[str, Any], *, now: Optional[datetime] = None) 
         dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
     except Exception:
         return None
-    now = now or datetime.utcnow()
+    now = now or datetime.now(timezone.utc)
     return (now - dt).total_seconds()
 


### PR DESCRIPTION
## Summary
- replace all uses of `datetime.utcnow()` with timezone aware `datetime.now(timezone.utc)`
- update all imports to include `timezone`
- adjust tests accordingly

## Testing
- `pytest -q` *(fails: TestAtrTpSlMult::test_atr_based_tp_sl)*

------
https://chatgpt.com/codex/tasks/task_e_6841287ebaec8333ab90929c6367a0b3