### PR TITLE
Implement VWAP delta indicator

### DIFF
--- a/backend/indicators/__init__.py
+++ b/backend/indicators/__init__.py
@@ -1,6 +1,7 @@
 from .candle_features import get_candle_features, compute_volume_sma
 from .keltner import calculate_keltner_bands
 from .rolling import RollingATR, RollingADX, RollingBBWidth, RollingKeltner
+from .vwap_band import get_vwap_delta
 
 __all__ = [
     "get_candle_features",
@@ -10,4 +11,5 @@ __all__ = [
     "RollingADX",
     "RollingBBWidth",
     "RollingKeltner",
+    "get_vwap_delta",
 ]

--- a/backend/indicators/vwap_band.py
+++ b/backend/indicators/vwap_band.py
@@ -1,0 +1,29 @@
+from collections import deque
+from typing import Sequence, Tuple
+
+
+def _compute_vwap(prices: Sequence[float], volumes: Sequence[float]) -> float:
+    """Return VWAP for given price and volume series."""
+    total_vol = sum(float(v) for v in volumes)
+    if total_vol == 0:
+        return 0.0
+    return sum(float(p) * float(v) for p, v in zip(prices, volumes)) / total_vol
+
+
+deviation_history: deque[float] = deque(maxlen=20)
+
+
+def get_vwap_delta(prices: Sequence[float], volumes: Sequence[float]) -> Tuple[float, float]:
+    """Return current VWAP deviation and shrinkage ratio."""
+    if len(prices) != len(volumes) or not prices:
+        return 0.0, 0.0
+    vwap = _compute_vwap(prices, volumes)
+    cur_price = float(prices[-1])
+    deviation = cur_price - vwap
+    deviation_history.append(deviation)
+    avg_dev = sum(abs(d) for d in deviation_history) / len(deviation_history)
+    shrink = deviation / avg_dev if avg_dev else 0.0
+    return deviation, shrink
+
+
+__all__ = ["get_vwap_delta"]

--- a/backend/tests/test_vwap_band.py
+++ b/backend/tests/test_vwap_band.py
@@ -1,0 +1,25 @@
+import unittest
+
+import backend.indicators.vwap_band as vb
+
+
+class TestVWAPBand(unittest.TestCase):
+    def setUp(self):
+        vb.deviation_history.clear()
+
+    def test_basic_delta(self):
+        prices = [100, 101, 102]
+        volumes = [1, 1, 1]
+        d, r = vb.get_vwap_delta(prices, volumes)
+        self.assertAlmostEqual(d, 1.0)
+        self.assertAlmostEqual(r, 1.0)
+
+    def test_history_ratio(self):
+        vb.get_vwap_delta([1, 1, 1], [1, 1, 1])  # deviation 0
+        d, r = vb.get_vwap_delta([1, 2, 1], [1, 1, 1])
+        self.assertNotEqual(r, 0.0)
+        self.assertAlmostEqual(d, 1 - (4/3), places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `get_vwap_delta` for calculating VWAP deviation
- expose new indicator in package exports
- test VWAP band calculations

## Testing
- `pytest backend/tests/test_vwap_band.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68414cd017ac8333acc115e48f737f64