### PR TITLE
Add ATRBoostDetector

### DIFF
--- a/analysis/regime_detector.py
+++ b/analysis/regime_detector.py
@@ -54,4 +54,17 @@ class RegimeDetector:
         return {"transition": False}
 
 
-__all__ = ["RegimeDetector"]
+class ATRBoostDetector:
+    """ATR 比率が閾値を超えたか判定するクラス."""
+
+    def __init__(self, length: int = 14, threshold: float = 1.2) -> None:
+        self.atr = RollingATR(length)
+        self.threshold = threshold
+
+    def update(self, tick: Dict[str, Any]) -> bool:
+        """ATR / ATR EMA が閾値を上回ると True."""
+        ratio = self.atr.update(tick)
+        return ratio > self.threshold
+
+
+__all__ = ["RegimeDetector", "ATRBoostDetector"]

--- a/backend/tests/test_atr_boost_detector.py
+++ b/backend/tests/test_atr_boost_detector.py
@@ -1,0 +1,25 @@
+import unittest
+
+from analysis.regime_detector import ATRBoostDetector
+
+
+class DummyTick(dict):
+    def __getattr__(self, item):
+        return self[item]
+
+
+def make_tick(high, low, close):
+    return DummyTick(high=high, low=low, close=close)
+
+
+class TestATRBoostDetector(unittest.TestCase):
+    def test_detect_boost(self):
+        det = ATRBoostDetector(length=3, threshold=1.2)
+        for _ in range(3):
+            self.assertFalse(det.update(make_tick(1.05, 0.95, 1.0)))
+        res = det.update(make_tick(1.5, 0.7, 1.2))
+        self.assertTrue(res)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `analysis/regime_detector` with `ATRBoostDetector`
- add unittest for ATR boost detection

## Testing
- `pytest -q backend/tests/test_atr_boost_detector.py`


------
https://chatgpt.com/codex/tasks/task_e_68414cd603848333b24b2e6bd003bd8e