### PR TITLE
Add scoring and tp/sl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,3 +437,10 @@ profit. The job runner calls `order_manager.place_trailing_stop()` to update the
 stop on the first trade ID, which replaces the previous order. OANDA cancels the
 old trailing stop automatically once the new one is applied. See
 `backend/strategy/exit_logic.py` lines 510-525 for the exact logic.
+
+## 4 レイヤー・スコアリングと TP/SL 最適化
+
+エントリーロジックではトレンド、モメンタム、ボラティリティ、パターンの4要素を組み合わせたスコアリング方式を採用しています。重みは `SCORE_WEIGHTS` で調整でき、総合スコアが `ENTRY_SCORE_MIN` を上回った場合のみポジションを開きます。
+
+TP/SL の組み合わせは複数候補から期待値を計算し、最も利益が見込めるものを自動選択します。`MIN_RRR` と `ENFORCE_RRR` を有効にするとリスクリワード比を維持したまま最適化されます。詳細は `docs/four_layer_scoring.md` を参照してください。
+

--- a/docs/four_layer_scoring.md
+++ b/docs/four_layer_scoring.md
@@ -1,0 +1,37 @@
+# 4 レイヤー・スコアリングと TP/SL 最適化
+
+本システムではエントリーの可否を多角的に判断するため、4 つのレイヤーからなるスコアリング手法を導入しました。各レイヤーは次の要素を評価し、0〜1 の値で貢献度を返します。
+
+1. **トレンドレイヤー** – EMA 方向や高位足の位置関係を基にした長期トレンド判定
+2. **モメンタムレイヤー** – ADX 変化量やボリューム増加率から現在の勢いを測定
+3. **ボラティリティレイヤー** – ATR 幅や Bollinger Band 拡張度合いを参照
+4. **パターンレイヤー** – ローソク足パターンや AI 解析結果
+
+最終スコアは各レイヤー値に重みを掛け、合計を重みの総和で割ることで算出します。
+
+```python
+score = (trend*w1 + momentum*w2 + volatility*w3 + pattern*w4) / (w1+w2+w3+w4)
+```
+
+重みは環境変数 `SCORE_WEIGHTS` で設定できます。`ENTRY_SCORE_MIN` を超えた場合にのみエントリーが許可されます。
+
+## TP/SL 最適化アルゴリズム
+
+取引ごとの期待値を高めるため、複数候補の TP/SL 組み合わせを評価し、最も EV (Expected Value) が高いものを採用します。各候補は成功確率 `p` と TP/SL 幅 `tp`、`sl` を持ち、期待値は以下の式で計算されます。
+
+```python
+EV = tp * p - sl * (1 - p)
+```
+
+`MIN_RRR` と `ENFORCE_RRR` を併用すると、リスクリワード比を維持しつつ最適な組み合わせを選択できます。
+
+### 設定例
+
+```env
+SCORE_WEIGHTS=trend:0.4,momentum:0.3,volatility:0.2,pattern:0.1
+ENTRY_SCORE_MIN=0.6
+TP_CANDIDATES=10,15,20
+SL_CANDIDATES=8,10,12
+MIN_RRR=1.3
+ENFORCE_RRR=true
+```


### PR DESCRIPTION
## Summary
- document new 4-layer scoring approach and TP/SL optimization algorithm
- mention the feature in the main README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414cdb59908333a963c1a842cdc458