### PR TITLE
Relax probability validation

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -30,6 +30,7 @@ AI_REGIME_COOLDOWN_SEC: int = int(env_loader.get_env("AI_REGIME_COOLDOWN_SEC", A
 # --- Threshold for AI‑proposed TP probability ---
 MIN_TP_PROB: float = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
 TP_PROB_HOURS: int = int(env_loader.get_env("TP_PROB_HOURS", "24"))
+PROB_MARGIN: float = float(env_loader.get_env("PROB_MARGIN", "0.02"))
 LIMIT_THRESHOLD_ATR_RATIO: float = float(env_loader.get_env("LIMIT_THRESHOLD_ATR_RATIO", "0.3"))
 MAX_LIMIT_AGE_SEC: int = int(env_loader.get_env("MAX_LIMIT_AGE_SEC", "180"))
 MIN_NET_TP_PIPS: float = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))
@@ -1162,7 +1163,14 @@ Respond with **one-line valid JSON** exactly as:
             sl *= noise_sl_mult
             risk["sl_pips"] = sl
 
-            if p + q > 1.01:
+            if p < 0 or p > 1 or q < 0 or q > 1:
+                logger.warning("Probability out of range - clamping to [0,1]")
+                p = max(0.0, min(1.0, p))
+                q = max(0.0, min(1.0, q))
+                risk["tp_prob"] = p
+                risk["sl_prob"] = q
+
+            if p + q > 1.0 + PROB_MARGIN:
                 logger.warning("Probabilities invalid — skipping plan")
                 plan["entry"]["side"] = "no"
                 return plan

--- a/backend/tests/test_prob_validation.py
+++ b/backend/tests/test_prob_validation.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class TestProbValidation(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        self._added = []
+        def add(name, mod):
+            if name not in sys.modules:
+                sys.modules[name] = mod
+                self._added.append(name)
+        add("pandas", types.ModuleType("pandas"))
+        openai_stub = types.ModuleType("openai")
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add("openai", openai_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+        add("requests", types.ModuleType("requests"))
+        add("numpy", types.ModuleType("numpy"))
+        import backend.strategy.openai_analysis as oa
+        importlib.reload(oa)
+        self.oa = oa
+
+    def tearDown(self):
+        for name in getattr(self, "_added", []):
+            sys.modules.pop(name, None)
+        os.environ.pop("MIN_TP_PROB", None)
+        os.environ.pop("PROB_MARGIN", None)
+
+    def test_sum_within_margin(self):
+        os.environ["MIN_TP_PROB"] = "0.5"
+        os.environ["PROB_MARGIN"] = "0.02"
+        self.oa.ask_openai = lambda *a, **k: {
+            "entry": {"side": "long"},
+            "risk": {"tp_pips": 10, "sl_pips": 5, "tp_prob": 0.51, "sl_prob": 0.51},
+        }
+        result = self.oa.get_trade_plan({}, {"M5": {}}, {"M5": []})
+        self.assertEqual(result.get("entry", {}).get("side"), "long")
+
+    def test_prob_clamped(self):
+        os.environ["MIN_TP_PROB"] = "0.5"
+        os.environ["PROB_MARGIN"] = "0.02"
+        self.oa.ask_openai = lambda *a, **k: {
+            "entry": {"side": "long"},
+            "risk": {"tp_pips": 10, "sl_pips": 5, "tp_prob": 1.5, "sl_prob": -0.2},
+        }
+        result = self.oa.get_trade_plan({}, {"M5": {}}, {"M5": []})
+        risk = result.get("risk", {})
+        self.assertEqual(risk.get("tp_prob"), 1.0)
+        self.assertEqual(risk.get("sl_prob"), 0.0)
+        self.assertEqual(result.get("entry", {}).get("side"), "long")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make allowed TP/SL probability error configurable via `PROB_MARGIN`
- clamp invalid probability values instead of rejecting the plan
- test the new probability validation behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841533e82288333a73dee858d6ffa2b