### PR TITLE
Add composite score threshold

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+# Example environment variables
+# Copy this file to .env and adjust as needed
+COMPOSITE_MIN=0.7

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -144,6 +144,7 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 - MIN_VOL_MA / MIN_VOL_M1: ボリュームフィルタの最小値
 - ADX_SLOPE_LOOKBACK: ADX の傾き計算に使う本数
 - ADX_DYNAMIC_COEFF: BB 幅によって ADX しきい値を補正する係数
+- COMPOSITE_MIN: ADXとBB幅から算出するComposite Trend Scoreのしきい値
 - EMA_FLAT_PIPS: EMA の傾きをフラットとみなす幅
 - OVERSHOOT_ATR_MULT: BB下限をATR×この倍率だけ割り込むとエントリーをブロック
 - REV_BLOCK_BARS / TAIL_RATIO_BLOCK / VOL_SPIKE_PERIOD:

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -38,6 +38,8 @@ BE_TRIGGER_PIPS: int = int(env_loader.get_env("BE_TRIGGER_PIPS", 10))
 BE_TRIGGER_R: float = float(env_loader.get_env("BE_TRIGGER_R", "0"))
 AI_LIMIT_CONVERT_MODEL: str = env_loader.get_env("AI_LIMIT_CONVERT_MODEL", "gpt-4.1-nano")
 MIN_RRR: float = float(env_loader.get_env("MIN_RRR", "0.8"))
+# --- Composite score threshold ---
+COMPOSITE_MIN: float = float(env_loader.get_env("COMPOSITE_MIN", "1.0"))
 # --- Exit bias factor ---
 EXIT_BIAS_FACTOR: float = float(env_loader.get_env("EXIT_BIAS_FACTOR", "1.0"))
 
@@ -980,16 +982,18 @@ def get_trade_plan(
 
     noise_val = f"{noise_pips:.1f}" if noise_pips is not None else "N/A"
     tv_score = "N/A"
+    comp_val = None
     try:
         adx_series = ind_m5.get("adx")
         bb_upper = ind_m5.get("bb_upper")
         bb_lower = ind_m5.get("bb_lower")
         if adx_series is not None and bb_upper is not None and bb_lower is not None:
             from backend.indicators.adx import calculate_adx_bb_score
-            val = calculate_adx_bb_score(adx_series, bb_upper, bb_lower)
-            tv_score = f"{val:.2f}"
+            comp_val = calculate_adx_bb_score(adx_series, bb_upper, bb_lower)
+            tv_score = f"{comp_val:.2f}"
     except Exception:
         tv_score = "N/A"
+        comp_val = None
     # --- calculate dynamic pullback threshold ----------------------------
     recent_high = None
     recent_low = None
@@ -1184,6 +1188,13 @@ Respond with **one-line valid JSON** exactly as:
 
         if p < MIN_TP_PROB or (tp * p - sl * q) <= 0:
             plan["entry"]["side"] = "no"
+
+    # Composite score check
+    try:
+        if comp_val is not None and comp_val < COMPOSITE_MIN:
+            plan["entry"]["side"] = "no"
+    except Exception:
+        pass
 
     if plan.get("entry", {}).get("side") == "no":
         plan["risk"] = {}

--- a/backend/tests/test_composite_threshold.py
+++ b/backend/tests/test_composite_threshold.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+class TestCompositeThreshold(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ["COMPOSITE_MIN"] = "0.7"
+        self._mods = []
+
+        def add(name, mod):
+            if name not in sys.modules:
+                sys.modules[name] = mod
+                self._mods.append(name)
+
+        pandas_stub = types.ModuleType("pandas")
+        add("pandas", pandas_stub)
+        openai_stub = types.ModuleType("openai")
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+        openai_stub.OpenAI = DummyClient
+        openai_stub.APIError = Exception
+        add("openai", openai_stub)
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+        add("requests", types.ModuleType("requests"))
+        add("numpy", types.ModuleType("numpy"))
+        adx_mod = types.ModuleType("backend.indicators.adx")
+        adx_mod.calculate_adx_bb_score = lambda *a, **k: 0.6
+        add("backend.indicators.adx", adx_mod)
+        import backend.strategy.openai_analysis as oa
+        importlib.reload(oa)
+        self.oa = oa
+
+    def tearDown(self):
+        for name in getattr(self, "_mods", []):
+            sys.modules.pop(name, None)
+        os.environ.pop("COMPOSITE_MIN", None)
+
+    def test_composite_score_blocks_entry(self):
+        self.oa.ask_openai = lambda *a, **k: {"entry": {"side": "long"}, "risk": {}}
+        indicators = {"M5": {"adx": [20], "bb_upper": [1.1], "bb_lower": [1.0]}}
+        result = self.oa.get_trade_plan({}, indicators, {"M5": []})
+        self.assertEqual(result.get("entry", {}).get("side"), "no")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `.env.template` and document COMPOSITE_MIN
- support `COMPOSITE_MIN` in openai_analysis
- filter entries when composite score below threshold
- test composite score check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416d48f2188333a7cd27ed63508b59