### PR TITLE
Implement probability normalization logic

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1191,7 +1191,15 @@ Respond with **one-line valid JSON** exactly as:
                 risk["tp_prob"] = p
                 risk["sl_prob"] = q
 
-            if p + q > 1.0 + PROB_MARGIN:
+            total = p + q
+            if abs(total - 1.0) <= 0.05:
+                p_norm = p / total
+                q_norm = q / total
+                risk["tp_prob"] = p_norm
+                risk["sl_prob"] = q_norm
+                p = p_norm
+                q = q_norm
+            elif total > 1.0 + PROB_MARGIN or total < 1.0 - PROB_MARGIN:
                 logger.warning("Probabilities invalid — skipping plan")
                 plan["entry"]["side"] = "no"
                 return plan


### PR DESCRIPTION
## Summary
- normalize TP/SL probabilities when their sum is close to 1
- skip invalid plans when sum is far from 1
- reload openai_analysis in tests to apply environment variable changes
- add normalization test for probability validation

## Testing
- `pytest backend/tests/test_prob_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684175e550ac8333bb5f3c0b9900660e