### PR TITLE
Implement risk validation helpers

### DIFF
--- a/backend/config/defaults.py
+++ b/backend/config/defaults.py
@@ -1,0 +1,4 @@
+"""Default configuration values for runtime."""
+
+# Minimum allowed stop-loss size in pips
+MIN_ABS_SL_PIPS = 5

--- a/backend/strategy/validators.py
+++ b/backend/strategy/validators.py
@@ -1,0 +1,44 @@
+"""Helper functions for validating AI trade plans."""
+
+from __future__ import annotations
+
+from backend.config.defaults import MIN_ABS_SL_PIPS
+
+
+def normalize_probs(tp_prob: float, sl_prob: float) -> tuple[float, float]:
+    """Return probabilities normalized to sum to 1 when total within [0.9, 1.1]."""
+    try:
+        tp = float(tp_prob)
+        sl = float(sl_prob)
+        total = tp + sl
+        if 0.9 <= total <= 1.1 and total > 0:
+            tp /= total
+            sl /= total
+        return tp, sl
+    except Exception:
+        return tp_prob, sl_prob
+
+
+def risk_autofix(risk: dict | None) -> dict:
+    """Ensure risk dictionary contains tp_pips/sl_pips/tp_prob/sl_prob values."""
+    if risk is None:
+        risk = {}
+    try:
+        tp = float(risk.get("tp_pips", 8))
+    except Exception:
+        tp = 8.0
+    try:
+        sl = float(risk.get("sl_pips", 4))
+    except Exception:
+        sl = 4.0
+    sl = max(sl, MIN_ABS_SL_PIPS)
+    try:
+        tp_prob = float(risk.get("tp_prob", 0.6))
+    except Exception:
+        tp_prob = 0.6
+    try:
+        sl_prob = float(risk.get("sl_prob", 0.4))
+    except Exception:
+        sl_prob = 0.4
+    tp_prob, sl_prob = normalize_probs(tp_prob, sl_prob)
+    return {"tp_pips": tp, "sl_pips": sl, "tp_prob": tp_prob, "sl_prob": sl_prob}


### PR DESCRIPTION
## Summary
- introduce `backend/config/defaults.py` with `MIN_ABS_SL_PIPS`
- add new validators module with probability normalization and risk auto-fix
- integrate new validators and constant into `openai_analysis`
- ensure SL never below absolute minimum and probabilities normalized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684186fe8ee48333990cbae22efd530a