### PR TITLE
Fix duplicate parameter in get_trade_plan

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -907,7 +907,6 @@ def get_trade_plan(
     *,
     higher_tf_direction: str | None = None,
     allow_delayed_entry: bool | None = None,
-    higher_tf_direction: str | None = None,
 ) -> dict:
     """
     Single‑shot call to the LLM that returns a dict:


### PR DESCRIPTION
## Summary
- remove duplicate `higher_tf_direction` parameter
- confirm successful compilation

## Testing
- `python -m py_compile backend/strategy/openai_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_68418f09900483338bd8c7409850ce36