### PR TITLE
Remove redundant regime cache update

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -609,10 +609,6 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
     _last_regime_ai_call_time = now
     return result
 
-    _cached_regime_result = result
-    _last_regime_ai_call_time = time.time()
-    return result
-
 
 
 # ----------------------------------------------------------------------
@@ -907,7 +903,6 @@ def get_trade_plan(
     *,
     higher_tf_direction: str | None = None,
     allow_delayed_entry: bool | None = None,
-    higher_tf_direction: str | None = None,
 ) -> dict:
     """
     Single‑shot call to the LLM that returns a dict:


### PR DESCRIPTION
## Summary
- clean up duplicated cache update in `get_market_condition`
- fix duplicate argument in `get_trade_plan`

## Testing
- `python -m py_compile backend/strategy/openai_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_68418f0a7cb883338ff715c77cd890be