### PR TITLE
Fix pips_from_entry initialization for exit decision

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -663,6 +663,8 @@ def get_exit_decision(
     units_val = float(current_position.get("units", 0))
     side = "SHORT" if units_val < 0 else "LONG"
 
+    pips_from_entry = None
+    unreal_pnl = 0
     # --- 現在値とエントリ価格からサイド別の差分を算出する ---
     try:
         bid = float(market_data.get("bid")) if isinstance(market_data, dict) else None
@@ -678,7 +680,8 @@ def get_exit_decision(
             pips_from_entry = 0
             unreal_pnl = 0
     except (ValueError, TypeError):
-        pips_from_entry = 0
+        # ここでは値を設定せず、後続のフォールバックに任せる
+        pips_from_entry = None
         unreal_pnl = 0
 
     secs_since_entry = market_data.get("secs_since_entry")


### PR DESCRIPTION
## Summary
- ensure `pips_from_entry` is initialized as `None`
- keep value `None` after initial calculation failure so fallback logic runs

## Testing
- `pytest backend/tests/test_higher_tf_prompt.py::TestHigherTFPrompt::test_prompt_contains_higher_tf_direction -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68419ad8858083338d187cc6c832543b