### PR TITLE
Add TREND_ADX_THRESH setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 
 - `DEFAULT_PAIR` … 取引する通貨ペア
 - `MIN_RRR` … 最低リスクリワード比。`ENFORCE_RRR` と併用すると常にこの比率を保ちます
+- `TREND_ADX_THRESH` … トレンド判定に使う ADX のしきい値 (デフォルト 20)
 - `SCALE_LOT_SIZE` … 追加エントリー時のロット数
 - `AI_MODEL` … OpenAI モデル名
 - `LINE_CHANNEL_TOKEN` / `LINE_USER_ID` … LINE 通知に使用する認証情報

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -190,6 +190,7 @@ SCALE_TRIGGER_ATR=0.5
 - CLIMAX_ZSCORE: ATR Z スコアの閾値
 - CLIMAX_TP_PIPS / CLIMAX_SL_PIPS: クライマックス時に使用する TP/SL
 - ALLOW_DELAYED_ENTRY: トレンドが過熱している場合に "wait" を返させ、押し目到来で再問い合わせする
+- TREND_ADX_THRESH: トレンド判定に用いるADXの基準値。プロンプトの条件とローカル判定で参照される
 - MIN_EARLY_EXIT_PROFIT_PIPS: 早期撤退を検討する際に必要な最低利益幅
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
 ■ OANDA_MATCH_SEC

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -181,6 +181,7 @@ ADX_NO_TRADE_MAX=0               # ADXノートレード上限
 ADX_RANGE_THRESHOLD=25           # レンジ判定ADX値
 ADX_SLOPE_LOOKBACK=3             # ADX傾き計算本数
 ADX_DYNAMIC_COEFF=0              # ADX補正係数
+TREND_ADX_THRESH=20             # トレンド判定のADX基準値
 ENABLE_RANGE_ENTRY=true          # レンジでもエントリー許可
 RANGE_CENTER_BLOCK_PCT=0.15      # BB中心ブロック比
 RANGE_ENTRY_OFFSET_PIPS=3.5      # BB中心近傍の指値切替幅

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -11,6 +11,7 @@ MIN_TP_PROB = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
 TP_PROB_HOURS = int(env_loader.get_env("TP_PROB_HOURS", "24"))
 MIN_RRR = float(env_loader.get_env("MIN_RRR", "0.8"))
 MIN_NET_TP_PIPS = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))
+TREND_ADX_THRESH = float(env_loader.get_env("TREND_ADX_THRESH", "20"))
 
 
 def _series_tail_list(series, n: int = 20) -> list:
@@ -135,7 +136,7 @@ def build_trade_plan_prompt(
     prompt = f"""
 ⚠️【Market Regime Classification – Flexible Criteria】
 Classify as "TREND" if ANY TWO of the following conditions are met:
-- ADX ≥ 20 maintained over at least the last 3 candles.
+- ADX ≥ {TREND_ADX_THRESH} maintained over at least the last 3 candles.
 - EMA consistently sloping upwards or downwards without major reversals within the last 3 candles.
 - Price consistently outside the Bollinger Band midline (above for bullish, below for bearish).
 
@@ -146,7 +147,7 @@ Under clearly identified TREND conditions, avoid counter-trend trades and never 
 
 🔄【Counter-Trend Trade Allowance】
 Allow short-term counter-trend trades only when all of the following are true:
-- ADX ≤ 20 or clearly declining.
+- ADX ≤ {TREND_ADX_THRESH} or clearly declining.
 - A clear reversal pattern (double top/bottom, head-and-shoulders) is present.
 - RSI ≤ 30 for LONG or ≥ 70 for SHORT, showing potential exhaustion.
 - Price action has stabilized with minor reversal candles.
@@ -163,16 +164,16 @@ Once a TREND is confirmed, prioritize entries on pullbacks. Shorts enter after p
 🔎【Minor Retracement Clarification】
 Do not interpret short-term retracements as trend reversals. Genuine trend reversals require ALL of the following simultaneously:
 - EMA direction reversal sustained for at least 3 candles.
-- ADX clearly drops below 20, indicating weakening trend momentum.
+- ADX clearly drops below {TREND_ADX_THRESH}, indicating weakening trend momentum.
 
 🎯【Improved Exit Strategy】
 Avoid exiting during normal trend pullbacks. Only exit a trend trade if **ALL** of the following are true:
 - EMA reverses direction and this is sustained for at least 3 consecutive candles.
-- ADX drops clearly below 20, showing momentum has faded.
+- ADX drops clearly below {TREND_ADX_THRESH}, showing momentum has faded.
 If these are not all met, HOLD the position even if RSI is extreme or price briefly retraces.
 
 ♻️【Immediate Re-entry Policy】
-If a stop-loss is triggered but original trend conditions remain intact (ADX≥20, clear EMA slope), immediately re-enter in the same direction upon the next valid signal.
+If a stop-loss is triggered but original trend conditions remain intact (ADX≥{TREND_ADX_THRESH}, clear EMA slope), immediately re-enter in the same direction upon the next valid signal.
 
 ### Recent Indicators (last 20 values each)
 ## M5

--- a/backend/tests/test_higher_tf_prompt.py
+++ b/backend/tests/test_higher_tf_prompt.py
@@ -38,7 +38,8 @@ class TestHigherTFPrompt(unittest.TestCase):
         self.oa.ask_openai = lambda prompt, **k: (captured.append(prompt) or '{"entry": {"side": "no"}}')
         self.oa.get_trade_plan({}, {"M5": {}}, {"M5": []}, higher_tf_direction="long")
         self.assertTrue(captured)
-        self.assertIn("Higher TF Direction", captured[0])
+        # プロンプトに Higher Timeframe Direction ラベルが含まれることを確認
+        self.assertIn("Higher Timeframe Direction", captured[0])
         self.assertIn("long", captured[0])
 
 if __name__ == "__main__":

--- a/tests/test_trend_adx_thresh.py
+++ b/tests/test_trend_adx_thresh.py
@@ -1,0 +1,29 @@
+import importlib
+import os
+
+def test_trend_adx_default():
+    if 'TREND_ADX_THRESH' in os.environ:
+        os.environ.pop('TREND_ADX_THRESH')
+    import backend.strategy.openai_prompt as prompt
+    importlib.reload(prompt)
+    assert prompt.TREND_ADX_THRESH == 20.0
+
+def test_trend_adx_env_override():
+    os.environ['TREND_ADX_THRESH'] = '30'
+    os.environ.setdefault('OPENAI_API_KEY', 'dummy')
+    import backend.strategy.openai_prompt as prompt
+    importlib.reload(prompt)
+    import sys, types
+    openai_stub = types.ModuleType('openai')
+    class DummyClient:
+        def __init__(self, *a, **k):
+            pass
+    openai_stub.OpenAI = DummyClient
+    openai_stub.APIError = Exception
+    sys.modules.setdefault('openai', openai_stub)
+    sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+    from backend.strategy import openai_analysis
+    importlib.reload(openai_analysis)
+    assert prompt.TREND_ADX_THRESH == 30.0
+    assert openai_analysis.TREND_ADX_THRESH == 30.0
+    os.environ.pop('TREND_ADX_THRESH')


### PR DESCRIPTION
## Summary
- make ADX threshold configurable via `TREND_ADX_THRESH`
- reference this value in prompts and analysis logic
- document the new environment variable
- adjust higher TF prompt test and add unit tests for `TREND_ADX_THRESH`

## Testing
- `pytest -q tests/test_trend_adx_thresh.py backend/tests/test_higher_tf_prompt.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419d40b6908333b70ce78b9b2ac724