### PR TITLE
Implement volatility spike override for narrow bands

### DIFF
--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -154,7 +154,8 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 - REV_BLOCK_BARS / TAIL_RATIO_BLOCK / VOL_SPIKE_PERIOD:
   Recent Candle Bias フィルターで参照する設定。直近のローソク足本数、ヒゲ比率、出来高急増判定期間を指定する。
   デフォルトは 3 / 2.0 / 5。
- - STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
+- VOL_SPIKE_ADX_MULT / VOL_SPIKE_ATR_MULT: BB幅がしきい値を下回っていても、ADXまたはATRがこの倍率で急拡大した場合は成行エントリーに切り替える
+- STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
 - ALIGN_STRICT: 上記と同義のエイリアス
 - TF_EMA_WEIGHTS: 上位足EMA整合の重み付け (例 `M5:0.4,H1:0.3,H4:0.3`)
 - AI_ALIGN_WEIGHT: AIの方向性をEMA整合に加味する重み

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -130,6 +130,8 @@ VOL_MA_PERIOD=10                 # 出来高平均期間
 MIN_VOL_MA=80                    # ボリュームフィルタMA
 MIN_VOL_M1=60                    # ボリュームフィルタM1
 VOL_SPIKE_PERIOD=5               # ボラ急増判定期間
+VOL_SPIKE_ADX_MULT=1.5           # ADX急拡大とみなす倍率
+VOL_SPIKE_ATR_MULT=1.5           # ATR急拡大とみなす倍率
 FOLLOW_ADX_MIN=25                # フォローモードADX条件
 BREAKOUT_ADX_MIN=30              # ブレイクアウト判定ADX
 

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -65,6 +65,8 @@ ALLOW_NO_PULLBACK_WHEN_ADX: float = float(
 ENABLE_RANGE_ENTRY: bool = (
     env_loader.get_env("ENABLE_RANGE_ENTRY", "false").lower() == "true"
 )
+VOL_SPIKE_ADX_MULT: float = float(env_loader.get_env("VOL_SPIKE_ADX_MULT", "1.5"))
+VOL_SPIKE_ATR_MULT: float = float(env_loader.get_env("VOL_SPIKE_ATR_MULT", "1.5"))
 ADX_TREND_ON: int = 25
 ADX_TREND_OFF: int = 18
 USE_LOCAL_PATTERN: bool = (
@@ -1332,6 +1334,35 @@ Respond with **one-line valid JSON** exactly as:
         ):
             plan["entry"]["side"] = "no"
     except (TypeError, ValueError, IndexError):
+        pass
+
+    # Narrow Bollinger Band override: switch to market on volatility spike
+    try:
+        bb_upper = ind_m5.get("bb_upper")
+        bb_lower = ind_m5.get("bb_lower")
+        if bb_upper is not None and bb_lower is not None and len(bb_upper) and len(bb_lower):
+            pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+            bw_pips = (bb_upper.iloc[-1] - bb_lower.iloc[-1]) / pip_size
+            bw_thresh = float(env_loader.get_env("BAND_WIDTH_THRESH_PIPS", "4"))
+            if bw_pips <= bw_thresh:
+                lookback = 3
+                adx_spike = False
+                atr_spike = False
+                adx_series = ind_m5.get("adx")
+                if adx_series is not None and len(adx_series) > lookback:
+                    adx_last = float(adx_series.iloc[-1]) if hasattr(adx_series, "iloc") else float(adx_series[-1])
+                    adx_prev = float(adx_series.iloc[-lookback-1]) if hasattr(adx_series, "iloc") else float(adx_series[-lookback-1])
+                    if adx_prev > 0 and adx_last / adx_prev >= VOL_SPIKE_ADX_MULT:
+                        adx_spike = True
+                atr_series = ind_m5.get("atr")
+                if atr_series is not None and len(atr_series) > lookback:
+                    atr_last = float(atr_series.iloc[-1]) if hasattr(atr_series, "iloc") else float(atr_series[-1])
+                    atr_prev = float(atr_series.iloc[-lookback-1]) if hasattr(atr_series, "iloc") else float(atr_series[-lookback-1])
+                    if atr_prev > 0 and atr_last / atr_prev >= VOL_SPIKE_ATR_MULT:
+                        atr_spike = True
+                if adx_spike or atr_spike:
+                    plan.setdefault("entry", {})["mode"] = "market"
+    except Exception:
         pass
     return plan
 


### PR DESCRIPTION
## Summary
- add VOL_SPIKE_ADX_MULT and VOL_SPIKE_ATR_MULT env variables
- override narrow BB width handling in `get_trade_plan`
- document new settings

## Testing
- `pytest -q` *(fails: TestHigherTFPrompt.test_prompt_contains_higher_tf_direction)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0d316808333b31e5b299fdb5c9e