### PR TITLE
Load params in JobRunner & fix prompt label

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -6,6 +6,13 @@ import json
 import os
 from backend.utils import env_loader, trade_age_seconds
 
+try:
+    from config import params_loader
+    # strategy.yml などから環境変数を読み込む
+    params_loader.load_params()
+except Exception:
+    pass
+
 from backend.market_data.tick_fetcher import fetch_tick_data
 
 from backend.market_data.candle_fetcher import fetch_multiple_timeframes

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1180,7 +1180,7 @@ After calculating TP hit probability, widen the SL by at least {env_loader.get_e
 ### Composite Trend Score
 {tv_score}
 
-### Higher TF Direction
+### Higher Timeframe Direction
 {higher_tf_direction or "unknown"}
 
 ### Pivot Levels

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -131,7 +131,12 @@ def build_trade_plan_prompt(
     except Exception:
         pass
 
-    direction_line = "\n### Higher TF Direction\n" + str(higher_tf_direction) + "\n" if higher_tf_direction else ""
+    # 上位足のトレンド方向を明示的に記載
+    direction_line = (
+        "\n### Higher Timeframe Direction\n" + str(higher_tf_direction) + "\n"
+        if higher_tf_direction
+        else ""
+    )
 
     prompt = f"""
 ⚠️【Market Regime Classification – Flexible Criteria】


### PR DESCRIPTION
## Summary
- load `strategy.yml` settings in the job runner
- update the prompt label for higher timeframe direction
- adjust same label in `openai_analysis`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a70cffdc8333b5a6ad929a89b2f2