### PR TITLE
Improve ADX info and risk defaults

### DIFF
--- a/backend/strategy/validators.py
+++ b/backend/strategy/validators.py
@@ -6,12 +6,12 @@ from backend.config.defaults import MIN_ABS_SL_PIPS
 
 
 def normalize_probs(tp_prob: float, sl_prob: float) -> tuple[float, float]:
-    """Return probabilities normalized to sum to 1 when total within [0.9, 1.1]."""
+    """Return probabilities normalized to sum to 1 when total within [0.5, 1.5]."""
     try:
         tp = float(tp_prob)
         sl = float(sl_prob)
         total = tp + sl
-        if 0.9 <= total <= 1.1 and total > 0:
+        if 0.5 <= total <= 1.5 and total > 0:
             tp /= total
             sl /= total
         return tp, sl
@@ -24,11 +24,11 @@ def risk_autofix(risk: dict | None) -> dict:
     if risk is None:
         risk = {}
     try:
-        tp = float(risk.get("tp_pips", 8))
+        tp = float(risk.get("tp_pips", 10))
     except Exception:
         tp = 8.0
     try:
-        sl = float(risk.get("sl_pips", 4))
+        sl = float(risk.get("sl_pips", 6))
     except Exception:
         sl = 4.0
     sl = max(sl, MIN_ABS_SL_PIPS)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,24 @@
+import pytest
+from backend.strategy.validators import normalize_probs, risk_autofix
+from backend.config.defaults import MIN_ABS_SL_PIPS
+
+
+def test_normalize_probs_within_range():
+    tp, sl = normalize_probs(0.9, 0.6)
+    assert tp == pytest.approx(0.6, abs=1e-6)
+    assert sl == pytest.approx(0.4, abs=1e-6)
+    assert tp + sl == pytest.approx(1.0, abs=1e-6)
+
+
+def test_normalize_probs_outside_range():
+    tp, sl = normalize_probs(0.4, 0.0)
+    assert tp == 0.4
+    assert sl == 0.0
+
+
+def test_risk_autofix_defaults():
+    r = risk_autofix(None)
+    assert r["tp_pips"] == 10.0
+    assert r["sl_pips"] >= 6.0 and r["sl_pips"] >= MIN_ABS_SL_PIPS
+    assert r["tp_prob"] == pytest.approx(0.6, abs=1e-6)
+    assert r["sl_prob"] == pytest.approx(0.4, abs=1e-6)


### PR DESCRIPTION
## Summary
- show recent ADX average and latest value in the OpenAI prompt
- require TP/SL info in the prompt instructions
- loosen probability normalisation and update default risk values
- test validator helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b098f9c88333b1a262c49ac0a325