### PR TITLE
Improve scalping market condition handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `SCALP_MODE` … スキャルプエントリーを有効にするフラグ
 - `SCALP_ADX_MIN` … スキャルプ実行時に必要なADX値
 - `SCALP_TP_PIPS` / `SCALP_SL_PIPS` … スキャルプ用の固定TP/SL幅
+- `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`)
 - `AI_MODEL` … OpenAI モデル名
 - `LINE_CHANNEL_TOKEN` / `LINE_USER_ID` … LINE 通知に使用する認証情報
 
@@ -63,6 +64,7 @@ SCALP_MODE: true
 SCALP_ADX_MIN: 35
 SCALP_TP_PIPS: 4
 SCALP_SL_PIPS: 2
+SCALP_COND_TF: M1
 ```
 
 

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -196,10 +196,12 @@ SCALE_TRIGGER_ATR=0.5
 - SCALP_MODE: スキャルピング用の固定TP/SLエントリーを有効化
 - SCALP_ADX_MIN: SCALP_MODE時に必要な最小ADX
 - SCALP_TP_PIPS / SCALP_SL_PIPS: スキャル時のTP/SL幅
+- SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
 - SCALP_MODE: スキャルプモードを有効にする
 - SCALP_ADX_MIN: スキャルプ実行に必要なADX下限
 - SCALP_TP_PIPS / SCALP_SL_PIPS: スキャルプ用のTP/SL幅
+- SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)
 ■ OANDA_MATCH_SEC
   ローカルトレードと OANDA 取引を照合するときの許容秒数。デフォルトは60秒。
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -241,3 +241,4 @@ SCALP_MODE=true                 # スキャルプモード有効化
 SCALP_ADX_MIN=45                 # スキャルプ時の最低ADX
 SCALP_TP_PIPS=5                  # スキャルプ時のTP幅
 SCALP_SL_PIPS=3                  # スキャルプ時のSL幅
+SCALP_COND_TF=M1                 # 市場判定に使う時間足(M1/M5等)

--- a/backend/tests/test_scalp_cond_tf.py
+++ b/backend/tests/test_scalp_cond_tf.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+
+
+class TestScalpCondTf(unittest.TestCase):
+    def setUp(self):
+        # stub external modules
+        self._mods = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._mods.append(name)
+        add("requests", types.ModuleType("requests"))
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = lambda *a, **k: None
+        add("pandas", pandas_stub)
+        add("numpy", types.ModuleType("numpy"))
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ.setdefault("OANDA_API_KEY", "dummy")
+        os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")
+        os.environ["SCALP_MODE"] = "true"
+        os.environ["SCALP_COND_TF"] = "M1"
+
+        import backend.scheduler.job_runner as jr
+        importlib.reload(jr)
+        self.jr = jr.JobRunner(interval_seconds=1)
+        self.jr.indicators_M1 = {"foo": 1}
+        self.jr.indicators_M5 = {"foo": 5}
+
+    def tearDown(self):
+        for n in self._mods:
+            sys.modules.pop(n, None)
+        os.environ.pop("SCALP_MODE", None)
+        os.environ.pop("SCALP_COND_TF", None)
+        os.environ.pop("OANDA_API_KEY", None)
+        os.environ.pop("OANDA_ACCOUNT_ID", None)
+        os.environ.pop("OPENAI_API_KEY", None)
+
+    def test_get_cond_indicators_scalp(self):
+        self.assertEqual(self.jr._get_cond_indicators(), {"foo": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use SCALP_COND_TF to select indicators for market condition
- document SCALP_COND_TF env var
- default SCALP_COND_TF=M1 in settings
- test that JobRunner uses the specified timeframe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c433b3988333a155e63bc1aa2ce6