### PR TITLE
Add short pullback filter

### DIFF
--- a/backend/filters/trend_pullback.py
+++ b/backend/filters/trend_pullback.py
@@ -65,3 +65,50 @@ def should_enter_long(candles: List[Dict], indicators: dict) -> bool:
         return False
 
     return True
+
+
+def should_enter_short(candles: List[Dict], indicators: dict) -> bool:
+    """Return True if short pullback conditions are met."""
+    if len(candles) < 2:
+        return False
+
+    adx_val = _last_val(indicators.get("adx"))
+    ema_fast = _last_val(indicators.get("ema_fast"))
+    ema_slow = _last_val(indicators.get("ema_slow"))
+    atr_val = _last_val(indicators.get("atr"))
+
+    if adx_val is None or ema_fast is None or ema_slow is None or atr_val is None:
+        return False
+
+    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+    adx_thresh = float(env_loader.get_env("TREND_PB_ADX", "25"))
+    min_atr_pips = float(env_loader.get_env("TREND_PB_MIN_ATR_PIPS", "0"))
+
+    # --- ADX と ATR によるフィルタ ---
+    if adx_val < adx_thresh or atr_val / pip_size < min_atr_pips:
+        return False
+
+    # --- EMA の並びを確認し下降トレンドかを判断 ---
+    if ema_fast >= ema_slow:
+        return False
+
+    last = candles[-1]
+    prev = candles[-2]
+    last_open = _get_val(last, "o")
+    last_close = _get_val(last, "c")
+    last_high = _get_val(last, "h")
+    prev_open = _get_val(prev, "o")
+    prev_close = _get_val(prev, "c")
+
+    # --- 戻り形成を確認（前足陽線 → 最新足陰線） ---
+    if prev_close <= prev_open or last_close >= last_open:
+        return False
+
+    # --- EMA 付近から反落しているか判定 ---
+    if last_high < ema_fast and last_high < ema_slow:
+        return False
+
+    return True
+
+
+__all__ = ["should_enter_long", "should_enter_short"]

--- a/backend/tests/test_trend_pullback.py
+++ b/backend/tests/test_trend_pullback.py
@@ -77,6 +77,32 @@ class TestTrendPullback(unittest.TestCase):
         ]
         self.assertFalse(self.tp.should_enter_long(candles, indicators))
 
+    def test_should_enter_short_true(self):
+        indicators = {
+            "adx": FakeSeries([20, 30]),
+            "ema_fast": FakeSeries([1.05, 1.0]),
+            "ema_slow": FakeSeries([1.05, 1.04]),
+            "atr": FakeSeries([0.1]),
+        }
+        candles = [
+            _c(1.03, 1.07, 0.99, 1.06),
+            _c(1.06, 1.08, 1.02, 1.03),
+        ]
+        self.assertTrue(self.tp.should_enter_short(candles, indicators))
+
+    def test_should_enter_short_false(self):
+        indicators = {
+            "adx": FakeSeries([20, 30]),
+            "ema_fast": FakeSeries([1.05, 1.0]),
+            "ema_slow": FakeSeries([1.05, 1.04]),
+            "atr": FakeSeries([0.1]),
+        }
+        candles = [
+            _c(1.03, 1.07, 0.99, 1.06),
+            _c(1.06, 1.08, 1.02, 1.07),
+        ]
+        self.assertFalse(self.tp.should_enter_short(candles, indicators))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `should_enter_short` filter for downward pullbacks
- use filter in entry logic and skip for break conditions
- test coverage for `should_enter_short`

## Testing
- `pytest -k trend_pullback -q`
- `pytest -q` (all tests)


------
https://chatgpt.com/codex/tasks/task_e_6841d2a7947c83339d1613e1ba6db757