### PR TITLE
Add scalp mode logging

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -268,6 +268,9 @@ class JobRunner:
             bool(token),
             bool(user_id),
         )
+        # SCALP_MODE の状態を起動時に記録
+        scalp_active = env_loader.get_env("SCALP_MODE", "false").lower() == "true"
+        logger.info("SCALP_MODE is %s", "ON" if scalp_active else "OFF")
 
     def _get_cond_indicators(self) -> dict:
         """Return indicators for market condition check."""

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -167,6 +167,8 @@ def process_entry(
 
     # --- Scalp entry shortcut ----------------------------------
     scalp_mode = env_loader.get_env("SCALP_MODE", "false").lower() == "true"
+    # SCALP_MODE の状態をログに残す
+    logging.info("SCALP_MODE is %s", "ON" if scalp_mode else "OFF")
     if scalp_mode:
         try:
             adx_series = indicators.get("adx")


### PR DESCRIPTION
## Summary
- log SCALP_MODE status in JobRunner startup
- log SCALP_MODE status when processing entries

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6841d70f669483338b6aa1036cb31342