### PR TITLE
Add scalping suppression based on ADX

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `SCALE_LOT_SIZE` … 追加エントリー時のロット数
 - `SCALP_MODE` … スキャルプエントリーを有効にするフラグ
 - `SCALP_ADX_MIN` … スキャルプ実行時に必要なADX値
+- `SCALP_SUPPRESS_ADX_MAX` … この値を超えるADXではSCALP_MODEを無効化
 - `SCALP_TP_PIPS` / `SCALP_SL_PIPS` … スキャルプ用の固定TP/SL幅
 - `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`)
 - `AI_MODEL` … OpenAI モデル名
@@ -62,6 +63,7 @@ ATR_RATIO: 1.8
 ```yaml
 SCALP_MODE: true
 SCALP_ADX_MIN: 35
+SCALP_SUPPRESS_ADX_MAX: 60
 SCALP_TP_PIPS: 4
 SCALP_SL_PIPS: 2
 SCALP_COND_TF: M1

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -195,11 +195,13 @@ SCALE_TRIGGER_ATR=0.5
 - MIN_EARLY_EXIT_PROFIT_PIPS: 早期撤退を検討する際に必要な最低利益幅
 - SCALP_MODE: スキャルピング用の固定TP/SLエントリーを有効化
 - SCALP_ADX_MIN: SCALP_MODE時に必要な最小ADX
+- SCALP_SUPPRESS_ADX_MAX: この値を超えるADXではSCALP_MODEをオフにする
 - SCALP_TP_PIPS / SCALP_SL_PIPS: スキャル時のTP/SL幅
 - SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
 - SCALP_MODE: スキャルプモードを有効にする
 - SCALP_ADX_MIN: スキャルプ実行に必要なADX下限
+- SCALP_SUPPRESS_ADX_MAX: この値を超えるADXではSCALP_MODEをオフにする
 - SCALP_TP_PIPS / SCALP_SL_PIPS: スキャルプ用のTP/SL幅
 - SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)
 ■ OANDA_MATCH_SEC

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -239,6 +239,7 @@ H1_BOUNCE_RANGE_PIPS=3           # H1安値/高値付近をブロックする範
 # === スキャルピング設定 ===
 SCALP_MODE=true                 # スキャルプモード有効化
 SCALP_ADX_MIN=45                 # スキャルプ時の最低ADX
+SCALP_SUPPRESS_ADX_MAX=70        # ADXがこの値を超える場合はスキャルプ無効
 SCALP_TP_PIPS=5                  # スキャルプ時のTP幅
 SCALP_SL_PIPS=3                  # スキャルプ時のSL幅
 SCALP_COND_TF=M1                 # 市場判定に使う時間足(M1/M5等)

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -168,8 +168,12 @@ def process_entry(
     if adx_series is not None and len(adx_series):
         adx_val = float(adx_series.iloc[-1]) if hasattr(adx_series, "iloc") else float(adx_series[-1])
     adx_min = float(env_loader.get_env("SCALP_ADX_MIN", "0"))
+    adx_max = float(env_loader.get_env("SCALP_SUPPRESS_ADX_MAX", "0"))
     if adx_val is not None:
-        os.environ["SCALP_MODE"] = "true" if adx_val >= adx_min else "false"
+        if adx_max > 0 and adx_val > adx_max:
+            os.environ["SCALP_MODE"] = "false"
+        else:
+            os.environ["SCALP_MODE"] = "true" if adx_val >= adx_min else "false"
 
     # --- Scalp entry shortcut ----------------------------------
     scalp_mode = env_loader.get_env("SCALP_MODE", "false").lower() == "true"

--- a/config/strategy.yml
+++ b/config/strategy.yml
@@ -10,5 +10,6 @@ reentry:
   trigger_pips_over_break: 1.5
 SCALP_MODE: false
 SCALP_ADX_MIN: 45
+SCALP_SUPPRESS_ADX_MAX: 70
 SCALP_TP_PIPS: 5
 SCALP_SL_PIPS: 3

--- a/tests/test_params_loader_scalp.py
+++ b/tests/test_params_loader_scalp.py
@@ -6,16 +6,18 @@ from config import params_loader
 class TestParamsLoaderScalp(unittest.TestCase):
     def test_scalp_keys_loaded(self):
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.yml')
-        tmp.write(b'SCALP_MODE: true\nSCALP_ADX_MIN: 35\n')
+        tmp.write(b'SCALP_MODE: true\nSCALP_ADX_MIN: 35\nSCALP_SUPPRESS_ADX_MAX: 70\n')
         tmp.close()
         try:
             params_loader.load_params(path=tmp.name, strategy_path=None, settings_path=None)
             self.assertEqual(os.environ.get("SCALP_MODE"), "True")
             self.assertEqual(os.environ.get("SCALP_ADX_MIN"), "35")
+            self.assertEqual(os.environ.get("SCALP_SUPPRESS_ADX_MAX"), "70")
         finally:
             os.unlink(tmp.name)
             os.environ.pop("SCALP_MODE", None)
             os.environ.pop("SCALP_ADX_MIN", None)
+            os.environ.pop("SCALP_SUPPRESS_ADX_MAX", None)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- disable scalping when ADX exceeds `SCALP_SUPPRESS_ADX_MAX`
- document new variable in README and ENV_README
- update default configs and strategy example
- extend unit tests for scalping mode
- verify params loader handles new variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684230de0e188333b935cf713d6caa0f