### PR TITLE
Fix docker build context issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+backend/logs/*.db*
+backend/logs/*.jsonl
+trades.db
+.git
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- add `.dockerignore` to avoid including large log files in Docker build context
- ignore compiled Python files and Git metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424921c50083339b37fb1abfbd84b1