### PR TITLE
Add scalping utilities with Bollinger bands

### DIFF
--- a/indicators/__init__.py
+++ b/indicators/__init__.py
@@ -1,0 +1,4 @@
+"""Indicator helpers for trading signals."""
+
+__all__ = ["patterns", "bollinger", "volatility"]
+

--- a/indicators/bollinger.py
+++ b/indicators/bollinger.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Bollinger Band utilities for multiple timeframes."""
+
+from typing import Sequence, Mapping, Dict
+
+try:
+    import pandas as pd
+except ImportError as e:  # pragma: no cover - dependency guard
+    raise ImportError(
+        "Pandas is required for indicator calculations."
+        " Install it with 'pip install pandas'."
+    ) from e
+
+
+def _calc_single(prices: Sequence[float], window: int = 20, num_std: float = 2.0) -> Dict[str, float]:
+    """Return latest Bollinger values as a dict."""
+    series = pd.Series(prices)
+    ma = series.rolling(window=window).mean()
+    std = series.rolling(window=window).std()
+    if ma.empty:
+        return {"middle": 0.0, "upper": 0.0, "lower": 0.0}
+    middle = ma.iloc[-1]
+    sd = std.iloc[-1]
+    return {"middle": middle, "upper": middle + num_std * sd, "lower": middle - num_std * sd}
+
+
+def multi_bollinger(
+    data: Mapping[str, Sequence[float]],
+    *,
+    window: int = 20,
+    num_std: float = 2.0,
+) -> Dict[str, Dict[str, float]]:
+    """Calculate Bollinger bands for each timeframe in ``data``."""
+    result: Dict[str, Dict[str, float]] = {}
+    for tf, prices in data.items():
+        result[tf] = _calc_single(prices, window=window, num_std=num_std)
+    return result
+
+
+__all__ = ["multi_bollinger"]
+

--- a/indicators/volatility.py
+++ b/indicators/volatility.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Utility functions for volatility measurements."""
+
+from typing import Sequence
+
+
+def candle_ranges(highs: Sequence[float], lows: Sequence[float]) -> list[float]:
+    """Return high-low range for each candle."""
+    return [h - l for h, l in zip(highs, lows)]
+
+
+def band_width(upper: Sequence[float], lower: Sequence[float]) -> list[float]:
+    """Return Bollinger band width for each value."""
+    return [u - l for u, l in zip(upper, lower)]
+
+
+__all__ = ["candle_ranges", "band_width"]
+

--- a/signals/scalp_strategy.py
+++ b/signals/scalp_strategy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Simple multi timeframe scalp utilities."""
+
+from typing import Sequence, Optional
+
+from indicators.bollinger import multi_bollinger
+
+
+def analyze_environment_m1(closes: Sequence[float]) -> str:
+    """Return ``"trend"`` or ``"range"`` based on Bollinger band width."""
+    data = {"M1": closes}
+    bands = multi_bollinger(data)["M1"]
+    width = bands["upper"] - bands["lower"]
+    if len(closes) < 2:
+        return "range"
+    prev = multi_bollinger({"M1": closes[:-1]})["M1"]
+    prev_width = prev["upper"] - prev["lower"]
+    return "trend" if width > prev_width else "range"
+
+
+def should_enter_trade_s10(
+    direction: str,
+    closes: Sequence[float],
+    bands_s10: dict,
+) -> Optional[str]:
+    """Return order side ``"long"`` or ``"short"`` if conditions met."""
+    if not closes:
+        return None
+    price = closes[-1]
+    upper = bands_s10["upper"]
+    lower = bands_s10["lower"]
+    if direction == "trend":
+        if price > upper:
+            return "long"
+        if price < lower:
+            return "short"
+    else:
+        if len(closes) < 2:
+            return None
+        prev = closes[-2]
+        if prev < lower and price > lower:
+            return "long"
+        if prev > upper and price < upper:
+            return "short"
+    return None
+
+
+__all__ = ["analyze_environment_m1", "should_enter_trade_s10"]
+

--- a/tests/test_scalp_strategy.py
+++ b/tests/test_scalp_strategy.py
@@ -1,0 +1,29 @@
+import pytest
+
+from indicators.bollinger import multi_bollinger
+from signals.scalp_strategy import analyze_environment_m1, should_enter_trade_s10
+
+
+def test_multi_bollinger_basic():
+    data = {
+        "M1": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "M5": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    }
+    res = multi_bollinger(data, window=3, num_std=1)
+    assert set(res.keys()) == {"M1", "M5"}
+    for v in res.values():
+        assert set(v.keys()) == {"middle", "upper", "lower"}
+
+
+def test_analyze_environment_m1():
+    prices = [1] * 10 + [2] * 10
+    mode = analyze_environment_m1(prices)
+    assert mode in {"trend", "range"}
+
+
+def test_should_enter_trade_s10_trend_breakout():
+    bands = {"upper": 1.5, "lower": 0.5}
+    side = should_enter_trade_s10("trend", [1.6], bands)
+    assert side == "long"
+
+


### PR DESCRIPTION
## Summary
- implement multi timeframe Bollinger indicator
- add volatility helpers
- create simple scalp strategy utilities
- export indicators in `__init__`
- test the new functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424ad15bd0833391414e71fa4e158a