### PR TITLE
Support S10 timeframe indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ exit is considered.
 `PULLBACK_PIPS` defines the offset used specifically when the price is within the pivot suppression range. The defaults are `2` and `3` respectively.
 `PULLBACK_ATR_RATIO` は ATR に基づくプルバック深度の調整係数で、1.0 なら ATR と同じ値、0.5 なら半分の深さを待ちます。
 `PIP_SIZE` specifies the pip value for the traded pair (e.g. `0.01` for JPY pairs) and is used when calculating the new volatility‑based pullback threshold.
-`TRADE_TIMEFRAMES` allows overriding which candle intervals are fetched for analysis. Specify as `M1:20,M5:50,M15:50,H1:120,H4:90,D:90` to cover short to long horizons.
+`TRADE_TIMEFRAMES` allows overriding which candle intervals are fetched for analysis. Specify as `S10:60,M1:20,M5:50,M15:50,H1:120,H4:90,D:90` to cover short to long horizons. `S10` denotes 10‑second candles.
 The system derives a dynamic pullback requirement from ATR, ADX and recent price swings. If indicators are missing, the fallback is `PULLBACK_PIPS`.
 `TP_BB_RATIO` scales the Bollinger band width when deriving a fallback take-profit target. For example, `0.6` uses 60% of the band width.
 `RANGE_ENTRY_OFFSET_PIPS` determines how far from the Bollinger band center price must be (in pips) before converting a market order to a LIMIT when `ENABLE_RANGE_ENTRY` is active. If the price is within this range, `entry_logic.py` places the order near the band high or low. The default is `3`.

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -197,7 +197,8 @@ SCALE_TRIGGER_ATR=0.5
 - SCALP_ADX_MIN: SCALP_MODE時に必要な最小ADX
 - SCALP_SUPPRESS_ADX_MAX: この値を超えるADXではSCALP_MODEをオフにする
 - SCALP_TP_PIPS / SCALP_SL_PIPS: スキャル時のTP/SL幅
-- SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)
+ - SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)。
+   S10 を指定すると 10 秒足データも取得する
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
 - SCALP_MODE: スキャルプモードを有効にする
 - SCALP_ADX_MIN: スキャルプ実行に必要なADX下限

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -37,7 +37,7 @@ SL_COOLDOWN_SEC=300              # SL後の再エントリー待機秒
 
 # === ローソク足設定 ===
 CANDLE_GRANULARITY=M5            # 主軸となる足種
-TRADE_TIMEFRAMES=M1:20,M5:50,M15:50,H1:120,H4:90,D:90  # 取得する時間足
+TRADE_TIMEFRAMES=S10:60,M1:20,M5:50,M15:50,H1:120,H4:90,D:90  # 取得する時間足
 
 # === Exitフィルタ ===
 RSI_EXIT_LOWER=30                # RSIがこの値以下で利確検討

--- a/backend/market_data/candle_fetcher.py
+++ b/backend/market_data/candle_fetcher.py
@@ -95,6 +95,11 @@ def fetch_multiple_timeframes(instrument=None, timeframes=None):
             "D": 90,    # 日足
         }
 
+    scalp_tf = os.getenv("SCALP_COND_TF", "").upper()
+    if scalp_tf and scalp_tf not in timeframes:
+        default_count = 60
+        timeframes[scalp_tf] = default_count
+
     candles_by_timeframe = {}
     for granularity, count in timeframes.items():
         fetch_gran = "D" if granularity == "D1" else granularity

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -224,6 +224,7 @@ class JobRunner:
         self.sl_cooldown_sec = SL_COOLDOWN_SEC
         # Storage for latest indicators by timeframe
         self.indicators_M1: dict | None = None
+        self.indicators_S10: dict | None = None
         self.indicators_M5: dict | None = None
         self.indicators_M15: dict | None = None
         self.indicators_H1: dict | None = None
@@ -738,6 +739,7 @@ class JobRunner:
                     # ---- Chart pattern detection per timeframe ----
                     self.patterns_by_tf = pattern_scanner.scan(candles_dict, PATTERN_NAMES)
 
+                    candles_s10 = candles_dict.get("S10", [])
                     candles_m1 = candles_dict.get("M1", [])
                     candles_m5 = candles_dict.get("M5", [])
                     candles_h1 = candles_dict.get("H1", [])
@@ -758,6 +760,7 @@ class JobRunner:
                         candles_dict,
                         allow_incomplete=True,
                     )
+                    self.indicators_S10 = indicators_multi.get("S10")
                     self.indicators_M1 = indicators_multi.get("M1")
                     self.indicators_M5 = indicators_multi.get("M5")
                     self.indicators_M15 = indicators_multi.get("M15")


### PR DESCRIPTION
## Summary
- support retrieving the scalp condition timeframe from settings
- ensure S10 data is fetched automatically
- store S10 indicators in JobRunner
- update docs and default settings
- test the `_get_cond_indicators` method for M1 and S10 cases

## Testing
- `pytest backend/tests/test_scalp_cond_tf.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842343dda908333954d86af60847a2f