### PR TITLE
Implement ADX-based strategy switch

### DIFF
--- a/signals/adx_strategy.py
+++ b/signals/adx_strategy.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""ADX値に基づくシンプルなストラテジー切換ユーティリティ."""
+
+from typing import Sequence, Optional
+
+from indicators.bollinger import multi_bollinger
+from signals.scalp_strategy import analyze_environment_m1, should_enter_trade_s10
+
+
+def choose_strategy(adx_value: float) -> str:
+    """ADXの値からモードを判定."""
+    if adx_value < 20:
+        return "none"
+    if adx_value < 30:
+        return "scalp"
+    return "trend_follow"
+
+
+def entry_signal(
+    adx_value: float,
+    closes_m1: Sequence[float],
+    closes_s10: Sequence[float],
+) -> Optional[str]:
+    """ADXに応じたトレード方向を組織."""
+    mode = choose_strategy(adx_value)
+    if mode == "scalp":
+        direction = analyze_environment_m1(closes_m1)
+        bands = multi_bollinger({"S10": closes_s10})["S10"]
+        return should_enter_trade_s10(direction, closes_s10, bands)
+    if mode == "trend_follow":
+        if len(closes_m1) < 2:
+            return None
+        last = closes_m1[-1]
+        prev = closes_m1[-2]
+        if last > prev:
+            return "long"
+        if last < prev:
+            return "short"
+    return None
+
+
+__all__ = ["choose_strategy", "entry_signal"]

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -1,0 +1,23 @@
+from signals.adx_strategy import choose_strategy, entry_signal
+
+
+def test_choose_strategy():
+    assert choose_strategy(15) == "none"
+    assert choose_strategy(25) == "scalp"
+    assert choose_strategy(35) == "trend_follow"
+
+
+def test_entry_signal_scalp():
+    adx = 25
+    closes_m1 = [1] * 20 + [2]
+    closes_s10 = list(range(20)) + [50]
+    side = entry_signal(adx, closes_m1, closes_s10)
+    assert side == "long"
+
+
+def test_entry_signal_trend():
+    adx = 40
+    closes_m1 = [1, 2, 3]
+    closes_s10 = [1, 2, 3]
+    side = entry_signal(adx, closes_m1, closes_s10)
+    assert side == "long"


### PR DESCRIPTION
## Summary
- add `adx_strategy` module selecting scalp or trend modes
- include basic tests covering the selector logic

## Testing
- `pytest -q tests/test_adx_mode.py`
- `pytest -q` *(fails: KeyboardInterrupt after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68424df379cc8333ac206409d64f022c