### PR TITLE
Implement ADX threshold configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `SCALP_SUPPRESS_ADX_MAX` … この値を超えるADXではSCALP_MODEを無効化
 - `SCALP_TP_PIPS` / `SCALP_SL_PIPS` … スキャルプ用の固定TP/SL幅
 - `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`)
+- `ADX_SCALP_MIN` … ADX がこの値以上でスキャルプモード
+- `ADX_TREND_MIN` … ADX がこの値以上でトレンドフォローモード
 - `AI_MODEL` … OpenAI モデル名
 - `LINE_CHANNEL_TOKEN` / `LINE_USER_ID` … LINE 通知に使用する認証情報
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -245,3 +245,5 @@ SCALP_SUPPRESS_ADX_MAX=70        # ADXがこの値を超える場合はスキャ
 SCALP_TP_PIPS=5                  # スキャルプ時のTP幅
 SCALP_SL_PIPS=3                  # スキャルプ時のSL幅
 SCALP_COND_TF=S10                 # 市場判定に使う時間足(M1/M5等)
+ADX_SCALP_MIN=20                 # スキャルプ開始に必要なADX
+ADX_TREND_MIN=30                 # トレンド移行に必要なADX

--- a/docs/adx_strategy.md
+++ b/docs/adx_strategy.md
@@ -1,0 +1,19 @@
+# entry_signal の使い方
+
+`entry_signal` 関数は ADX 値からスキャルプ・トレンドフォローを
+自動的に切り替えるシンプルなユーティリティです。主な環境変数は
+次の 2 つです。
+
+- `ADX_SCALP_MIN` … この値以上で `scalp` モードとなります
+- `ADX_TREND_MIN` … この値以上で `trend_follow` モードとなります
+
+デフォルトではそれぞれ 20、30 に設定されています。閾値を変更
+したい場合は `backend/config/settings.env` で上書きしてください。
+
+```
+ADX_SCALP_MIN=25
+ADX_TREND_MIN=40
+```
+
+これらを変更後にモジュールを再読み込みすると `choose_strategy`
+の判定基準も自動的に切り替わります。

--- a/signals/adx_strategy.py
+++ b/signals/adx_strategy.py
@@ -4,15 +4,21 @@ from __future__ import annotations
 
 from typing import Sequence, Optional
 
+from backend.utils import env_loader
+
 from indicators.bollinger import multi_bollinger
 from signals.scalp_strategy import analyze_environment_m1, should_enter_trade_s10
 
 
+ADX_SCALP_MIN = float(env_loader.get_env("ADX_SCALP_MIN", "20"))
+ADX_TREND_MIN = float(env_loader.get_env("ADX_TREND_MIN", "30"))
+
+
 def choose_strategy(adx_value: float) -> str:
     """ADXの値からモードを判定."""
-    if adx_value < 20:
+    if adx_value < ADX_SCALP_MIN:
         return "none"
-    if adx_value < 30:
+    if adx_value < ADX_TREND_MIN:
         return "scalp"
     return "trend_follow"
 
@@ -40,4 +46,9 @@ def entry_signal(
     return None
 
 
-__all__ = ["choose_strategy", "entry_signal"]
+__all__ = [
+    "choose_strategy",
+    "entry_signal",
+    "ADX_SCALP_MIN",
+    "ADX_TREND_MIN",
+]

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -1,23 +1,60 @@
-from signals.adx_strategy import choose_strategy, entry_signal
+import importlib
+import os
+import sys
+import types
 
 
-def test_choose_strategy():
-    assert choose_strategy(15) == "none"
-    assert choose_strategy(25) == "scalp"
-    assert choose_strategy(35) == "trend_follow"
+def _reload_module():
+    import signals.adx_strategy as mod
+    return importlib.reload(mod)
+
+
+def test_choose_strategy_default():
+    os.environ.pop("ADX_SCALP_MIN", None)
+    os.environ.pop("ADX_TREND_MIN", None)
+    mod = _reload_module()
+    assert mod.ADX_SCALP_MIN == 20.0
+    assert mod.ADX_TREND_MIN == 30.0
+    assert mod.choose_strategy(15) == "none"
+    assert mod.choose_strategy(25) == "scalp"
+    assert mod.choose_strategy(35) == "trend_follow"
+
+
+def test_choose_strategy_env_override():
+    os.environ["ADX_SCALP_MIN"] = "10"
+    os.environ["ADX_TREND_MIN"] = "25"
+    sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+    mod = _reload_module()
+    assert mod.ADX_SCALP_MIN == 10.0
+    assert mod.ADX_TREND_MIN == 25.0
+    assert mod.choose_strategy(9) == "none"
+    assert mod.choose_strategy(15) == "scalp"
+    assert mod.choose_strategy(30) == "trend_follow"
+    os.environ.pop("ADX_SCALP_MIN")
+    os.environ.pop("ADX_TREND_MIN")
 
 
 def test_entry_signal_scalp():
+    os.environ["ADX_SCALP_MIN"] = "20"
+    os.environ["ADX_TREND_MIN"] = "40"
+    mod = _reload_module()
     adx = 25
     closes_m1 = [1] * 20 + [2]
     closes_s10 = list(range(20)) + [50]
-    side = entry_signal(adx, closes_m1, closes_s10)
+    side = mod.entry_signal(adx, closes_m1, closes_s10)
     assert side == "long"
+    os.environ.pop("ADX_SCALP_MIN")
+    os.environ.pop("ADX_TREND_MIN")
 
 
 def test_entry_signal_trend():
-    adx = 40
+    os.environ["ADX_SCALP_MIN"] = "20"
+    os.environ["ADX_TREND_MIN"] = "40"
+    mod = _reload_module()
+    adx = 45
     closes_m1 = [1, 2, 3]
     closes_s10 = [1, 2, 3]
-    side = entry_signal(adx, closes_m1, closes_s10)
+    side = mod.entry_signal(adx, closes_m1, closes_s10)
     assert side == "long"
+    os.environ.pop("ADX_SCALP_MIN")
+    os.environ.pop("ADX_TREND_MIN")


### PR DESCRIPTION
## Summary
- make ADX thresholds configurable via `ADX_SCALP_MIN` and `ADX_TREND_MIN`
- document new variables and usage in `docs/adx_strategy.md`
- update README with the new environment variable descriptions
- load new variables in `signals.adx_strategy`
- test module reload with env overrides

## Testing
- `pytest tests/test_adx_mode.py -q`
- `pytest -q` *(full suite)*

------
https://chatgpt.com/codex/tasks/task_e_684253724f148333b2f99dc2d9df06ad