### PR TITLE
Switch to ADX_SCALP_MIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `TREND_ADX_THRESH` … トレンド判定に使う ADX のしきい値 (デフォルト 20)
 - `SCALE_LOT_SIZE` … 追加エントリー時のロット数
 - `SCALP_MODE` … スキャルプエントリーを有効にするフラグ
-- `SCALP_ADX_MIN` … スキャルプ実行時に必要なADX値
 - `SCALP_SUPPRESS_ADX_MAX` … この値を超えるADXではSCALP_MODEを無効化
 - `SCALP_TP_PIPS` / `SCALP_SL_PIPS` … スキャルプ用の固定TP/SL幅
 - `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`)
@@ -64,7 +63,7 @@ ATR_RATIO: 1.8
 スキャルピング用の設定例は以下の通りです。
 ```yaml
 SCALP_MODE: true
-SCALP_ADX_MIN: 35
+ADX_SCALP_MIN: 35
 SCALP_SUPPRESS_ADX_MAX: 60
 SCALP_TP_PIPS: 4
 SCALP_SL_PIPS: 2

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -196,14 +196,14 @@ SCALE_TRIGGER_ATR=0.5
 - TREND_ADX_THRESH: トレンド判定に用いるADXの基準値。プロンプトの条件とローカル判定で参照される
 - MIN_EARLY_EXIT_PROFIT_PIPS: 早期撤退を検討する際に必要な最低利益幅
 - SCALP_MODE: スキャルピング用の固定TP/SLエントリーを有効化
-- SCALP_ADX_MIN: SCALP_MODE時に必要な最小ADX
+- ADX_SCALP_MIN: SCALP_MODE時に必要な最小ADX
 - SCALP_SUPPRESS_ADX_MAX: この値を超えるADXではSCALP_MODEをオフにする
 - SCALP_TP_PIPS / SCALP_SL_PIPS: スキャル時のTP/SL幅
  - SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)。
    S10 を指定すると 10 秒足データも取得する
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
 - SCALP_MODE: スキャルプモードを有効にする
-- SCALP_ADX_MIN: スキャルプ実行に必要なADX下限
+- ADX_SCALP_MIN: スキャルプ実行に必要なADX下限
 - SCALP_SUPPRESS_ADX_MAX: この値を超えるADXではSCALP_MODEをオフにする
 - SCALP_TP_PIPS / SCALP_SL_PIPS: スキャルプ用のTP/SL幅
 - SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -240,10 +240,9 @@ H1_BOUNCE_RANGE_PIPS=3           # H1安値/高値付近をブロックする範
 
 # === スキャルピング設定 ===
 SCALP_MODE=true                 # スキャルプモード有効化
-SCALP_ADX_MIN=20                 # スキャルプ時の最低ADX
+ADX_SCALP_MIN=20                 # スキャルプ開始に必要なADX
 SCALP_SUPPRESS_ADX_MAX=70        # ADXがこの値を超える場合はスキャルプ無効
 SCALP_TP_PIPS=5                  # スキャルプ時のTP幅
 SCALP_SL_PIPS=3                  # スキャルプ時のSL幅
 SCALP_COND_TF=S10                 # 市場判定に使う時間足(M1/M5等)
-ADX_SCALP_MIN=20                 # スキャルプ開始に必要なADX
 ADX_TREND_MIN=40                 # トレンド移行に必要なADX

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -167,7 +167,7 @@ def process_entry(
     adx_val = None
     if adx_series is not None and len(adx_series):
         adx_val = float(adx_series.iloc[-1]) if hasattr(adx_series, "iloc") else float(adx_series[-1])
-    adx_min = float(env_loader.get_env("SCALP_ADX_MIN", "0"))
+    adx_min = float(env_loader.get_env("ADX_SCALP_MIN", "0"))
     adx_max = float(env_loader.get_env("SCALP_SUPPRESS_ADX_MAX", "0"))
     if adx_val is not None:
         if adx_max > 0 and adx_val > adx_max:
@@ -188,7 +188,7 @@ def process_entry(
                     adx_val = float(adx_series.iloc[-1])
                 else:
                     adx_val = float(adx_series[-1])
-            adx_min = float(env_loader.get_env("SCALP_ADX_MIN", "0"))
+            adx_min = float(env_loader.get_env("ADX_SCALP_MIN", "0"))
             if adx_val is not None and adx_val >= adx_min:
                 side = (market_cond or {}).get("trend_direction", "long")
                 params = {

--- a/backend/tests/test_scalp_mode.py
+++ b/backend/tests/test_scalp_mode.py
@@ -61,7 +61,7 @@ class TestScalpMode(unittest.TestCase):
 
         os.environ["PIP_SIZE"] = "0.01"
         os.environ["SCALP_MODE"] = "true"
-        os.environ["SCALP_ADX_MIN"] = "30"
+        os.environ["ADX_SCALP_MIN"] = "30"
         os.environ["SCALP_TP_PIPS"] = "2"
         os.environ["SCALP_SL_PIPS"] = "1"
 
@@ -76,7 +76,7 @@ class TestScalpMode(unittest.TestCase):
         for key in [
             "PIP_SIZE",
             "SCALP_MODE",
-            "SCALP_ADX_MIN",
+            "ADX_SCALP_MIN",
             "SCALP_SUPPRESS_ADX_MAX",
             "SCALP_TP_PIPS",
             "SCALP_SL_PIPS",

--- a/config/strategy.yml
+++ b/config/strategy.yml
@@ -9,7 +9,7 @@ reentry:
   enable: true
   trigger_pips_over_break: 1.5
 SCALP_MODE: false
-SCALP_ADX_MIN: 45
+  ADX_SCALP_MIN: 45
 SCALP_SUPPRESS_ADX_MAX: 70
 SCALP_TP_PIPS: 5
 SCALP_SL_PIPS: 3

--- a/tests/test_params_loader_scalp.py
+++ b/tests/test_params_loader_scalp.py
@@ -6,17 +6,17 @@ from config import params_loader
 class TestParamsLoaderScalp(unittest.TestCase):
     def test_scalp_keys_loaded(self):
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.yml')
-        tmp.write(b'SCALP_MODE: true\nSCALP_ADX_MIN: 35\nSCALP_SUPPRESS_ADX_MAX: 70\n')
+        tmp.write(b'SCALP_MODE: true\nADX_SCALP_MIN: 35\nSCALP_SUPPRESS_ADX_MAX: 70\n')
         tmp.close()
         try:
             params_loader.load_params(path=tmp.name, strategy_path=None, settings_path=None)
             self.assertEqual(os.environ.get("SCALP_MODE"), "True")
-            self.assertEqual(os.environ.get("SCALP_ADX_MIN"), "35")
+            self.assertEqual(os.environ.get("ADX_SCALP_MIN"), "35")
             self.assertEqual(os.environ.get("SCALP_SUPPRESS_ADX_MAX"), "70")
         finally:
             os.unlink(tmp.name)
             os.environ.pop("SCALP_MODE", None)
-            os.environ.pop("SCALP_ADX_MIN", None)
+            os.environ.pop("ADX_SCALP_MIN", None)
             os.environ.pop("SCALP_SUPPRESS_ADX_MAX", None)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- unify environment variable names for scalping ADX threshold
- adjust tests and docs accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425b7ff3c483338b8ebb4f1a97a2e3