### PR TITLE
Enable configurable scalp environment timeframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `SCALP_MODE` … スキャルプエントリーを有効にするフラグ
 - `SCALP_SUPPRESS_ADX_MAX` … この値を超えるADXではSCALP_MODEを無効化
 - `SCALP_TP_PIPS` / `SCALP_SL_PIPS` … ボリンジャーバンドが取得できない場合に使う固定TP/SL幅
-- `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`)
+- `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`). この値でトレンド/レンジ判定に用いる足を変更できます
 - `ADX_SCALP_MIN` … ADX がこの値以上でスキャルプモード
 - `ADX_TREND_MIN` … ADX がこの値以上でトレンドフォローモード
 - `AI_MODEL` … OpenAI モデル名

--- a/signals/adx_strategy.py
+++ b/signals/adx_strategy.py
@@ -7,7 +7,7 @@ from typing import Sequence, Optional
 from backend.utils import env_loader
 
 from indicators.bollinger import multi_bollinger
-from signals.scalp_strategy import analyze_environment_m1, should_enter_trade_s10
+from signals.scalp_strategy import analyze_environment_tf, analyze_environment_m1, should_enter_trade_s10
 
 
 ADX_SCALP_MIN = float(env_loader.get_env("ADX_SCALP_MIN", "20"))
@@ -31,7 +31,11 @@ def entry_signal(
     """ADXに応じたトレード方向を組織."""
     mode = choose_strategy(adx_value)
     if mode == "scalp":
-        direction = analyze_environment_m1(closes_m1)
+        tf = env_loader.get_env("SCALP_COND_TF", "M1").upper()
+        if tf == "S10":
+            direction = analyze_environment_tf(closes_s10, tf)
+        else:
+            direction = analyze_environment_tf(closes_m1, tf)
         bands = multi_bollinger({"S10": closes_s10})["S10"]
         return should_enter_trade_s10(direction, closes_s10, bands)
     if mode == "trend_follow":

--- a/tests/test_scalp_strategy.py
+++ b/tests/test_scalp_strategy.py
@@ -1,7 +1,7 @@
 import pytest
 
 from indicators.bollinger import multi_bollinger
-from signals.scalp_strategy import analyze_environment_m1, should_enter_trade_s10
+from signals.scalp_strategy import analyze_environment_m1, analyze_environment_tf, should_enter_trade_s10
 
 
 def test_multi_bollinger_basic():
@@ -19,6 +19,12 @@ def test_analyze_environment_m1():
     prices = [1] * 10 + [2] * 10
     mode = analyze_environment_m1(prices)
     assert mode in {"trend", "range"}
+
+
+def test_analyze_environment_tf_env_override(monkeypatch):
+    prices = [1] * 10 + [2] * 10
+    monkeypatch.setenv("SCALP_COND_TF", "M1")
+    assert analyze_environment_tf(prices) in {"trend", "range"}
 
 
 def test_should_enter_trade_s10_trend_breakout():


### PR DESCRIPTION
## Summary
- allow scalp environment timeframe to be set via `SCALP_COND_TF`
- use that timeframe in `entry_signal`
- document the setting
- test the new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684260b1e3b48333badeba32308432ab