### PR TITLE
Add aggressive scalp tuning doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ TRADES_DB_PATH=trades-002.db
 エントリーフィルタの詳細は `docs/entry_filter.md` を参照してください。
 高位足の使い方に関する補足は `docs/higher_tf_strategy.md` を参照してください。
 低ボラ時のエントリー仕様は `docs/low_vol_entry.md` を参照してください。
+より積極的にスキャルプするための設定例は `docs/aggressive_scalp.md` にまとめています。
    `RANGE_CENTER_BLOCK_PCT` controls how close to the Bollinger band center price
-   can be when ADX is below `ADX_RANGE_THRESHOLD`. Set to `0.3` (30%) to block
-   entries near the middle of a range, helping suppress counter-trend trades.
+    can be when ADX is below `ADX_RANGE_THRESHOLD`. Set to `0.3` (30%) to block
+    entries near the middle of a range, helping suppress counter-trend trades.
    `BAND_WIDTH_THRESH_PIPS` defines the Bollinger band width that triggers
    range mode regardless of ADX. When the width falls below this value the system
    treats the market as ranging and the AI prompt notes that *BB width is

--- a/docs/aggressive_scalp.md
+++ b/docs/aggressive_scalp.md
@@ -1,0 +1,26 @@
+# 積極的なスキャルプ設定
+
+スキャルプモードでより頻繁にエントリーしたい場合は、以下の環境変数を調整します。
+
+## 推奨値
+
+- `ENABLE_RANGE_ENTRY=true`  
+  ADX が低くてもレンジ内でエントリーを許可します。
+- `BAND_WIDTH_THRESH_PIPS=0`  
+  ボリンジャーバンド幅によるレンジ判定を無効化します。
+- `SCALP_ADX_MIN=20`  
+  必要なADXしきい値を引き下げます。
+- `BYPASS_PULLBACK_ADX_MIN=25`  
+  これを超えるとプルバック待機を省略します。
+- `AI_COOLDOWN_SEC_FLAT=15`  
+  ノーポジ時のAIクールダウンを短縮します。
+- `MIN_RRR=1.0`
+- `ENFORCE_RRR=false`
+- `SCALP_TP_PIPS=4`
+- `SCALP_SL_PIPS=4`
+
+## 反映手順
+
+1. `backend/config/settings.env` に上記を追記または変更します。
+2. `docker compose restart piphawk-runner` でコンテナを再起動します。
+3. 起動ログで新しい値が読み込まれていることを確認します。


### PR DESCRIPTION
## Summary
- document how to adjust scalping parameters for more active trading
- reference the new doc from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842927cb71883338a94e68b69231074