### PR TITLE
Fix missing signals in job runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend /app/backend
 COPY analysis /app/analysis
+COPY signals /app/signals
 
 # create an empty SQLite database if not provided
 RUN touch /app/trades.db

--- a/backend/Dockerfile.job
+++ b/backend/Dockerfile.job
@@ -16,6 +16,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # backendごと/appにコピー
 COPY backend /app/backend
 COPY analysis /app/analysis
+COPY signals /app/signals
 
 ENV PYTHONUNBUFFERED=1
 ENV TZ=Asia/Tokyo


### PR DESCRIPTION
## Summary
- include `signals` directory when building Docker images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842907c48b88333b7b5fb0bd09f1eed