### PR TITLE
Fix Dockerfile to include indicators module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend /app/backend
 COPY analysis /app/analysis
 COPY signals /app/signals
+COPY indicators /app/indicators
 
 # create an empty SQLite database if not provided
 RUN touch /app/trades.db


### PR DESCRIPTION
## Summary
- include `indicators` directory in Docker build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684295f7946483339d9f098e5bfef4fa