### PR TITLE
Fix determine_trade_mode for trade runner

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -811,7 +811,7 @@ class JobRunner:
                         for c in candles_tf
                         if c.get("mid")
                     ]
-                    self.trade_mode = determine_trade_mode(adx_val, closes_tf, tf=tf_mode)
+                    self.trade_mode = determine_trade_mode(adx_val, closes_tf, scalp_tf=tf_mode)
                     logger.info("Current trade mode: %s", self.trade_mode)
 
                     # チェック：保留LIMIT注文の更新

--- a/signals/adx_strategy.py
+++ b/signals/adx_strategy.py
@@ -41,27 +41,22 @@ def determine_trade_mode(
     """市場状態からトレードモードを返す."""
     scalp_tf = (scalp_tf or SCALP_COND_TF).upper()
     trend_tf = (trend_tf or TREND_COND_TF).upper()
-    mode = choose_strategy(adx_value)
-    if mode == "trend_follow":
-        ref = closes_trend if closes_trend is not None else closes_scalp
-        if analyze_environment_tf(ref, trend_tf) == "range":
-            return "scalp"
     logger = logging.getLogger(__name__)
-    env = analyze_environment_tf(closes_tf, tf)
-
-    mode = choose_strategy(adx_value)
     reason = ""
+    mode = choose_strategy(adx_value)
 
     if mode == "none":
         reason = f"ADX {adx_value:.1f} < {ADX_SCALP_MIN}"
     elif mode == "scalp":
         reason = f"{ADX_SCALP_MIN} <= ADX {adx_value:.1f} < {ADX_TREND_MIN}"
     else:  # trend_follow
+        ref = closes_trend if closes_trend is not None else closes_scalp
+        env = analyze_environment_tf(ref, trend_tf)
         if env == "range":
-            reason = f"{tf or 'M1'} range despite ADX {adx_value:.1f} >= {ADX_TREND_MIN}"
+            reason = f"{trend_tf} range despite ADX {adx_value:.1f} >= {ADX_TREND_MIN}"
             mode = "scalp"
         else:
-            reason = f"ADX {adx_value:.1f} >= {ADX_TREND_MIN} and {tf or 'M1'} trend"
+            reason = f"ADX {adx_value:.1f} >= {ADX_TREND_MIN} and {trend_tf} trend"
 
     logger.info("determine_trade_mode -> %s (%s)", mode, reason)
     return mode

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -58,3 +58,32 @@ def test_entry_signal_trend():
     assert side == "long"
     os.environ.pop("ADX_SCALP_MIN")
     os.environ.pop("ADX_TREND_MIN")
+
+
+def test_determine_trade_mode(monkeypatch):
+    os.environ["ADX_SCALP_MIN"] = "20"
+    os.environ["ADX_TREND_MIN"] = "40"
+    mod = _reload_module()
+
+    monkeypatch.setattr(mod, "analyze_environment_tf", lambda closes, tf: "trend")
+    assert (
+        mod.determine_trade_mode(45, [1, 2, 3], [1, 2, 3], scalp_tf="M1", trend_tf="M5")
+        == "trend_follow"
+    )
+
+    monkeypatch.setattr(mod, "analyze_environment_tf", lambda closes, tf: "range")
+    assert (
+        mod.determine_trade_mode(45, [1, 2, 3], [1, 2, 3], scalp_tf="M1", trend_tf="M5")
+        == "scalp"
+    )
+
+    assert (
+        mod.determine_trade_mode(15, [1, 2], scalp_tf="M1", trend_tf="M5") == "none"
+    )
+
+    assert (
+        mod.determine_trade_mode(25, [1, 2], scalp_tf="M1", trend_tf="M5") == "scalp"
+    )
+
+    os.environ.pop("ADX_SCALP_MIN")
+    os.environ.pop("ADX_TREND_MIN")


### PR DESCRIPTION
## Summary
- repair determine_trade_mode logic
- use new argument in job runner
- cover determine_trade_mode in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a19b90a88333a27963b760b0bb0a