### PR TITLE
Handle zero band width threshold

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -253,7 +253,11 @@ def get_market_condition(context: dict, higher_tf: dict | None = None) -> dict:
     bw_thresh = float(env_loader.get_env("BAND_WIDTH_THRESH_PIPS", "4"))
     adx_base = float(env_loader.get_env("ADX_RANGE_THRESHOLD", "25"))
     coeff = float(env_loader.get_env("ADX_DYNAMIC_COEFF", "0"))
-    width_ratio = ((bw_pips - bw_thresh) / bw_thresh) if bw_pips is not None else 0.0
+    width_ratio = (
+        (bw_pips - bw_thresh) / bw_thresh
+        if bw_pips is not None and bw_thresh != 0
+        else 0.0
+    )
     adx_dynamic_thresh = adx_base * (1 + coeff * width_ratio)
 
     # DI cross detection for trend reversal

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -535,7 +535,11 @@ def pass_entry_filter(
     # --- Dynamic ADX threshold based on BB width -----------------------
     adx_base = float(os.getenv("ADX_RANGE_THRESHOLD", "25"))
     coeff = float(os.getenv("ADX_DYNAMIC_COEFF", "0"))
-    width_ratio = ((bw_pips - bw_thresh) / bw_thresh) if bw_pips is not None else 0.0
+    width_ratio = (
+        (bw_pips - bw_thresh) / bw_thresh
+        if bw_pips is not None and bw_thresh != 0
+        else 0.0
+    )
     adx_thresh = adx_base * (1 + coeff * width_ratio)
     range_mode = latest_adx is not None and latest_adx < adx_thresh
 


### PR DESCRIPTION
## Summary
- avoid division by zero in signal filter
- apply same safe logic to openai analysis

## Testing
- `pytest tests/test_trend_adx_thresh.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842acc0f110833385095bd0b4d36bc9