### PR TITLE
Enable automatic mode switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `MIN_RRR` … 最低リスクリワード比。`ENFORCE_RRR` と併用すると常にこの比率を保ちます
 - `TREND_ADX_THRESH` … トレンド判定に使う ADX のしきい値 (デフォルト 20)
 - `SCALE_LOT_SIZE` … 追加エントリー時のロット数
-- `SCALP_MODE` … スキャルプエントリーを有効にするフラグ
-- `SCALP_SUPPRESS_ADX_MAX` … この値を超えるADXではSCALP_MODEを無効化
+- `SCALP_SUPPRESS_ADX_MAX` … この値を超えるADXではスキャルプを無効化
 - `SCALP_TP_PIPS` / `SCALP_SL_PIPS` … ボリンジャーバンドが取得できない場合に使う固定TP/SL幅
 - `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`). この値でトレンド/レンジ判定に用いる足を変更できます
 - `TREND_COND_TF` … トレンドフォロー時の市場判定に使う時間足 (デフォルト `M5`)
@@ -64,7 +63,6 @@ ATR_RATIO: 1.8
 
 スキャルピング用の設定例は以下の通りです。
 ```yaml
-SCALP_MODE: true
 ADX_SCALP_MIN: 35
 SCALP_SUPPRESS_ADX_MAX: 60
 SCALP_TP_PIPS: 4

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -195,7 +195,7 @@ SCALE_TRIGGER_ATR=0.5
 - ALLOW_DELAYED_ENTRY: トレンドが過熱している場合に "wait" を返させ、押し目到来で再問い合わせする
 - TREND_ADX_THRESH: トレンド判定に用いるADXの基準値。プロンプトの条件とローカル判定で参照される
 - MIN_EARLY_EXIT_PROFIT_PIPS: 早期撤退を検討する際に必要な最低利益幅
-- SCALP_MODE: スキャルピング用の固定TP/SLエントリーを有効化
+ - SCALP_MODE: スキャルプモードを強制したい場合に true/false を指定
 - ADX_SCALP_MIN: SCALP_MODE時に必要な最小ADX
 - SCALP_SUPPRESS_ADX_MAX: この値を超えるADXではSCALP_MODEをオフにする
  - SCALP_TP_PIPS / SCALP_SL_PIPS: ボリンジャーバンドが使えない場合の固定TP/SL幅
@@ -204,7 +204,7 @@ SCALE_TRIGGER_ATR=0.5
 - TREND_COND_TF: トレンドフォロー時に市場判定へ使う時間足 (デフォルト M5)
 - SCALP_OVERRIDE_RANGE: true でレンジ判定を無視してスキャルを実行
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
-- SCALP_MODE: スキャルプモードを有効にする
+ - SCALP_MODE: スキャルプモードを強制したい場合に true/false を指定
 - ADX_SCALP_MIN: スキャルプ実行に必要なADX下限
 - SCALP_SUPPRESS_ADX_MAX: この値を超えるADXではSCALP_MODEをオフにする
  - SCALP_TP_PIPS / SCALP_SL_PIPS: ボリバン幅を参照できないときのTP/SL

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -239,7 +239,7 @@ USE_INCOMPLETE_BARS=false          # 未確定足の利用可否
 H1_BOUNCE_RANGE_PIPS=3           # H1安値/高値付近をブロックする範囲
 
 # === スキャルピング設定 ===
-SCALP_MODE=true                 # スキャルプモード有効化
+SCALP_MODE=                     # 自動判定に任せる場合は空欄のまま
 ADX_SCALP_MIN=13                 # スキャルプ開始に必要なADX
 SCALP_SUPPRESS_ADX_MAX=70        # ADXがこの値を超える場合はスキャルプ無効
 SCALP_TP_PIPS=5                  # スキャルプ時のTP幅

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -273,14 +273,14 @@ class JobRunner:
             bool(token),
             bool(user_id),
         )
-        # SCALP_MODE の状態を起動時に記録
+        # 初期の SCALP_MODE 設定をログへ記録
         scalp_active = env_loader.get_env("SCALP_MODE", "false").lower() == "true"
-        logger.info("SCALP_MODE is %s", "ON" if scalp_active else "OFF")
+        logger.info("Initial SCALP_MODE is %s", "ON" if scalp_active else "OFF")
 
     def _get_cond_indicators(self) -> dict:
         """Return indicators for market condition check."""
-        tf = "M5"
-        if env_loader.get_env("SCALP_MODE", "false").lower() == "true":
+        tf = env_loader.get_env("TREND_COND_TF", "M5").upper()
+        if self.trade_mode == "scalp":
             tf = env_loader.get_env("SCALP_COND_TF", self.scalp_cond_tf).upper()
         return getattr(self, f"indicators_{tf}", {}) or {}
 

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -233,23 +233,18 @@ def process_entry(
             if hasattr(adx_series, "iloc")
             else float(adx_series[-1])
         )
-    scalp_env = os.getenv("SCALP_MODE")
     reason = ""
-    if scalp_env in ("true", "false"):
-        trade_mode = "scalp" if scalp_env == "true" else "trend_follow"
-        reason = f"override SCALP_MODE={scalp_env}"
+    trade_mode = choose_strategy(adx_val or 0.0)
+    min_scalp = float(env_loader.get_env("ADX_SCALP_MIN", "20"))
+    min_trend = float(env_loader.get_env("ADX_TREND_MIN", "30"))
+    if adx_val is None:
+        reason = "ADX unavailable"
+    elif trade_mode == "none":
+        reason = f"ADX {adx_val:.1f} < {min_scalp}"
+    elif trade_mode == "scalp":
+        reason = f"{min_scalp} <= ADX {adx_val:.1f} < {min_trend}"
     else:
-        trade_mode = choose_strategy(adx_val or 0.0)
-        min_scalp = float(env_loader.get_env("ADX_SCALP_MIN", "20"))
-        min_trend = float(env_loader.get_env("ADX_TREND_MIN", "30"))
-        if adx_val is None:
-            reason = "ADX unavailable"
-        elif trade_mode == "none":
-            reason = f"ADX {adx_val:.1f} < {min_scalp}"
-        elif trade_mode == "scalp":
-            reason = f"{min_scalp} <= ADX {adx_val:.1f} < {min_trend}"
-        else:
-            reason = f"ADX {adx_val:.1f} >= {min_trend}"
+        reason = f"ADX {adx_val:.1f} >= {min_trend}"
     logging.info(f"Trade mode decided: {trade_mode} ({reason})")
     scalp_mode = trade_mode == "scalp"
     adx_max = float(env_loader.get_env("SCALP_SUPPRESS_ADX_MAX", "0"))

--- a/backend/tests/test_scalp_cond_tf.py
+++ b/backend/tests/test_scalp_cond_tf.py
@@ -31,14 +31,12 @@ class TestScalpCondTf(unittest.TestCase):
         os.environ.setdefault("OPENAI_API_KEY", "dummy")
         os.environ.setdefault("OANDA_API_KEY", "dummy")
         os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")
-        os.environ["SCALP_MODE"] = "true"
         os.environ["SCALP_COND_TF"] = "M1"
 
         import backend.scheduler.job_runner as jr
         importlib.reload(jr)
         self.jr = jr.JobRunner(interval_seconds=1)
-        os.environ["SCALP_MODE"] = "true"
-        os.environ["SCALP_COND_TF"] = "M1"
+        self.jr.trade_mode = "scalp"
         self.jr.indicators_M1 = {"foo": 1}
         self.jr.indicators_M5 = {"foo": 5}
         self.jr.scalp_cond_tf = "M1"
@@ -46,7 +44,6 @@ class TestScalpCondTf(unittest.TestCase):
     def tearDown(self):
         for n in self._mods:
             sys.modules.pop(n, None)
-        os.environ.pop("SCALP_MODE", None)
         os.environ.pop("SCALP_COND_TF", None)
         os.environ.pop("OANDA_API_KEY", None)
         os.environ.pop("OANDA_ACCOUNT_ID", None)

--- a/backend/tests/test_scalp_mode.py
+++ b/backend/tests/test_scalp_mode.py
@@ -79,8 +79,8 @@ class TestScalpMode(unittest.TestCase):
         add("backend.logs.log_manager", log_stub)
 
         os.environ["PIP_SIZE"] = "0.01"
-        os.environ["SCALP_MODE"] = "true"
         os.environ["ADX_SCALP_MIN"] = "30"
+        os.environ["ADX_TREND_MIN"] = "50"
         os.environ["SCALP_TP_PIPS"] = "2"
         os.environ["SCALP_SL_PIPS"] = "1"
 
@@ -95,11 +95,12 @@ class TestScalpMode(unittest.TestCase):
             sys.modules.pop(name, None)
         for key in [
             "PIP_SIZE",
-            "SCALP_MODE",
             "ADX_SCALP_MIN",
+            "ADX_TREND_MIN",
             "SCALP_SUPPRESS_ADX_MAX",
             "SCALP_TP_PIPS",
             "SCALP_SL_PIPS",
+            "SCALP_MODE",
         ]:
             os.environ.pop(key, None)
 

--- a/config/strategy.yml
+++ b/config/strategy.yml
@@ -8,8 +8,7 @@ filters:
 reentry:
   enable: true
   trigger_pips_over_break: 1.5
-SCALP_MODE: false
-  ADX_SCALP_MIN: 45
+ADX_SCALP_MIN: 45
 SCALP_SUPPRESS_ADX_MAX: 70
 SCALP_TP_PIPS: 5
 SCALP_SL_PIPS: 3


### PR DESCRIPTION
## Summary
- remove SCALP_MODE override in entry logic
- switch indicator set in JobRunner based on current trade mode
- drop SCALP_MODE from default settings
- update docs and examples
- adjust unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ada4c4748333b95baafd2c4c4d59