### PR TITLE
Make strategy.yml keys effective

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ reentry:
 ```
 
 `min_atr_sl_multiplier` は ATR を基にした最小ストップ幅の倍率、`min_rr_ratio` は最低リスクリワード比を示します。`avoid_false_break` ではブレイク失敗回避のための期間と閾値を設定し、`reentry` を有効にするとブレイク後に再びエントリーする条件を制御できます。
+これらの値は `params_loader.load_params()` により `MIN_ATR_MULT` などの環境変数に変換されます。
 
 ## パラメータ変更履歴の確認
 

--- a/config/params_loader.py
+++ b/config/params_loader.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+# YAML内キーと環境変数名のマッピング
+_KEY_ALIASES = {
+    "RISK_MIN_ATR_SL_MULTIPLIER": "MIN_ATR_MULT",
+    "RISK_MIN_RR_RATIO": "MIN_RRR",
+    "FILTERS_AVOID_FALSE_BREAK_LOOKBACK_CANDLES": "FALSE_BREAK_LOOKBACK",
+    "FILTERS_AVOID_FALSE_BREAK_THRESHOLD_RATIO": "FALSE_BREAK_RATIO",
+    "REENTRY_TRIGGER_PIPS_OVER_BREAK": "REENTRY_TRIGGER_PIPS",
+}
+
 
 def _parse_value(val: str):
     val = val.strip()
@@ -95,6 +104,11 @@ def load_params(
         se = Path(settings_path)
         if se.exists():
             env_params.update(_flatten(_parse_yaml_file(se)))
+
+    # キーエイリアスの適用
+    for src, target in _KEY_ALIASES.items():
+        if src in env_params and target not in env_params:
+            env_params[target] = env_params[src]
 
     for k, v in env_params.items():
         os.environ[k] = str(v)

--- a/tests/test_params_loader_strategy.py
+++ b/tests/test_params_loader_strategy.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+import unittest
+from config import params_loader
+
+class TestParamsLoaderStrategy(unittest.TestCase):
+    def test_strategy_aliases(self):
+        yml = b"""\nrisk:\n  min_atr_sl_multiplier: 1.1\n  min_rr_ratio: 1.5\nfilters:\n  avoid_false_break:\n    lookback_candles: 10\n    threshold_ratio: 0.4\nreentry:\n  trigger_pips_over_break: 1.2\n"""
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.yml')
+        tmp.write(yml)
+        tmp.close()
+        try:
+            params_loader.load_params(path=tmp.name, strategy_path=None, settings_path=None)
+            self.assertEqual(os.environ.get('MIN_ATR_MULT'), '1.1')
+            self.assertEqual(os.environ.get('MIN_RRR'), '1.5')
+            self.assertEqual(os.environ.get('FALSE_BREAK_LOOKBACK'), '10')
+            self.assertEqual(os.environ.get('FALSE_BREAK_RATIO'), '0.4')
+            self.assertEqual(os.environ.get('REENTRY_TRIGGER_PIPS'), '1.2')
+        finally:
+            os.unlink(tmp.name)
+            for k in ['MIN_ATR_MULT','MIN_RRR','FALSE_BREAK_LOOKBACK','FALSE_BREAK_RATIO','REENTRY_TRIGGER_PIPS']:
+                os.environ.pop(k, None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- map strategy.yml keys to environment variable names in `params_loader`
- document the automatic mapping in README
- test alias mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b666247c8333952798d97f314b3a