### PR TITLE
Fix restart import error

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -5,6 +5,11 @@ import logging
 import json
 import os
 import sys
+# プロジェクトルートをパスに追加してモジュールを確実に読み込む
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from backend.utils import env_loader, trade_age_seconds
 
 try:


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` on startup

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6842d49f1db883338b943cdbea0e23b8