### PR TITLE
Fix auto restart to keep module imports

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -307,7 +307,8 @@ class JobRunner:
         if os.getenv("AUTO_RESTART", "false").lower() == "true":
             logger.info("AUTO_RESTART enabled – restarting process")
             python = sys.executable
-            os.execv(python, [python] + sys.argv)
+            # preserve module-based execution to keep import paths intact
+            os.execv(python, [python, "-m", "backend.scheduler.job_runner", *sys.argv[1:]])
 
     # ────────────────────────────────────────────────────────────
     #  Poll & renew pending LIMIT orders


### PR DESCRIPTION
## Summary
- ensure the job runner restarts with `-m backend.scheduler.job_runner`

## Testing
- `pytest -k 'params_loader' -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d567b23c83339addced4d6b027d2