### PR TITLE
Fix job_runner trade mode logic

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -261,20 +261,14 @@ class JobRunner:
         mode_env = env_loader.get_env("SCALP_MODE")
         if mode_env is None:
             self.trade_mode = None
-        else:
-          
-            self.trade_mode = "scalp" if scalp_env.lower() == "true" else "trend_follow"
-            self.current_params_file = (
-                "config/scalp.yml" if self.trade_mode == "scalp" else "config/trend.yml"
-            )
-        self.mode_reason = ""
-            self.trade_mode = "scalp" if mode_env.lower() == "true" else "trend_follow"
-        if self.trade_mode == "scalp":
-            self.current_params_file = "config/scalp.yml"
-        elif self.trade_mode == "trend_follow":
-            self.current_params_file = "config/trend.yml"
-        else:
             self.current_params_file = "config/strategy.yml"
+        elif mode_env.lower() == "true":
+            self.trade_mode = "scalp"
+            self.current_params_file = "config/scalp.yml"
+        else:
+            self.trade_mode = "trend_follow"
+            self.current_params_file = "config/trend.yml"
+        self.mode_reason = ""
 
         # Restore TP adjustment flags based on existing TP order comment
         try:


### PR DESCRIPTION
## Summary
- fix inconsistent initialization of `trade_mode` and config path in job_runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e26b1cd883339ed428fbbb32568f