### PR TITLE
Implement volatility-trend mode matrix

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,3 +10,9 @@ AI_COOLDOWN_SEC=30
 # Copy this file to .env and adjust as needed
 COMPOSITE_MIN=0.7
 SCALP_OVERRIDE_RANGE=
+
+# Trade mode thresholds
+ATR_HIGH_RATIO=1.4
+ATR_LOW_RATIO=0.8
+ADX_TREND_THR=25
+ADX_FLAT_THR=17

--- a/backend/config/default_settings.json
+++ b/backend/config/default_settings.json
@@ -122,5 +122,9 @@
     "REV_BLOCK_BARS": 3,
     "TAIL_RATIO_BLOCK": 2.0,
     "SCALP_AI_ADX_MIN": 25,
+    "ATR_HIGH_RATIO": 1.4,
+    "ATR_LOW_RATIO": 0.8,
+    "ADX_TREND_THR": 25,
+    "ADX_FLAT_THR": 17,
     "SCALP_AI_BBWIDTH_MAX": 4
   }

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -253,3 +253,8 @@ ADX_TREND_MIN=70                 # トレンド移行に必要なADX
 SCALP_OVERRIDE_RANGE=false
 
 AUTO_RESTART=true
+# === Trade mode matrix ===
+ATR_HIGH_RATIO=1.4
+ATR_LOW_RATIO=0.8
+ADX_TREND_THR=25
+ADX_FLAT_THR=17

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -69,39 +69,13 @@ def test_entry_signal_trend():
     os.environ.pop("ADX_TREND_MIN")
 
 
-def test_decide_trade_mode_trend(monkeypatch):
-    monkeypatch.setenv("MODE_ATR_PIPS_MIN", "4")
-    monkeypatch.setenv("MODE_BBWIDTH_PIPS_MIN", "2")
-    monkeypatch.setenv("MODE_EMA_SLOPE_MIN", "0.1")
-    monkeypatch.setenv("MODE_ADX_MIN", "20")
-    monkeypatch.setenv("MODE_VOL_MA_MIN", "50")
+def test_decide_trade_mode_matrix(monkeypatch):
+    monkeypatch.setenv("ATR_HIGH_RATIO", "1.3")
+    monkeypatch.setenv("ATR_LOW_RATIO", "0.8")
+    monkeypatch.setenv("ADX_TREND_THR", "25")
+    monkeypatch.setenv("ADX_FLAT_THR", "15")
     cm = _reload_composite()
-    inds = {
-        "atr": [0.05],
-        "bb_upper": [101.0],
-        "bb_lower": [100.0],
-        "ema_slope": [0.2],
-        "macd_hist": [0.3],
-        "adx": [30],
-        "volume": [60, 70, 80, 90, 100],
-    }
-    assert cm.decide_trade_mode(inds) == "trend_follow"
-
-
-def test_decide_trade_mode_scalp(monkeypatch):
-    monkeypatch.setenv("MODE_ATR_PIPS_MIN", "6")
-    monkeypatch.setenv("MODE_BBWIDTH_PIPS_MIN", "4")
-    monkeypatch.setenv("MODE_EMA_SLOPE_MIN", "0.5")
-    monkeypatch.setenv("MODE_ADX_MIN", "50")
-    monkeypatch.setenv("MODE_VOL_MA_MIN", "100")
-    cm = _reload_composite()
-    inds = {
-        "atr": [0.03],
-        "bb_upper": [100.03],
-        "bb_lower": [100.0],
-        "ema_slope": [0.1],
-        "macd_hist": [0.05],
-        "adx": [20],
-        "volume": [20, 30, 40, 50, 60],
-    }
-    assert cm.decide_trade_mode(inds) == "scalp"
+    assert cm.decide_trade_mode_matrix(1.5, 1.0, 10) == "scalp_range"
+    assert cm.decide_trade_mode_matrix(1.5, 1.0, 30) == "scalp_momentum"
+    assert cm.decide_trade_mode_matrix(0.7, 1.0, 30) == "trend_follow"
+    assert cm.decide_trade_mode_matrix(1.0, 1.0, 20) == "flat"


### PR DESCRIPTION
## Summary
- add ATR/ADX matrix logic in `signals/composite_mode`
- expose matrix thresholds via env and config files
- update tests for the new trade mode matrix

## Testing
- `pytest tests/test_adx_mode.py::test_decide_trade_mode_matrix -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ee7f268c8333aadfd8876f2b199e