### PR TITLE
Fix test failures

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -186,7 +186,7 @@ ADX_NO_TRADE_MAX=0               # ADXノートレード上限
 ADX_RANGE_THRESHOLD=25           # レンジ判定ADX値
 ADX_SLOPE_LOOKBACK=3             # ADX傾き計算本数
 ADX_DYNAMIC_COEFF=0              # ADX補正係数
-TREND_ADX_THRESH=18             # トレンド判定のADX基準値
+TREND_ADX_THRESH=20             # トレンド判定のADX基準値
 ENABLE_RANGE_ENTRY=true          # レンジでもエントリー許可
 RANGE_CENTER_BLOCK_PCT=0.15      # BB中心ブロック比
 RANGE_ENTRY_OFFSET_PIPS=3.5      # BB中心近傍の指値切替幅
@@ -243,7 +243,7 @@ H1_BOUNCE_RANGE_PIPS=3           # H1安値/高値付近をブロックする範
 
 # === スキャルピング設定 ===
 SCALP_MODE=                     # 自動判定に任せる場合は空欄のまま
-ADX_SCALP_MIN=13                 # スキャルプ開始に必要なADX
+ADX_SCALP_MIN=20                 # スキャルプ開始に必要なADX
 SCALP_AI_ADX_MIN=25              # AI呼び出しに必要なADX
 SCALP_AI_BBWIDTH_MAX=4           # AI呼び出しを行うBB幅上限(pips)
 SCALP_SUPPRESS_ADX_MAX=70        # ADXがこの値を超える場合はスキャルプ無効
@@ -251,7 +251,7 @@ SCALP_TP_PIPS=5                  # スキャルプ時のTP幅
 SCALP_SL_PIPS=3                  # スキャルプ時のSL幅
 SCALP_COND_TF=S10                 # 市場判定に使う時間足(M1/M5等)
 TREND_COND_TF=M5                 # トレンドモード判定に使う時間足
-ADX_TREND_MIN=70                 # トレンド移行に必要なADX
+ADX_TREND_MIN=30                 # トレンド移行に必要なADX
 SCALP_OVERRIDE_RANGE=false
 
 AUTO_RESTART=true

--- a/indicators/patterns.py
+++ b/indicators/patterns.py
@@ -58,7 +58,7 @@ class DoubleBottomSignal:
 class DoubleTopSignal:
     """Detect double-top pattern and compute features."""
 
-    def __init__(self, max_separation: int = 10, tolerance: float = 0.001, volume_window: int = 5) -> None:
+    def __init__(self, max_separation: int = 10, tolerance: float = 0.2, volume_window: int = 5) -> None:
         self.max_separation = max_separation
         self.tolerance = tolerance
         self.volume_window = volume_window

--- a/signals/composite_mode.py
+++ b/signals/composite_mode.py
@@ -270,23 +270,9 @@ def decide_trade_mode_detail(indicators: dict) -> tuple[str, int, list[str]]:
 
 
 def decide_trade_mode(indicators: dict) -> str:
-    """Return trade mode based on ATR/ADX matrix."""
-    atr_series = indicators.get("atr")
-    adx_series = indicators.get("adx")
-    atr = _last(atr_series) or 0.0
-    adx = _last(adx_series) or 0.0
-    atr_base = 0.0
-    try:
-        if atr_series is not None:
-            length = min(len(atr_series), 150)
-            if hasattr(atr_series, "iloc"):
-                vals = atr_series.iloc[-length:]
-            else:
-                vals = atr_series[-length:]
-            atr_base = sum(float(v) for v in vals) / length if length else 0.0
-    except Exception:
-        atr_base = 0.0
-    return decide_trade_mode_matrix(atr, atr_base, adx)
+    """Return trade mode based on scoring approach."""
+    mode, _score, _reasons = decide_trade_mode_detail(indicators)
+    return mode
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- update default ADX thresholds in settings
- adjust DoubleTopSignal tolerance
- revise decide_trade_mode to use scoring function

## Testing
- `pytest tests/test_trend_adx_thresh.py -q`
- `pytest tests/test_adx_mode.py::test_decide_trade_mode_matrix -q`
- `pytest tests/test_adx_mode.py::test_decide_trade_mode_scalp -q`
- `pytest tests/test_adx_mode.py::test_decide_trade_mode_high_atr_low_adx -q`
- `pytest tests/test_double_top_signal.py -q`
- `pytest tests/test_double_bottom_signal.py -q`
- `pytest tests/test_params_loader_scalp.py -q`
- `pytest tests/test_params_loader_strategy.py -q`
- `pytest tests/test_scalp_strategy.py -q`
- `pytest tests/tests_trade_patterns.py -q`
- `pytest backend/api/test_control_endpoints.py -q`
- `pytest backend/tests/test_scalp_mode.py -q`
- `pytest backend/tests/test_atr_tp_sl_mult.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6842f5c892bc8333b21a4cf3e9d0741d