### PR TITLE
Implement advanced mode scoring with YAML parameters

### DIFF
--- a/analysis/notebooks/mode_score_demo.ipynb
+++ b/analysis/notebooks/mode_score_demo.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mode scoring demo\n",
+    "簡易的なスコア計算の確認用ノートブックです。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from signals.composite_mode import decide_trade_mode_detail\n",
+    "from signals.mode_params import reload_params\n",
+    "reload_params()\n",
+    "\n",
+    "ind_m5 = {\n",
+    "    'atr_pct': [0.005],\n",
+    "    'adx': [30],\n",
+    "    'ema_slope': [0.2],\n",
+    "}\n",
+    "ind_m1 = {\n",
+    "    'atr_pct': [0.003],\n",
+    "    'adx': [25],\n",
+    "}\n",
+    "data = {'M5': ind_m5, 'M1': ind_m1}\n",
+    "mode, score, reasons = decide_trade_mode_detail({'M1': ind_m1, **ind_m5})\n",
+    "print(mode, score, reasons)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -824,6 +824,11 @@ class JobRunner:
                         indicators["ema_slope_h4"] = self.indicators_H4.get("ema_slope")
                         indicators["adx_h4"] = self.indicators_H4.get("adx")
 
+                    if self.indicators_M1:
+                        indicators["M1"] = self.indicators_M1
+                    if self.indicators_S10:
+                        indicators["S10"] = self.indicators_S10
+
                     align = is_multi_tf_aligned(
                         {
                             "M1": self.indicators_M1 or {},

--- a/config/mode_thresholds.yml
+++ b/config/mode_thresholds.yml
@@ -1,0 +1,38 @@
+volatility_levels:
+  low:
+    adx_m5_min: 22
+    atr_pct_m5_min: 0.003
+    adx_m1_min: 18
+    atr_pct_m1_min: 0.002
+  normal:
+    adx_m5_min: 25
+    atr_pct_m5_min: 0.004
+    adx_m1_min: 20
+    atr_pct_m1_min: 0.0025
+  high:
+    adx_m5_min: 28
+    atr_pct_m5_min: 0.005
+    adx_m1_min: 22
+    atr_pct_m1_min: 0.003
+scalp:
+  adx_m5_max: 15
+  atr_pct_m5_max: 0.0025
+  adx_m1_max: 12
+  body_shrink_ratio: 0.35
+  s10_adx_min: 20
+  s10_atr_pct_min: 0.001
+weights:
+  adx_m5: 2
+  atr_pct_m5: 1
+  adx_m1: 1
+  atr_pct_m1: 1
+  ema_slope_base: 1
+  ema_slope_strong: 2
+hysteresis:
+  trend: 3
+  scalp: 3
+trend_score_min: 3
+scalp_score_max: -1
+ema_slope:
+  mild: 0.05
+  strong: 0.15

--- a/config/params_loader.py
+++ b/config/params_loader.py
@@ -40,6 +40,7 @@ def load_params(
     strategy_path: str | Path | None = Path(__file__).resolve().parent
     / "strategy.yml",
     settings_path: str | Path | None = Path(__file__).resolve().parent / "settings.yaml",
+    mode_path: str | Path | None = Path(__file__).resolve().parent / "mode_thresholds.yml",
 ):
     """Load YAML parameters and export them as environment variables."""
 
@@ -58,6 +59,11 @@ def load_params(
         se = Path(settings_path)
         if se.exists():
             env_params.update(_flatten(_parse_yaml_file(se)))
+
+    if mode_path is not None:
+        mp = Path(mode_path)
+        if mp.exists():
+            env_params.update(_flatten(_parse_yaml_file(mp)))
 
     # キーエイリアスの適用
     for src, target in _KEY_ALIASES.items():

--- a/signals/mode_params.py
+++ b/signals/mode_params.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import yaml
+
+_DEFAULT_PATH = Path(__file__).resolve().parent.parent / "config/mode_thresholds.yml"
+
+_params: dict | None = None
+
+
+def get_params() -> dict:
+    global _params
+    if _params is None:
+        path = Path(os.getenv("MODE_CONFIG", _DEFAULT_PATH))
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                _params = yaml.safe_load(f) or {}
+        except Exception:
+            _params = {}
+    return _params
+
+
+def reload_params(path: str | Path | None = None) -> None:
+    global _params
+    if path is None:
+        path = os.getenv("MODE_CONFIG", _DEFAULT_PATH)
+    path = Path(path)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            _params = yaml.safe_load(f) or {}
+    except Exception:
+        _params = {}
+
+__all__ = ["get_params", "reload_params"]

--- a/tests/test_params_loader_mode.py
+++ b/tests/test_params_loader_mode.py
@@ -1,0 +1,22 @@
+import os
+import tempfile
+import unittest
+from config import params_loader
+
+class TestParamsLoaderMode(unittest.TestCase):
+    def test_mode_keys_loaded(self):
+        yml = "trend_score_min: 5\nweights:\n  adx_m5: 3\n"
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.yml')
+        tmp.write(yml.encode())
+        tmp.close()
+        try:
+            params_loader.load_params(mode_path=tmp.name, path=None, strategy_path=None, settings_path=None)
+            self.assertEqual(os.environ.get('TREND_SCORE_MIN'), '5')
+            self.assertEqual(os.environ.get('WEIGHTS_ADX_M5'), '3')
+        finally:
+            os.unlink(tmp.name)
+            os.environ.pop('TREND_SCORE_MIN', None)
+            os.environ.pop('WEIGHTS_ADX_M5', None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `mode_thresholds.yml` for ATR/ADX thresholds and weights
- load new parameters via `params_loader` and `signals.mode_params`
- enhance `composite_mode` scoring using multi-timeframe data
- include M1/S10 indicators when deciding trade mode
- add a demo notebook for score calculation
- add unit test for loading mode parameters

## Testing
- `pip install fastapi pyyaml httpx apscheduler line-bot-sdk`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f765c3c08333873d56a3d3c29dc0