### PR TITLE
Add prompt bias configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `SCALP_COND_TF` … スキャルプ時に市場判断へ使用する時間足 (デフォルト `M1`). この値でトレンド/レンジ判定に用いる足を変更できます
 - `TREND_COND_TF` … トレンドフォロー時の市場判定に使う時間足 (デフォルト `M5`)
 - `SCALP_OVERRIDE_RANGE` … true ならレンジ判定を無視してスキャルを優先
+- `SCALP_PROMPT_BIAS` … `aggressive` にするとスキャルプAIが積極的にエントリー判断
 - `ADX_SCALP_MIN` … ADX がこの値以上でスキャルプモード
 - `ADX_TREND_MIN` … ADX がこの値以上でトレンドフォローモード
+- `TREND_PROMPT_BIAS` … `aggressive` にするとトレンドフォローAIがより積極的
 - `MODE_ATR_PIPS_MIN` / `MODE_BBWIDTH_PIPS_MIN` … ボラティリティ判定用の閾値
 - `MODE_EMA_SLOPE_MIN` / `MODE_ADX_MIN` … モメンタム判定のしきい値
 - `MODE_VOL_MA_MIN` … 流動性判定に使う出来高平均

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -12,6 +12,7 @@ TP_PROB_HOURS = int(env_loader.get_env("TP_PROB_HOURS", "24"))
 MIN_RRR = float(env_loader.get_env("MIN_RRR", "0.8"))
 MIN_NET_TP_PIPS = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))
 TREND_ADX_THRESH = float(env_loader.get_env("TREND_ADX_THRESH", "20"))
+TREND_PROMPT_BIAS = env_loader.get_env("TREND_PROMPT_BIAS", "normal").lower()
 
 
 def _series_tail_list(series, n: int = 20) -> list:
@@ -277,4 +278,10 @@ Your task:
 Respond with **one-line valid JSON** exactly as:
 {{"regime":{{...}},"entry":{{...}},"risk":{{...}},"entry_confidence":0.0}}
 """
+    bias_note = ""
+    if TREND_PROMPT_BIAS == "aggressive":
+        bias_note = (
+            "\nBe proactive: when signals are mixed, favor taking a position rather than returning 'no'."
+        )
+    prompt += bias_note
     return prompt, comp_val

--- a/backend/strategy/openai_scalp_analysis.py
+++ b/backend/strategy/openai_scalp_analysis.py
@@ -7,6 +7,7 @@ from backend.utils import env_loader, parse_json_answer
 logger = logging.getLogger(__name__)
 
 AI_SCALP_MODEL = env_loader.get_env("AI_SCALP_MODEL", "gpt-4.1-nano")
+SCALP_PROMPT_BIAS = env_loader.get_env("SCALP_PROMPT_BIAS", "normal").lower()
 
 
 def _series_tail_list(series, n: int = 20) -> list:
@@ -29,11 +30,17 @@ def get_scalp_plan(indicators: dict, candles: list, *, higher_tf_direction: str 
     rsi_vals = _series_tail_list(indicators.get("rsi"), 5)
     bb_upper = _series_tail_list(indicators.get("bb_upper"), 5)
     bb_lower = _series_tail_list(indicators.get("bb_lower"), 5)
+    bias_note = ""
+    if SCALP_PROMPT_BIAS == "aggressive":
+        bias_note = (
+            "\nWhen conditions are unclear, prefer taking a position rather than returning 'no'."
+        )
     prompt = (
         "You are a forex scalping assistant.\n"
         "Analyze the short-term indicators and decide whether to buy, sell or stay flat.\n"
         f"ADX:{adx_vals}\nRSI:{rsi_vals}\nBB_upper:{bb_upper}\nBB_lower:{bb_lower}\n"
         f"Candles:{candles[-20:]}\nHigher direction:{higher_tf_direction}\n"
+        f"{bias_note}\n"
         "Respond with JSON as {\"side\":\"long|short|no\",\"tp_pips\":float,\"sl_pips\":float}"
     )
     try:
@@ -47,4 +54,4 @@ def get_scalp_plan(indicators: dict, candles: list, *, higher_tf_direction: str 
     return plan
 
 
-__all__ = ["get_scalp_plan", "AI_SCALP_MODEL"]
+__all__ = ["get_scalp_plan", "AI_SCALP_MODEL", "SCALP_PROMPT_BIAS"]

--- a/docs/aggressive_scalp.md
+++ b/docs/aggressive_scalp.md
@@ -18,6 +18,7 @@
 - `ENFORCE_RRR=false`
 - `SCALP_TP_PIPS=4`
 - `SCALP_SL_PIPS=4`
+- `SCALP_PROMPT_BIAS=aggressive`
 
 ## 反映手順
 


### PR DESCRIPTION
## Summary
- add `SCALP_PROMPT_BIAS` and `TREND_PROMPT_BIAS` environment variables
- let scalp/trend prompts include bias note when aggressive
- document new options in README and aggressive scalp guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6842fd26f7548333b6cc609f800566c0