### PR TITLE
Mode-specific entry filter

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1402,6 +1402,7 @@ class JobRunner:
                             self.indicators_M1,
                             self.indicators_M15,
                             self.indicators_H1,
+                            mode=self.trade_mode,
                         ):
                             logger.info("Filter OK → Processing entry decision with AI.")
                             self.last_ai_call = datetime.now()  # record AI call time *before* the call


### PR DESCRIPTION
## Summary
- add `mode` argument to `pass_entry_filter` for scalp/trend logic
- pass trade mode from job runner when checking entry filter

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q tests` *(fails: detect_upper_wick_cluster expected True)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb70be1c83338136ad28a4639cf0