### PR TITLE
Fix consistency handling in AI logic

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -179,7 +179,8 @@ def calc_consistency(
     if not local or not ai:
         ai_score = 0.5
     else:
-        ai_score = 1.0 if local == ai else 0.0
+        # When local and AI disagree, use a neutral score instead of zero
+        ai_score = 1.0 if local == ai else 0.5
 
     local_score = (
         ema_ok * _get_dynamic_weight("ema")

--- a/backend/tests/test_consistency_weights.py
+++ b/backend/tests/test_consistency_weights.py
@@ -69,8 +69,33 @@ class TestConsistencyWeights(unittest.TestCase):
             adx_ok=1.0,
             rsi_cross_ok=1.0,
         )
-        expected_local = 0.1 + 0.1 + 0.8
-        expected_alpha = self.oa.LOCAL_WEIGHT_THRESHOLD * expected_local + (1 - self.oa.LOCAL_WEIGHT_THRESHOLD)
+        expected_local = (
+            self.oa._get_dynamic_weight("ema")
+            + self.oa._get_dynamic_weight("adx")
+            + self.oa._get_dynamic_weight("rsi")
+        )
+        expected_alpha = (
+            self.oa.LOCAL_WEIGHT_THRESHOLD * expected_local
+            + (1 - self.oa.LOCAL_WEIGHT_THRESHOLD)
+        )
+        self.assertAlmostEqual(alpha, expected_alpha)
+
+    def test_disagreement_partial_score(self):
+        alpha = self.oa.calc_consistency(
+            "trend",
+            "range",
+            ema_ok=1.0,
+            adx_ok=1.0,
+            rsi_cross_ok=0.0,
+        )
+        expected_local = (
+            self.oa._get_dynamic_weight("ema") + self.oa._get_dynamic_weight("adx")
+        )
+        expected_ai = 0.5
+        expected_alpha = (
+            self.oa.LOCAL_WEIGHT_THRESHOLD * expected_local
+            + (1 - self.oa.LOCAL_WEIGHT_THRESHOLD) * expected_ai
+        )
         self.assertAlmostEqual(alpha, expected_alpha)
 
 

--- a/config/params_loader.py
+++ b/config/params_loader.py
@@ -46,9 +46,10 @@ def load_params(
 
     env_params: dict[str, object] = {}
 
-    p = Path(path)
-    if p.exists():
-        env_params.update(_flatten(_parse_yaml_file(p)))
+    if path is not None:
+        p = Path(path)
+        if p.exists():
+            env_params.update(_flatten(_parse_yaml_file(p)))
 
     if strategy_path is not None:
         sp = Path(strategy_path)


### PR DESCRIPTION
## Summary
- soften `calc_consistency` so AI disagreement is neutral rather than zero
- skip YAML load when main path is `None`
- extend consistency weight tests for disagreement case

## Testing
- `pytest backend/tests/test_consistency_weights.py backend/api/test_control_endpoints.py tests/test_params_loader_mode.py tests/test_params_loader_scalp.py tests/test_params_loader_strategy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6843012fcba483338bd5decc750efa09