### PR TITLE
Implement AI retry with aggressive bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Piphawk AI is an automated trading system that uses the OANDA REST API for order
 - `ADX_SCALP_MIN` … ADX がこの値以上でスキャルプモード
 - `ADX_TREND_MIN` … ADX がこの値以上でトレンドフォローモード
 - `TREND_PROMPT_BIAS` … `aggressive` にするとトレンドフォローAIがより積極的
+- `AI_RETRY_ON_NO` … true にするとAIが "no" を返した際に再度 "aggressive" バイアスで判定
 - `MODE_ATR_PIPS_MIN` / `MODE_BBWIDTH_PIPS_MIN` … ボラティリティ判定用の閾値
 - `MODE_EMA_SLOPE_MIN` / `MODE_ADX_MIN` … モメンタム判定のしきい値
 - `MODE_VOL_MA_MIN` … 流動性判定に使う出来高平均

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -380,6 +380,23 @@ def process_entry(
         allow_delayed_entry=allow_delayed_entry,
     )
 
+    # -- "no" の場合は攻めたバイアスで再試行 --------------------
+    if (
+        plan.get("entry", {}).get("side", "no").lower() not in ("long", "short")
+        and env_loader.get_env("AI_RETRY_ON_NO", "false").lower() == "true"
+    ):
+        plan = oa.get_trade_plan(
+            market_data,
+            indicators_multi,
+            candles_dict,
+            patterns=patterns,
+            detected_patterns=detected,
+            allow_delayed_entry=allow_delayed_entry,
+            trend_prompt_bias="aggressive",
+        )
+        ai_raw = json.dumps(plan, ensure_ascii=False)
+        logging.info(f"AI trade plan aggressive retry: {ai_raw}")
+
     # Raw JSON for audit log
     ai_raw = json.dumps(plan, ensure_ascii=False)
     logging.info(f"AI trade plan raw: {ai_raw}")

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -945,6 +945,7 @@ def get_trade_plan(
     instrument: str | None = None,
     trade_mode: str | None = None,
     mode_reason: str | None = None,
+    trend_prompt_bias: str | None = None,
 ) -> dict:
     """
     Single‑shot call to the LLM that returns a dict:
@@ -1005,10 +1006,17 @@ def get_trade_plan(
         pattern_line = pattern_name
 
     prompt, comp_val = build_trade_plan_prompt(
-        ind_m5, ind_m1, ind_d1, candles_m5, candles_m1, candles_d1,
-        hist_stats, pattern_line,
+        ind_m5,
+        ind_m1,
+        ind_d1,
+        candles_m5,
+        candles_m1,
+        candles_d1,
+        hist_stats,
+        pattern_line,
         allow_delayed_entry=allow_delayed_entry,
         higher_tf_direction=higher_tf_direction,
+        trend_prompt_bias=trend_prompt_bias,
     )
     # --------------------------------------------------------------
     # Estimate market "noise" from ATR and Bollinger band width

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -41,6 +41,7 @@ def build_trade_plan_prompt(
     *,
     allow_delayed_entry: bool = False,
     higher_tf_direction: str | None = None,
+    trend_prompt_bias: str | None = None,
 ) -> Tuple[str, float | None]:
     """Return the prompt string for ``get_trade_plan`` and the composite score."""
     # --------------------------------------------------------------
@@ -278,8 +279,9 @@ Your task:
 Respond with **one-line valid JSON** exactly as:
 {{"regime":{{...}},"entry":{{...}},"risk":{{...}},"entry_confidence":0.0}}
 """
+    bias = trend_prompt_bias or TREND_PROMPT_BIAS
     bias_note = ""
-    if TREND_PROMPT_BIAS == "aggressive":
+    if bias == "aggressive":
         bias_note = (
             "\nBe proactive: when signals are mixed, favor taking a position rather than returning 'no'."
         )


### PR DESCRIPTION
## Summary
- add `trend_prompt_bias` param to prompt builder
- expose `trend_prompt_bias` in `get_trade_plan`
- retry AI call with aggressive bias when side is `no`
- document new `AI_RETRY_ON_NO` environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ff8dd3c0833399d56580d095f686