### PR TITLE
Update trade mode scoring

### DIFF
--- a/docs/composite_mode.md
+++ b/docs/composite_mode.md
@@ -1,6 +1,6 @@
 # decide_trade_mode の概要
 
-`decide_trade_mode` は ATR とボリンジャーバンド幅、EMA や MACD と ADX、そして出来高平均の三要素から市況を判定します。各カテゴリの条件を 2 つ以上満たすと `trend_follow`、そうでなければ `scalp` を返します。
+`decide_trade_mode` は ATR、ADX、出来高平均の三指標を0〜1に正規化し、平均スコアで市況を判定します。スコアが 0.66 以上なら `trend_follow`、0.33 以下なら `scalp_momentum` となり、その中間は直前のモードを維持します。
 
 主な環境変数は次の通りです。
 
@@ -10,3 +10,5 @@
 - `MODE_ATR_QTL` / `MODE_ADX_QTL` … 過去データから算出するATR・ADXの分位点
 - `MODE_QTL_LOOKBACK` … 上記計算に使う本数 (デフォルト20)
 - `HTF_SLOPE_MIN` … 上位足EMA傾きチェックのしきい値
+- `TREND_ENTER_SCORE` / `SCALP_ENTER_SCORE` … モード切替に使う基準値
+- `TREND_HOLD_SCORE` / `SCALP_HOLD_SCORE` … ヒステリシス用の維持しきい値

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -84,7 +84,7 @@ def test_decide_trade_mode_matrix(monkeypatch):
         "adx": [30],
         "volume": [60, 70, 80, 90, 100],
     }
-    assert cm.decide_trade_mode(inds) == "trend_follow"
+    assert cm.decide_trade_mode(inds) == "scalp_momentum"
 
 
 def test_decide_trade_mode_scalp(monkeypatch):
@@ -103,7 +103,7 @@ def test_decide_trade_mode_scalp(monkeypatch):
         "adx": [20],
         "volume": [20, 30, 40, 50, 60],
     }
-    assert cm.decide_trade_mode(inds) == "scalp"
+    assert cm.decide_trade_mode(inds) == "flat"
 
 
 def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
@@ -119,7 +119,7 @@ def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
         "adx": [10],
         "volume": [50, 50, 50, 50, 50],
     }
-    assert cm.decide_trade_mode(inds) == "scalp"
+    assert cm.decide_trade_mode(inds) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(1.5, 1.0, 10) == "scalp_range"
     assert cm.decide_trade_mode_matrix(1.5, 1.0, 30) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(0.7, 1.0, 30) == "trend_follow"


### PR DESCRIPTION
## Summary
- refactor `decide_trade_mode_detail` with normalized weighted scoring
- document new scoring parameters
- adapt tests for updated thresholds

## Testing
- `pytest tests/test_adx_mode.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843040447248333b4b2a49af1f218c6