### PR TITLE
Fix AUTO_RESTART loop for scalp_momentum

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -307,6 +307,7 @@ class JobRunner:
         """Load YAML parameters for the given mode and optionally restart."""
         file_map = {
             "scalp": "config/scalp.yml",
+            "scalp_momentum": "config/scalp.yml",
             "trend_follow": "config/trend.yml",
         }
         path = file_map.get(mode, "config/strategy.yml")


### PR DESCRIPTION
## Summary
- handle `scalp_momentum` in JobRunner parameter reload

## Testing
- `pytest -q` *(fails: manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68430b370a7c8333995aa16f5bd48f21