### PR TITLE
Persist trade mode across restarts

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -14,8 +14,13 @@ from backend.utils import env_loader, trade_age_seconds
 
 try:
     from config import params_loader
-    # strategy.yml などから環境変数を読み込む
-    params_loader.load_params()
+    last_mode = getattr(params_loader, "load_last_mode", lambda: None)()
+    if last_mode in ("scalp", "scalp_momentum"):
+        params_loader.load_params(path="config/scalp.yml")
+    elif last_mode == "trend_follow":
+        params_loader.load_params(path="config/trend.yml")
+    else:
+        params_loader.load_params()
 except Exception:
     pass
 
@@ -311,6 +316,10 @@ class JobRunner:
             "trend_follow": "config/trend.yml",
         }
         path = file_map.get(mode, "config/strategy.yml")
+        try:
+            params_loader.save_last_mode(mode)
+        except Exception:
+            pass
         if self.current_params_file == path:
             return
         try:

--- a/config/params_loader.py
+++ b/config/params_loader.py
@@ -4,6 +4,27 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import yaml
+import json
+
+STATE_FILE = Path("/tmp/last_trade_mode.json")
+
+
+def load_last_mode() -> str | None:
+    """Return last trade mode stored in STATE_FILE."""
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text()).get("mode")
+        except Exception:
+            return None
+    return None
+
+
+def save_last_mode(mode: str) -> None:
+    """Persist current trade mode to STATE_FILE."""
+    try:
+        STATE_FILE.write_text(json.dumps({"mode": mode}))
+    except Exception:
+        pass
 
 # YAML内キーと環境変数名のマッピング
 _KEY_ALIASES = {


### PR DESCRIPTION
## Summary
- remember last trade mode in `/tmp/last_trade_mode.json`
- reload parameters for saved mode on startup
- store latest mode whenever reloading params

## Testing
- `pip install fastapi PyYAML httpx apscheduler line-bot-sdk`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430e9cc51c8333a7a295280c242645