### PR TITLE
Add scalp filter override

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The indicators module also calculates `adx_bb_score`, a composite value derived 
 `PATTERN_EXCLUDE_TFS` に `M1` などを指定すると、その時間足ではパターン検出を行いません。
 `PATTERN_TFS` を `M1,M5` のように設定すると、指定した時間足のみをスキャンします。
 `STRICT_ENTRY_FILTER` controls whether the M1 RSI cross signal is required. Set to `false` to skip the cross check (default `true`).
+`SCALP_STRICT_FILTER` applies the same rule only in scalp mode. Set to `true` when an M1 RSI cross must be observed for scalping entries.
 `HIGHER_TF_ENABLED` を `true` にすると、上位足ピボットとの距離も TP 計算に利用します。
 `VOL_MA_PERIOD` sets the averaging window for volume checks. If the average falls below `MIN_VOL_MA` (or `MIN_VOL_M1`) the entry is blocked.
 `ADX_SLOPE_LOOKBACK` defines how many candles to look back when computing ADX slope, and `ADX_DYNAMIC_COEFF` scales the ADX threshold based on Bollinger width.

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -144,6 +144,7 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 - PATTERN_MIN_BARS / PATTERN_TOLERANCE: パターン成立条件の細かい調整
 - PATTERN_EXCLUDE_TFS / PATTERN_TFS: チャートパターン検出を行う/除外する時間足
 - STRICT_ENTRY_FILTER: M1 RSI クロス必須判定のオン/オフ
+- SCALP_STRICT_FILTER: スキャル時にもクロスを要求するか
 - HIGHER_TF_ENABLED: 上位足ピボットをTP計算に利用するか
 - VOL_MA_PERIOD: 出来高平均を計算する期間
 - MIN_VOL_MA / MIN_VOL_M1: ボリュームフィルタの最小値

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -126,6 +126,7 @@ PATTERN_EXCLUDE_TFS=M1           # 除外時間足
 USE_LOCAL_PATTERN=true           # ローカル検出を併用
 LOCAL_WEIGHT_THRESHOLD=0.3       # ローカル優先度
 STRICT_ENTRY_FILTER=false        # M1 RSIクロス必須か
+SCALP_STRICT_FILTER=false        # スキャル時のクロス必須
 ALLOW_DELAYED_ENTRY=false        # トレンド過熱時に待機許可
 
 # === ボリューム関連 ===

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -21,6 +21,8 @@ from backend.indicators.adx import calculate_adx_slope
 logger = logging.getLogger(__name__)
 
 REVERSAL_RSI_DIFF = float(os.getenv("REVERSAL_RSI_DIFF", "15"))
+# スキャル専用の厳格判定フラグ
+SCALP_STRICT_FILTER = os.getenv("SCALP_STRICT_FILTER", "false").lower() == "true"
 
 
 def _ema_direction(fast, slow) -> str | None:
@@ -440,6 +442,8 @@ def pass_entry_filter(
 
     # --- M1 RSI cross-up/down check ----------------------------------
     strict = os.getenv("STRICT_ENTRY_FILTER", "true").lower() == "true"
+    if mode == "scalp":
+        strict = SCALP_STRICT_FILTER
     if strict:
         if indicators_m1 is None:
             try:


### PR DESCRIPTION
## Summary
- introduce `SCALP_STRICT_FILTER` to relax M1 RSI cross requirement for scalping
- document the environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431b9055608333b8eef2438316180e