### PR TITLE
Fix scalp_momentum detection

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -304,7 +304,7 @@ class JobRunner:
     def _get_cond_indicators(self) -> dict:
         """Return indicators for market condition check."""
         tf = env_loader.get_env("TREND_COND_TF", "M5").upper()
-        if self.trade_mode == "scalp":
+        if self.trade_mode in ("scalp", "scalp_momentum"):
             tf = env_loader.get_env("SCALP_COND_TF", self.scalp_cond_tf).upper()
         return getattr(self, f"indicators_{tf}", {}) or {}
 

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -235,7 +235,7 @@ def process_entry(
         )
     trade_mode = decide_trade_mode(indicators)
     logging.info("Trade mode decided: %s", trade_mode)
-    scalp_mode = trade_mode == "scalp"
+    scalp_mode = trade_mode in ("scalp", "scalp_momentum") and adx_val is not None
     adx_max = float(env_loader.get_env("SCALP_SUPPRESS_ADX_MAX", "0"))
     if adx_val is not None and adx_max > 0 and adx_val > adx_max:
         scalp_mode = False

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -613,7 +613,7 @@ def pass_entry_filter(
     else:
         atr_condition = (latest_atr / pip_size) >= (atr_th / pip_size)
 
-    if mode == "scalp":
+    if mode in ("scalp", "scalp_momentum"):
         atr_condition = True
         required = 1
     elif mode == "trend_follow":


### PR DESCRIPTION
## Summary
- support `scalp_momentum` mode in JobRunner and strategy logic
- handle scalp momentum in signal filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431a4878a883338ac116d0fa66cf7e