### PR TITLE
Update scalping thresholds

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -26,7 +26,7 @@ SHORT_TP_ATR_RATIO=0.6           # ATR短期倍率によるTP調整
 TP_BB_RATIO=1.0                  # BB幅からTP算出する倍率
 
 # === AIクールダウンとロット制限 ===
-AI_COOLDOWN_SEC_FLAT=30          # ノーポジ時のAI呼び出し間隔
+AI_COOLDOWN_SEC_FLAT=15          # ノーポジ時のAI呼び出し間隔
 AI_COOLDOWN_SEC_OPEN=60          # ポジション保有時のAI間隔
 MIN_TRADE_LOT=30.0               # 最小ロット数
 MAX_TRADE_LOT=30.0               # 最大ロット数
@@ -171,12 +171,13 @@ MAX_LIMIT_AGE_SEC=600            # 指値有効秒数
 PENDING_GRACE_MIN=3              # 再評価までの猶予分
 MAX_LIMIT_RETRY=3                # 指値再調整回数
 PULLBACK_LIMIT_OFFSET_PIPS=1     # 指値基本オフセット
-PULLBACK_PIPS=3                  # ピボット抑制時オフセット
+PULLBACK_PIPS=1                  # ピボット抑制時オフセット
 MAX_SPREAD_PIPS=1.2              # 指値切替の最大スプレッド
 PULLBACK_ATR_RATIO=0.3           # ATR比によるプルバック閾値
 EXT_BLOCK_ATR=1.5                # EMA乖離ATR倍率でエントリーブロック
 REENTRY_TRIGGER_PIPS=1           # 再エントリー用乖離幅
-BYPASS_PULLBACK_ADX_MIN=22       # ADXがこの値以上ならプルバック待ちをスキップ
+BREAK_PIPS_MIN=1                 # ブレイクとみなす最小pips
+BYPASS_PULLBACK_ADX_MIN=20       # ADXがこの値以上ならプルバック待ちをスキップ
 
 # === クールダウン・ADXレンジ ===
 COOL_BBWIDTH_PCT=0               # BB幅によるクールダウン
@@ -244,12 +245,13 @@ H1_BOUNCE_RANGE_PIPS=3           # H1安値/高値付近をブロックする範
 # === スキャルピング設定 ===
 SCALP_MODE=                     # 自動判定に任せる場合は空欄のまま
 ADX_SCALP_MIN=20                 # スキャルプ開始に必要なADX
-SCALP_AI_ADX_MIN=25              # AI呼び出しに必要なADX
+SCALP_AI_ADX_MIN=15              # AI呼び出しに必要なADX
 SCALP_AI_BBWIDTH_MAX=4           # AI呼び出しを行うBB幅上限(pips)
 SCALP_SUPPRESS_ADX_MAX=70        # ADXがこの値を超える場合はスキャルプ無効
 SCALP_TP_PIPS=5                  # スキャルプ時のTP幅
 SCALP_SL_PIPS=3                  # スキャルプ時のSL幅
 SCALP_COND_TF=S10                 # 市場判定に使う時間足(M1/M5等)
+SCALP_PROMPT_BIAS=aggressive     # AIプロンプトの攻め姿勢
 TREND_COND_TF=M5                 # トレンドモード判定に使う時間足
 ADX_TREND_MIN=30                 # トレンド移行に必要なADX
 SCALP_OVERRIDE_RANGE=false


### PR DESCRIPTION
## Summary
- lower thresholds for AI scalping entry
- allow bypass of pullback more often
- shorten AI cooldown
- add bias parameter for more aggressive entries

## Testing
- `pytest backend/tests/test_atr_tp_sl_mult.py::TestAtrTpSlMult::test_atr_based_tp_sl -vv`
- `pytest tests backend/tests -q` *(fails: module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68431e10be0c8333a73db9c221b6d176