### PR TITLE
Add range trading note prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ TRADES_DB_PATH=trades-002.db
    range mode regardless of ADX. When the width falls below this value the system
    treats the market as ranging and the AI prompt notes that *BB width is
    contracting*.
-   `ENABLE_RANGE_ENTRY` を `true` にすると、ADX のノートレード判定を無視してレンジ相場でもエントリーを許可します。価格がボリンジャーバンド中心から `RANGE_ENTRY_OFFSET_PIPS` pips 以内にある場合は、市場注文をバンド端の LIMIT に変換します。この処理は `backend/strategy/entry_logic.py` で行われます。
+`ENABLE_RANGE_ENTRY` を `true` にすると、ADX のノートレード判定を無視してレンジ相場でもエントリーを許可します。価格がボリンジャーバンド中心から `RANGE_ENTRY_OFFSET_PIPS` pips 以内にある場合は、市場注文をバンド端の LIMIT に変換します。この処理は `backend/strategy/entry_logic.py` で行われます。
+`RANGE_ENTRY_NOTE` を指定すると、その内容が AI プロンプトに追記され、レンジ相場での細かな指示を外部から設定できます。
 `AI_PROFIT_TRIGGER_RATIO` defines what portion of the take-profit target must
 be reached before an AI exit check occurs. The default value is `0.5` (50%).
 `SCALE_LOT_SIZE` sets how many lots are added when the AI exit decision is `SCALE`.

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -13,6 +13,11 @@ MIN_RRR = float(env_loader.get_env("MIN_RRR", "0.8"))
 MIN_NET_TP_PIPS = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))
 TREND_ADX_THRESH = float(env_loader.get_env("TREND_ADX_THRESH", "20"))
 TREND_PROMPT_BIAS = env_loader.get_env("TREND_PROMPT_BIAS", "normal").lower()
+# レンジ相場でのトレード方針を任意に追記できる環境変数
+RANGE_ENTRY_NOTE = env_loader.get_env(
+    "RANGE_ENTRY_NOTE",
+    "When the market is RANGE, consider quick trades near Bollinger Band edges with small targets."
+)
 
 
 def _series_tail_list(series, n: int = 20) -> list:
@@ -169,6 +174,7 @@ Classify as "TREND" if ANY TWO of the following conditions are met:
 - Price consistently outside the Bollinger Band midline (above for bullish, below for bearish).
 
 If these conditions are not clearly met, classify the market as "RANGE".
+{RANGE_ENTRY_NOTE}
 
 🚫【Counter-trend Trade Prohibition】
 Under clearly identified TREND conditions, avoid counter-trend trades and never rely solely on RSI extremes. Treat pullbacks as trend continuation. However, if a strong reversal pattern such as a double top/bottom or head-and-shoulders is detected and ADX is turning down, a small counter-trend position is acceptable.


### PR DESCRIPTION
## Summary
- add new `RANGE_ENTRY_NOTE` env var for range prompt
- mention it in README documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431f0477f883339b4c8ae51b60c766