### PR TITLE
Enhance trade mode scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ loaded from environment variables and optional YAML files under `config/`.
 - `MODE_ATR_PIPS_MIN` / `MODE_BBWIDTH_PIPS_MIN` … ボラティリティ判定用の閾値
 - `MODE_EMA_SLOPE_MIN` / `MODE_ADX_MIN` … モメンタム判定のしきい値
 - `MODE_VOL_MA_MIN` … 流動性判定に使う出来高平均
+- `MODE_DI_DIFF_MIN` / `MODE_DI_DIFF_STRONG` … +DIと−DIの差を評価する閾値
+- `MODE_VOL_RATIO_MIN` / `MODE_VOL_RATIO_STRONG` … 出来高比率判定に使用
+- `MODE_BONUS_START_JST` / `MODE_BONUS_END_JST` … トレンドを優遇する時間帯
+- `MODE_PENALTY_START_JST` / `MODE_PENALTY_END_JST` … スキャルプを優遇する時間帯
 - `MODE_ATR_QTL` / `MODE_ADX_QTL` … ATR・ADX の分位点を利用する場合の割合
 - `MODE_QTL_LOOKBACK` … 分位点計算に使う過去本数
 - `HTF_SLOPE_MIN` … 上位足 EMA 傾きチェック用のしきい値

--- a/docs/composite_mode.md
+++ b/docs/composite_mode.md
@@ -1,14 +1,18 @@
 # decide_trade_mode の概要
 
-`decide_trade_mode` は ATR、ADX、出来高平均の三指標を0〜1に正規化し、平均スコアで市況を判定します。スコアが 0.66 以上なら `trend_follow`、0.33 以下なら `scalp_momentum` となり、その中間は直前のモードを維持します。
+`decide_trade_mode` は ATR、ADX、DI 差、EMA 傾き、出来高を各 0〜2 点でスコア化し、合計点を正規化して市況を判定します。指標が強ければ 2 点、基準を満たせば 1 点と段階的に加算されます。スコアが 0.66 以上なら `trend_follow`、0.33 以下なら `scalp_momentum` となり、その中間は直前のモードを維持します。
 
 主な環境変数は次の通りです。
 
 - `MODE_ATR_PIPS_MIN` / `MODE_BBWIDTH_PIPS_MIN` … ボラティリティ判定に使う閾値
 - `MODE_EMA_SLOPE_MIN` / `MODE_ADX_MIN` … モメンタム判定のしきい値
+- `MODE_DI_DIFF_MIN` / `MODE_DI_DIFF_STRONG` … +DIと−DIの差を評価する閾値
+- `MODE_VOL_RATIO_MIN` / `MODE_VOL_RATIO_STRONG` … 出来高と平均の比率評価に使用
 - `MODE_VOL_MA_MIN` … 流動性判定に使う出来高平均
 - `MODE_ATR_QTL` / `MODE_ADX_QTL` … 過去データから算出するATR・ADXの分位点
 - `MODE_QTL_LOOKBACK` … 上記計算に使う本数 (デフォルト20)
 - `HTF_SLOPE_MIN` … 上位足EMA傾きチェックのしきい値
 - `TREND_ENTER_SCORE` / `SCALP_ENTER_SCORE` … モード切替に使う基準値
 - `TREND_HOLD_SCORE` / `SCALP_HOLD_SCORE` … ヒステリシス用の維持しきい値
+- `MODE_BONUS_START_JST` / `MODE_BONUS_END_JST` … トレンド寄りに補正する時間帯
+- `MODE_PENALTY_START_JST` / `MODE_PENALTY_END_JST` … スキャルプ寄りに補正する時間帯

--- a/tests/test_composite_scoring.py
+++ b/tests/test_composite_scoring.py
@@ -1,0 +1,52 @@
+import importlib
+import os
+
+
+def _reload_module():
+    import signals.composite_mode as cm
+    return importlib.reload(cm)
+
+
+def test_mode_scores_trend(monkeypatch):
+    monkeypatch.setenv("MODE_ADX_MIN", "25")
+    monkeypatch.setenv("MODE_ADX_STRONG", "40")
+    monkeypatch.setenv("MODE_DI_DIFF_MIN", "10")
+    monkeypatch.setenv("MODE_DI_DIFF_STRONG", "25")
+    monkeypatch.setenv("MODE_EMA_SLOPE_MIN", "0.1")
+    monkeypatch.setenv("MODE_EMA_SLOPE_STRONG", "0.3")
+    monkeypatch.setenv("MODE_VOL_MA_MIN", "80")
+    monkeypatch.setenv("MODE_VOL_RATIO_MIN", "1")
+    monkeypatch.setenv("MODE_VOL_RATIO_STRONG", "2")
+    monkeypatch.setenv("MODE_ATR_PIPS_MIN", "5")
+    cm = _reload_module()
+    inds = {
+        "atr": [10.0],
+        "adx": [45],
+        "plus_di": [50],
+        "minus_di": [10],
+        "ema_slope": [0.4],
+        "volume": [200, 200, 200, 200, 200],
+    }
+    mode, score, _ = cm.decide_trade_mode_detail(inds)
+    assert mode == "trend_follow"
+    assert score > 0.9
+
+
+def test_mode_scores_scalp(monkeypatch):
+    monkeypatch.setenv("MODE_ADX_MIN", "25")
+    monkeypatch.setenv("MODE_DI_DIFF_MIN", "10")
+    monkeypatch.setenv("MODE_EMA_SLOPE_MIN", "0.1")
+    monkeypatch.setenv("MODE_VOL_MA_MIN", "80")
+    monkeypatch.setenv("MODE_ATR_PIPS_MIN", "5")
+    cm = _reload_module()
+    inds = {
+        "atr": [3.0],
+        "adx": [20],
+        "plus_di": [21],
+        "minus_di": [20],
+        "ema_slope": [0.05],
+        "volume": [60, 60, 60, 60, 60],
+    }
+    mode, score, _ = cm.decide_trade_mode_detail(inds)
+    assert mode == "scalp_momentum"
+    assert score < 0.5


### PR DESCRIPTION
## Summary
- integrate DI difference and EMA slope into scoring
- adjust score with time-of-day bonus/penalty
- update composite mode documentation and env variables
- add tests for new scoring logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a0a319748333859dd881e0ce2033