### PR TITLE
Add regime GMM detector and CVaR utility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,4 @@ docker==7.0.0
 line-bot-sdk
 apscheduler==3.10.4
 PyYAML==6.0.1
+scikit-learn==1.4.2

--- a/docs/adaptive_architecture.md
+++ b/docs/adaptive_architecture.md
@@ -6,7 +6,9 @@
 ## 1. レジーム認識層
 
 - 価格・テクニカル指標・オーダーフローから特徴量を生成し、GMM あるいは HDBSCAN に
-  よるクラスタリングで市場レジームを分類します。
+  よるクラスタリングで市場レジームを分類します。単純な実装例として
+  `regime/gmm_detector.py` の `GMMRegimeDetector` クラスを追加しました
+  【F:regime/gmm_detector.py†L1-L30】。
 - 主要な特徴量として ATR・ADX などのテクニカル値を `indicators/rolling.py` で計算しま
   す【F:backend/indicators/rolling.py†L24-L48】。
 - 学習済みモデルは `models/` 以下に保存し、ジョブランナー起動時に読み込みます。
@@ -24,7 +26,8 @@
 - ロット数計算や TP/SL 管理は `strategy/risk_manager.py` の `calc_lot_size` に代表される
   関数群で処理します【F:backend/strategy/risk_manager.py†L1-L12】。
 - ポジション全体のリスクを CVaR 等で監視し、必要に応じてポジション縮小や強制決済を
-  行います。
+  行います。`risk/cvar.py` に `calc_cvar` 関数を実装し、損益系列から簡単に計算でき
+  るようにしました【F:risk/cvar.py†L1-L19】。
 - ストップロス・トレーリングは `strategy/exit_logic.py` にまとめられています
   【F:backend/strategy/exit_logic.py†L15-L24】。
 

--- a/regime/__init__.py
+++ b/regime/__init__.py
@@ -1,0 +1,3 @@
+from .gmm_detector import GMMRegimeDetector
+
+__all__ = ["GMMRegimeDetector"]

--- a/regime/gmm_detector.py
+++ b/regime/gmm_detector.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Gaussian Mixture Model によるレジーム認識クラス."""
+
+from typing import Any
+
+import numpy as np
+from sklearn.mixture import GaussianMixture
+
+
+class GMMRegimeDetector:
+    """単純な GMM ベースのレジーム検出器."""
+
+    def __init__(self, n_components: int = 3, random_state: int | None = None) -> None:
+        self.model = GaussianMixture(n_components=n_components, random_state=random_state)
+
+    def fit(self, features: np.ndarray) -> None:
+        """特徴量行列でモデルを学習."""
+        self.model.fit(features)
+
+    def predict(self, features: np.ndarray) -> np.ndarray:
+        """レジームラベルを返す."""
+        return self.model.predict(features)
+
+    def predict_one(self, x: Any) -> int:
+        """単一サンプルのラベルを返すヘルパー."""
+        arr = np.asarray(x).reshape(1, -1)
+        return int(self.predict(arr)[0])
+
+__all__ = ["GMMRegimeDetector"]

--- a/risk/__init__.py
+++ b/risk/__init__.py
@@ -1,0 +1,4 @@
+from .trade_guard import TradeGuard
+from .cvar import calc_cvar
+
+__all__ = ["TradeGuard", "calc_cvar"]

--- a/risk/cvar.py
+++ b/risk/cvar.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""CVaR (Expected Shortfall) 計算ユーティリティ."""
+
+from typing import Sequence
+
+
+def calc_cvar(returns: Sequence[float], alpha: float = 0.05) -> float:
+    """指定した信頼水準での平均損失を返す。"""
+    if not returns:
+        raise ValueError("returns must not be empty")
+    if not 0 < alpha <= 1:
+        raise ValueError("alpha must be in (0,1]")
+    sorted_returns = sorted(returns)
+    idx = max(1, int(len(sorted_returns) * alpha))
+    tail = sorted_returns[:idx]
+    return sum(tail) / len(tail)
+
+__all__ = ["calc_cvar"]

--- a/tests/test_cvar.py
+++ b/tests/test_cvar.py
@@ -1,0 +1,16 @@
+from risk.cvar import calc_cvar
+import pytest
+
+
+def test_calc_cvar_basic():
+    returns = [1.0, -2.0, -1.0, 3.0, -4.0]
+    result = calc_cvar(returns, alpha=0.4)
+    assert result == pytest.approx((-4.0 - 2.0)/2)
+
+
+def test_calc_cvar_errors():
+    with pytest.raises(ValueError):
+        calc_cvar([])
+    with pytest.raises(ValueError):
+        calc_cvar([1,2], alpha=0)
+

--- a/tests/test_gmm_detector.py
+++ b/tests/test_gmm_detector.py
@@ -1,0 +1,13 @@
+import numpy as np
+from regime.gmm_detector import GMMRegimeDetector
+
+
+def test_gmm_regime_detector():
+    X = np.array([[0.0], [0.1], [0.2], [3.0], [3.1], [3.2]])
+    detector = GMMRegimeDetector(n_components=2, random_state=42)
+    detector.fit(X)
+    labels = detector.predict(X)
+    assert set(labels) == {0, 1}
+    single = detector.predict_one([0.05])
+    assert single in {0, 1}
+


### PR DESCRIPTION
## Summary
- implement `GMMRegimeDetector` for clustering based regime recognition
- provide `calc_cvar` helper to compute Conditional VaR
- document new modules in `adaptive_architecture.md`
- add corresponding unit tests
- include `scikit-learn` dependency

## Testing
- `pytest -q tests/test_cvar.py tests/test_gmm_detector.py`
- `pytest -q` *(fails: TestAtrTpSlMult::test_atr_based_tp_sl)*

------
https://chatgpt.com/codex/tasks/task_e_6843b13bedbc8333be907c65845c9824