### PR TITLE
Add clustering regime recognition

### DIFF
--- a/analysis/cluster_regime.py
+++ b/analysis/cluster_regime.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""学習済みクラスタリングモデルを用いたレジーム推定ヘルパー."""
+
+from typing import Any
+import pickle
+from pathlib import Path
+
+import numpy as np
+
+from regime import RegimeFeatureExtractor
+
+
+class ClusterRegime:
+    """保存済みモデルと特徴量抽出器でレジーム推定を行うクラス."""
+
+    def __init__(self, model_path: str, extractor: RegimeFeatureExtractor | None = None) -> None:
+        self.model_path = Path(model_path)
+        self.extractor = extractor or RegimeFeatureExtractor()
+        with self.model_path.open("rb") as f:
+            self.model = pickle.load(f)
+        self.current: int | None = None
+
+    def update(self, tick: dict[str, Any]) -> dict[str, Any]:
+        """tick データを処理してレジーム判定を返す."""
+        feat = self.extractor.update(tick).reshape(1, -1)
+        label = int(self.model.predict(feat)[0])
+        transition = label != self.current
+        self.current = label
+        return {"regime_id": label, "transition": transition}
+
+    def predict_one(self, x: Any) -> int:
+        arr = np.asarray(x).reshape(1, -1)
+        return int(self.model.predict(arr)[0])
+
+__all__ = ["ClusterRegime"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,3 +34,4 @@ line-bot-sdk
 apscheduler==3.10.4
 PyYAML==6.0.1
 scikit-learn==1.4.2
+hdbscan==0.8.33

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -227,6 +227,16 @@ class JobRunner:
         # Epoch timestamp of last AI call (seconds)
         self.last_ai_call = datetime.min
         self.regime_detector = RegimeDetector()
+        model_file = os.path.join(PROJECT_ROOT, "models", "regime_gmm.pkl")
+        if os.path.exists(model_file):
+            try:
+                from analysis.cluster_regime import ClusterRegime
+                self.cluster_regime = ClusterRegime(model_file)
+            except Exception as exc:  # pragma: no cover - optional model
+                logger.warning(f"ClusterRegime load failed: {exc}")
+                self.cluster_regime = None
+        else:
+            self.cluster_regime = None
         # Entry cooldown settings
         self.entry_cooldown_sec = int(env_loader.get_env("ENTRY_COOLDOWN_SEC", "30"))
         self.last_close_ts: datetime | None = None
@@ -775,6 +785,10 @@ class JobRunner:
                         rd_res = self.regime_detector.update(tick)
                         if rd_res.get("transition"):
                             self.last_ai_call = datetime.min
+                        if self.cluster_regime:
+                            cr_res = self.cluster_regime.update(tick)
+                            if cr_res.get("transition"):
+                                self.last_ai_call = datetime.min
                     except Exception as exc:
                         logger.debug(f"RegimeDetector update failed: {exc}")
 

--- a/regime/__init__.py
+++ b/regime/__init__.py
@@ -1,3 +1,5 @@
 from .gmm_detector import GMMRegimeDetector
+from .hdbscan_detector import HDBSCANRegimeDetector
+from .features import RegimeFeatureExtractor
 
-__all__ = ["GMMRegimeDetector"]
+__all__ = ["GMMRegimeDetector", "HDBSCANRegimeDetector", "RegimeFeatureExtractor"]

--- a/regime/features.py
+++ b/regime/features.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""レジーム分類用の特徴量計算ヘルパー."""
+
+from typing import Any, Dict
+
+import numpy as np
+
+from backend.indicators.rolling import RollingATR, RollingADX, RollingBBWidth
+
+
+class RegimeFeatureExtractor:
+    """ローリング指標を用いた特徴量抽出クラス."""
+
+    def __init__(self, window: int = 20) -> None:
+        self.atr = RollingATR(window)
+        self.adx = RollingADX(window)
+        self.bbwidth = RollingBBWidth(window=window)
+
+    def update(self, tick: Dict[str, Any]) -> np.ndarray:
+        """tick データから特徴量を生成する."""
+        atr_ratio = self.atr.update(tick)
+        adx_val, _ = self.adx.update(tick)
+        bw_ratio = self.bbwidth.update(tick)
+        return np.array([atr_ratio, adx_val, bw_ratio], dtype=float)
+
+    def process_all(self, data: list[Dict[str, Any]]) -> np.ndarray:
+        """複数データポイントから特徴量行列を作成する."""
+        feats = [self.update(t) for t in data]
+        return np.vstack(feats)
+
+__all__ = ["RegimeFeatureExtractor"]

--- a/regime/hdbscan_detector.py
+++ b/regime/hdbscan_detector.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""HDBSCAN によるレジーム認識クラス."""
+
+from typing import Any
+
+import numpy as np
+
+try:
+    import hdbscan
+    from hdbscan import prediction as hdbscan_prediction
+except Exception as exc:  # pragma: no cover - optional dependency
+    hdbscan = None
+    hdbscan_prediction = None
+
+
+class HDBSCANRegimeDetector:
+    """HDBSCAN を用いたレジーム分類器."""
+
+    def __init__(self, min_cluster_size: int = 5) -> None:
+        if hdbscan is None:
+            raise ImportError("hdbscan library is required for HDBSCANRegimeDetector")
+        self.model = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size, prediction_data=True)
+
+    def fit(self, features: np.ndarray) -> None:
+        """特徴量行列でモデルを学習."""
+        self.model.fit(features)
+
+    def predict(self, features: np.ndarray) -> np.ndarray:
+        """レジームラベルを返す."""
+        if hdbscan_prediction is None:
+            raise RuntimeError("hdbscan prediction utilities not available")
+        labels, _ = hdbscan_prediction.approximate_predict(self.model, features)
+        return labels
+
+    def predict_one(self, x: Any) -> int:
+        """単一サンプルのラベルを返すヘルパー."""
+        arr = np.asarray(x).reshape(1, -1)
+        return int(self.predict(arr)[0])
+
+__all__ = ["HDBSCANRegimeDetector"]

--- a/tests/test_hdbscan_detector.py
+++ b/tests/test_hdbscan_detector.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+try:
+    import hdbscan  # noqa: F401
+except Exception:  # pragma: no cover - skip if not available
+    pytest.skip("hdbscan not available", allow_module_level=True)
+
+from regime.hdbscan_detector import HDBSCANRegimeDetector
+
+
+def test_hdbscan_regime_detector():
+    X = np.array([[0.0], [0.1], [0.2], [3.0], [3.1], [3.2]])
+    detector = HDBSCANRegimeDetector(min_cluster_size=2)
+    detector.fit(X)
+    labels = detector.predict(X)
+    assert set(labels) == {0, 1}
+    single = detector.predict_one([0.05])
+    assert single in {0, 1}


### PR DESCRIPTION
## Summary
- implement `HDBSCANRegimeDetector` and feature extraction helpers
- allow loading pretrained clustering model with `ClusterRegime`
- integrate regime model in job runner
- add tests for HDBSCAN detector
- include hdbscan in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68444fc826188333adbff78823fdda38