### PR TITLE
Implement portfolio risk manager

### DIFF
--- a/backend/strategy/risk_manager.py
+++ b/backend/strategy/risk_manager.py
@@ -1,9 +1,24 @@
 """Risk management helper functions."""
 from __future__ import annotations
 
+from typing import Optional
 
-def calc_lot_size(balance: float, risk_pct: float, sl_pips: float, pip_value: float) -> float:
+try:
+    from risk.portfolio_risk_manager import PortfolioRiskManager
+except Exception:  # pragma: no cover - optional dependency during tests
+    PortfolioRiskManager = None  # type: ignore
+
+
+def calc_lot_size(
+    balance: float,
+    risk_pct: float,
+    sl_pips: float,
+    pip_value: float,
+    risk_engine: Optional[PortfolioRiskManager] = None,
+) -> float:
     """Return allowed lot size based on account balance and risk percent."""
+    if risk_engine is not None:
+        return risk_engine.get_allowed_lot(balance, risk_pct, sl_pips, pip_value)
     if sl_pips <= 0 or pip_value <= 0:
         raise ValueError("sl_pips and pip_value must be positive")
     risk_amount = balance * risk_pct

--- a/docs/adaptive_architecture.md
+++ b/docs/adaptive_architecture.md
@@ -24,7 +24,7 @@
 ## 3. 統合リスクエンジン
 
 - ロット数計算や TP/SL 管理は `strategy/risk_manager.py` の `calc_lot_size` に代表される
-  関数群で処理します【F:backend/strategy/risk_manager.py†L1-L12】。
+  関数群で処理します【F:backend/strategy/risk_manager.py†L1-L25】。
 - ポジション全体のリスクを CVaR 等で監視し、必要に応じてポジション縮小や強制決済を
   行います。`risk/cvar.py` に `calc_cvar` 関数を実装し、損益系列から簡単に計算でき
   るようにしました【F:risk/cvar.py†L1-L19】。

--- a/risk/__init__.py
+++ b/risk/__init__.py
@@ -1,4 +1,5 @@
 from .trade_guard import TradeGuard
 from .cvar import calc_cvar
+from .portfolio_risk_manager import PortfolioRiskManager
 
-__all__ = ["TradeGuard", "calc_cvar"]
+__all__ = ["TradeGuard", "calc_cvar", "PortfolioRiskManager"]

--- a/risk/portfolio_risk_manager.py
+++ b/risk/portfolio_risk_manager.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""CVaRベースのポートフォリオリスク管理エンジン."""
+
+from typing import Sequence
+
+from .cvar import calc_cvar
+from backend.strategy import risk_manager as strat_rm
+
+
+class PortfolioRiskManager:
+    """シンプルなポートフォリオリスク管理クラス."""
+
+    def __init__(self, max_cvar: float, alpha: float = 0.05) -> None:
+        self.max_cvar = float(max_cvar)
+        self.alpha = float(alpha)
+        self.current_cvar = 0.0
+
+    def update_risk_metrics(
+        self, trade_log: Sequence[float], open_positions: Sequence[float] | None = None
+    ) -> None:
+        """実現損益と含み損益からCVaRを計算する."""
+        returns: list[float] = list(trade_log)
+        if open_positions:
+            returns.extend(open_positions)
+        if returns:
+            self.current_cvar = calc_cvar(returns, self.alpha)
+        else:
+            self.current_cvar = 0.0
+
+    def check_stop_conditions(self) -> bool:
+        """許容CVaRを超過したかを判定する."""
+        return abs(self.current_cvar) >= self.max_cvar
+
+    def get_allowed_lot(
+        self,
+        balance: float,
+        risk_pct: float,
+        sl_pips: float,
+        pip_value: float,
+    ) -> float:
+        """現在のリスク水準に基づきロット数を返す."""
+        base = strat_rm.calc_lot_size(balance, risk_pct, sl_pips, pip_value)
+        if self.check_stop_conditions():
+            return 0.0
+        factor = max(0.0, 1.0 - abs(self.current_cvar) / self.max_cvar)
+        return base * factor
+
+__all__ = ["PortfolioRiskManager"]

--- a/tests/test_portfolio_risk_manager.py
+++ b/tests/test_portfolio_risk_manager.py
@@ -1,0 +1,18 @@
+from risk.portfolio_risk_manager import PortfolioRiskManager
+from backend.strategy.risk_manager import calc_lot_size
+
+
+def test_portfolio_risk_manager_basic():
+    mgr = PortfolioRiskManager(max_cvar=2.0, alpha=0.5)
+    mgr.update_risk_metrics([-1.0, -3.0], [])
+    assert mgr.check_stop_conditions()
+    lot = calc_lot_size(10000, 0.01, 20, 0.1, risk_engine=mgr)
+    assert lot == 0.0
+
+
+def test_portfolio_risk_manager_reduction():
+    mgr = PortfolioRiskManager(max_cvar=5.0, alpha=0.5)
+    mgr.update_risk_metrics([-1.0, -3.0], [])
+    lot = calc_lot_size(10000, 0.01, 20, 0.1, risk_engine=mgr)
+    base = calc_lot_size(10000, 0.01, 20, 0.1)
+    assert 0 < lot < base


### PR DESCRIPTION
## Summary
- add CVaR-based `PortfolioRiskManager`
- expose new risk manager in package init
- extend `calc_lot_size` to support portfolio risk engine
- update documentation with new line references
- test portfolio risk management logic

## Testing
- `pytest tests/test_portfolio_risk_manager.py tests/test_cvar.py backend/tests/test_risk_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68444fee546083339d817d547e4ae3d0