### PR TITLE
Implement monitoring layer with Kafka metrics

### DIFF
--- a/backend/logs/perf_stats_logger.py
+++ b/backend/logs/perf_stats_logger.py
@@ -6,6 +6,12 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    from monitoring.metrics_publisher import publish as publish_metric
+except Exception:  # pragma: no cover - optional during tests
+    def publish_metric(*_args, **_kwargs):
+        return None
+
 LOG_PATH = Path(__file__).resolve().parent / "perf_stats.jsonl"
 
 
@@ -20,6 +26,10 @@ def log_perf(tag: str, start: float, end: float) -> None:
         with LOG_PATH.open("a", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False)
             f.write("\n")
+    except Exception:
+        pass
+    try:
+        publish_metric("perf_seconds", data["elapsed"], {"tag": tag})
     except Exception:
         pass
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,3 +34,5 @@ line-bot-sdk
 apscheduler==3.10.4
 PyYAML==6.0.1
 scikit-learn==1.4.2
+kafka-python==2.0.2
+prometheus-client==0.20.0

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -71,6 +71,8 @@ except Exception:  # pragma: no cover - test stubs may lack filter_pre_ai
         return False
 from analysis.signal_filter import is_multi_tf_aligned
 from backend.logs.perf_stats_logger import PerfTimer
+from monitoring import metrics_publisher
+from monitoring.safety_trigger import SafetyTrigger
 from backend.strategy.signal_filter import pass_exit_filter
 from backend.strategy.openai_analysis import (
     get_market_condition,
@@ -207,6 +209,11 @@ class JobRunner:
     def __init__(self, interval_seconds=1):
         self.interval_seconds = interval_seconds
         self.last_run = None
+        self._stop = False
+        loss_lim = float(env_loader.get_env("LOSS_LIMIT", "0"))
+        err_lim = int(env_loader.get_env("ERROR_LIMIT", "0"))
+        self.safety = SafetyTrigger(loss_limit=loss_lim, error_limit=err_lim)
+        self.safety.attach(self.stop)
         # --- AI cooldown values ---------------------------------------
         #   * AI_COOLDOWN_SEC_OPEN : エントリー用クールダウン時間
         #   * AI_COOLDOWN_SEC_FLAT : エグジット用クールダウン時間
@@ -744,7 +751,7 @@ class JobRunner:
 
     def run(self):
         logger.info("Job Runner started.")
-        while True:
+        while not self._stop:
             try:
                 timer = PerfTimer("job_loop")
                 now = datetime.now(timezone.utc)
@@ -1049,6 +1056,13 @@ class JobRunner:
                                     ai_reason="peak exit",
                                     exit_reason=ExitReason.RISK,
                                     is_manual=False,
+                                )
+                                pl = float(has_position.get("pl_corrected", has_position.get("pl", 0)))
+                                self.safety.record_loss(pl)
+                                metrics_publisher.publish(
+                                    "trade_pl",
+                                    pl,
+                                    {"reason": "peak"},
                                 )
                                 self.last_close_ts = datetime.now(timezone.utc)
                                 send_line_message(
@@ -1632,12 +1646,23 @@ class JobRunner:
                 self.last_run = now
 
                 update_oanda_trades()
+                metrics_publisher.publish(
+                    "job_loop_success",
+                    1,
+                    {"mode": self.trade_mode or "unknown"},
+                )
                 time.sleep(self.interval_seconds)
                 timer.stop()
 
             except Exception as e:
                 logger.error(f"Error occurred during job execution: {e}", exc_info=True)
+                self.safety.record_error()
+                metrics_publisher.publish("job_error", 1)
                 time.sleep(self.interval_seconds)
+
+    def stop(self) -> None:
+        """Signal the runner loop to exit."""
+        self._stop = True
 
 
 if __name__ == "__main__":

--- a/monitoring/metrics_publisher.py
+++ b/monitoring/metrics_publisher.py
@@ -1,0 +1,54 @@
+import json
+import logging
+import os
+from datetime import datetime
+
+from kafka import KafkaProducer
+from prometheus_client import Gauge
+
+logger = logging.getLogger(__name__)
+
+KAFKA_SERVERS = os.getenv("KAFKA_SERVERS", "localhost:9092")
+METRICS_TOPIC = os.getenv("METRICS_TOPIC", "metrics")
+
+# Kafka producer is initialized lazily so unit tests can run without Kafka.
+_producer = None
+_gauges: dict[str, Gauge] = {}
+
+
+def _get_producer() -> KafkaProducer | None:
+    global _producer
+    if _producer is None:
+        try:
+            _producer = KafkaProducer(
+                bootstrap_servers=KAFKA_SERVERS.split(","),
+                value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            )
+        except Exception as exc:  # pragma: no cover - Kafka optional
+            logger.debug(f"Kafka producer init failed: {exc}")
+            _producer = None
+    return _producer
+
+
+def publish(metric: str, value: float, labels: dict | None = None) -> None:
+    """Send metric to Kafka and update Prometheus gauge."""
+    labels = labels or {}
+    data = {
+        "metric": metric,
+        "value": value,
+        "labels": labels,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    producer = _get_producer()
+    if producer:
+        try:
+            producer.send(METRICS_TOPIC, data)
+        except Exception as exc:  # pragma: no cover
+            logger.debug(f"Kafka publish failed: {exc}")
+    gauge_key = metric + "_" + "_".join(sorted(labels))
+    if gauge_key not in _gauges:
+        _gauges[gauge_key] = Gauge(metric, metric, labelnames=list(labels))
+    try:
+        _gauges[gauge_key].labels(**labels).set(value)
+    except Exception as exc:  # pragma: no cover - avoid crash
+        logger.debug(f"Gauge update failed: {exc}")

--- a/monitoring/safety_trigger.py
+++ b/monitoring/safety_trigger.py
@@ -1,0 +1,50 @@
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+
+class SafetyTrigger:
+    """Monitor loss and error metrics and trigger stop callbacks."""
+
+    def __init__(self, loss_limit: float = 0.0, error_limit: int = 0, cooldown_sec: int = 0):
+        self.loss_limit = loss_limit
+        self.error_limit = error_limit
+        self.cooldown = timedelta(seconds=cooldown_sec)
+        self._loss = 0.0
+        self._errors = 0
+        self._stopped_at: datetime | None = None
+        self._callback = None
+
+    def attach(self, callback) -> None:
+        """Set callback invoked on stop."""
+        self._callback = callback
+
+    def record_loss(self, amount: float) -> None:
+        self._loss += amount
+        logger.debug(f"Cumulative loss updated: {self._loss}")
+        self._check()
+
+    def record_error(self) -> None:
+        self._errors += 1
+        logger.debug(f"Error count updated: {self._errors}")
+        self._check()
+
+    def _check(self) -> None:
+        if self._stopped_at and datetime.utcnow() - self._stopped_at < self.cooldown:
+            return
+        if self.loss_limit and self._loss <= -abs(self.loss_limit):
+            logger.warning("Loss limit exceeded – triggering stop")
+            self._trigger()
+        if self.error_limit and self._errors >= self.error_limit:
+            logger.warning("Error limit exceeded – triggering stop")
+            self._trigger()
+
+    def _trigger(self) -> None:
+        self._stopped_at = datetime.utcnow()
+        if self._callback:
+            try:
+                self._callback()
+            except Exception as exc:  # pragma: no cover
+                logger.error(f"Safety trigger callback failed: {exc}")
+


### PR DESCRIPTION
## Summary
- add `metrics_publisher` to send Kafka metrics and expose Prometheus gauges
- implement `SafetyTrigger` for self-stop logic
- log PerfTimer data to Kafka
- publish job loop success and trade P/L metrics
- track loss and errors to trigger safety stop
- update requirements with kafka and prometheus libraries

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ImportError and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844500e3bf88333bb782d021cbc11f0