### PR TITLE
Add macro analyzer and local model modules

### DIFF
--- a/ai/local_model.py
+++ b/ai/local_model.py
@@ -1,0 +1,57 @@
+"""OpenAI 互換のローカルモデル呼び出しラッパー"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from backend.utils import env_loader
+from backend.utils import openai_client
+
+logger = logging.getLogger(__name__)
+
+USE_LOCAL_MODEL = env_loader.get_env("USE_LOCAL_MODEL", "false").lower() == "true"
+LOCAL_MODEL_NAME = env_loader.get_env("LOCAL_MODEL_NAME", "distilgpt2")
+
+_pipeline = None
+
+
+def _load_pipeline():
+    global _pipeline
+    if _pipeline is None:
+        try:
+            from transformers import pipeline
+
+            _pipeline = pipeline("text-generation", model=LOCAL_MODEL_NAME)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.error("Failed to load local model: %s", exc)
+            raise
+    return _pipeline
+
+
+def ask_model(
+    prompt: str,
+    system_prompt: str = "You are a helpful assistant.",
+    model: str | None = None,
+    **kwargs: Any,
+) -> dict:
+    """OpenAI API と互換の返値を持つモデル呼び出し"""
+    if USE_LOCAL_MODEL:
+        pipe = _load_pipeline()
+        try:
+            outputs = pipe(prompt, max_new_tokens=256)
+            text = outputs[0]["generated_text"]
+            try:
+                return json.loads(text)
+            except Exception:
+                return {"text": text}
+        except Exception as exc:
+            logger.error("Local model inference failed: %s", exc)
+            raise
+    else:
+        return openai_client.ask_openai(
+            prompt,
+            system_prompt=system_prompt,
+            model=model,
+            **kwargs,
+        )

--- a/ai/macro_analyzer.py
+++ b/ai/macro_analyzer.py
@@ -1,0 +1,80 @@
+"""FRED と GDELT からニュースを取得して要約するモジュール"""
+from __future__ import annotations
+
+import requests
+from typing import Any
+
+from backend.utils import env_loader
+from ai.local_model import ask_model
+from ai.prompt_templates import get_template
+
+
+class MacroAnalyzer:
+    """経済ニュース要約とセンチメント解析を行うクラス"""
+
+    def __init__(self, fred_api_key: str | None = None):
+        self.fred_api_key = fred_api_key or env_loader.get_env("FRED_API_KEY")
+
+    # ------------------------------------------------------------
+    # FRED API
+    # ------------------------------------------------------------
+    def fetch_fred_series(self, series_id: str, limit: int = 10) -> list[dict]:
+        if not self.fred_api_key:
+            raise RuntimeError("FRED_API_KEY not set")
+        url = "https://api.stlouisfed.org/fred/series/observations"
+        params = {
+            "series_id": series_id,
+            "api_key": self.fred_api_key,
+            "file_type": "json",
+            "limit": limit,
+        }
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("observations", [])
+
+    # ------------------------------------------------------------
+    # GDELT API
+    # ------------------------------------------------------------
+    def fetch_gdelt_articles(self, query: str, maxrecords: int = 10) -> list[dict]:
+        url = "https://api.gdeltproject.org/api/v2/doc/doc"
+        params = {
+            "query": query,
+            "mode": "ArtList",
+            "format": "json",
+            "maxrecords": maxrecords,
+        }
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json().get("articles", [])
+
+    def summarize_articles(self, articles: list[dict]) -> str:
+        headlines = [a.get("title") or a.get("semtitle") or "" for a in articles]
+        text = "\n".join(headlines)
+        prompt = get_template("news_summary").format(text=text)
+        result = ask_model(prompt)
+        if isinstance(result, dict):
+            return result.get("summary") or result.get("text", "")
+        return str(result)
+
+    def get_market_summary(
+        self, query: str = "economy", series_id: str = "UNRATE"
+    ) -> dict[str, Any]:
+        """FRED 指標とニュース要約をまとめて取得する"""
+        fred = []
+        try:
+            fred = self.fetch_fred_series(series_id, 5)
+        except Exception:
+            fred = []
+        articles = []
+        try:
+            articles = self.fetch_gdelt_articles(query, 5)
+        except Exception:
+            articles = []
+        summary = ""
+        if articles:
+            try:
+                summary = self.summarize_articles(articles)
+            except Exception:
+                summary = ""
+        return {"fred": fred, "summary": summary, "articles": articles}

--- a/ai/prompt_templates.py
+++ b/ai/prompt_templates.py
@@ -1,0 +1,15 @@
+"""プロンプトテンプレート管理モジュール"""
+
+PROMPT_TEMPLATES = {
+    "news_summary": (
+        "Summarize the following news headlines and infer market sentiment in three sentences.\n{text}"
+    ),
+    "technical_entry": (
+        "Based on the given technical indicators, decide entry side and risk levels." 
+    ),
+}
+
+
+def get_template(name: str) -> str:
+    """テンプレート名から文字列を取得する。"""
+    return PROMPT_TEMPLATES.get(name, "")

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -45,6 +45,7 @@ def build_trade_plan_prompt(
     candles_d1: list,
     hist_stats: dict | None,
     pattern_line: str | None,
+    macro_summary: str | None = None,
     *,
     allow_delayed_entry: bool = False,
     higher_tf_direction: str | None = None,
@@ -284,6 +285,9 @@ Pivot: {ind_m5.get('pivot')}, R1: {ind_m5.get('pivot_r1')}, S1: {ind_m5.get('piv
 
 ### N-Wave Target
 {ind_m5.get('n_wave_target')}
+
+### Macro News Summary
+{macro_summary if macro_summary else 'N/A'}
 
 Your task:
 1. Clearly classify the current regime as "trend" or "range". If "trend", specify direction as "long" or "short". Output this at JSON key "regime".


### PR DESCRIPTION
## Summary
- add new `ai` package for AI helper modules
- implement `MacroAnalyzer` fetching FRED and GDELT news
- add local model wrapper `ask_model`
- manage prompt strings with `prompt_templates`
- include macro news summary in trade prompts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68445a05806483339e554975936ca825