### PR TITLE
Enhance job runner logging

### DIFF
--- a/backend/logs/info_logger.py
+++ b/backend/logs/info_logger.py
@@ -1,0 +1,20 @@
+import logging
+
+# INFOログ用ユーティリティ
+logger = logging.getLogger(__name__)
+
+
+def info(key: str, **vals) -> None:
+    """Log formatted INFO message.
+
+    Parameters
+    ----------
+    key : str
+        イベント種別を表すキー
+    **vals : Any
+        付加情報をキー=値形式で受け取る
+    """
+    msg = " ".join(f"{k}={v}" for k, v in vals.items())
+    logger.info("%s %s", key, msg)
+
+__all__ = ["logger", "info"]

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -1,6 +1,7 @@
 import os
 import requests
 from backend.logs.log_manager import log_trade, log_error
+from backend.logs.info_logger import info
 from backend.logs.trade_logger import ExitReason
 from backend.utils.price import format_price
 from backend.risk_manager import (
@@ -532,6 +533,15 @@ class OrderManager:
             rrr=rrr,
             is_manual=False,
         )
+        info(
+            "entry",
+            pair=instrument,
+            side=side,
+            id=result.get("orderFillTransaction", {}).get("id"),
+            price=entry_price,
+            lot=lot_size,
+            regime=(strategy_params.get("market_cond") or {}).get("market_condition"),
+        )
         return result
 
     def exit_trade(self, position):
@@ -587,6 +597,13 @@ class OrderManager:
             exit_time=datetime.now(timezone.utc).isoformat(),
             exit_reason=ExitReason.MANUAL,
             is_manual=True,
+        )
+        info(
+            "exit",
+            pair=instrument,
+            reason="MANUAL",
+            price=entry_price,
+            pnl=position.get("pl"),
         )
         return result
 


### PR DESCRIPTION
## Summary
- add `info_logger` utility for structured INFO logging
- standardize logging format and log startup info
- record regime changes, entries and exits with AI context
- log entry/exit events in `OrderManager`

## Testing
- `pip install -q fastapi numpy pandas pyyaml httpx scikit-learn mabwiser apscheduler line-bot-sdk`
- `pytest -q` *(fails: module backend.strategy...)*)

------
https://chatgpt.com/codex/tasks/task_e_68445eaccbd883338cd263604fd9005b