### PR TITLE
Enable Prometheus metrics export

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,12 @@ will be appended to `backend/logs/perf_stats.jsonl`.
 
 Both services can also be launched via Docker using `Dockerfile.api` and `Dockerfile.job` respectively.
 
+## Metrics Monitoring
+
+The API exposes Prometheus metrics at `/metrics`. The job runner also starts a
+Prometheus server so monitoring tools can scrape data. Set `METRICS_PORT` to
+control the port (default `8001`).
+
 ### Apple Silicon (ARM) users
 
 If you are on an M1/M2 Mac or other ARM-based machine, build the images for

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, APIRouter
+from fastapi import FastAPI, HTTPException, APIRouter, Response
 from backend.utils import env_loader
 import sqlite3
 import os
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from backend.utils.notification import send_line_message
 
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 
 app = FastAPI()
@@ -24,6 +25,16 @@ logger = logging.getLogger(__name__)
 def health():
     """Return 200 OK with a tiny JSON payload."""
     return {"status": "ok"}
+
+
+# ------------------------------------------------------------------
+# Prometheus metrics endpoint
+# ------------------------------------------------------------------
+@app.get("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    data = generate_latest()
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
 
 
 # --- CORS ---

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -5,6 +5,7 @@ import logging
 import json
 import os
 import sys
+from prometheus_client import start_http_server
 # プロジェクトルートをパスに追加してモジュールを確実に読み込む
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if PROJECT_ROOT not in sys.path:
@@ -214,6 +215,13 @@ class JobRunner:
         self.interval_seconds = interval_seconds
         self.last_run = None
         self._stop = False
+        # Start Prometheus metrics server
+        metrics_port = int(env_loader.get_env("METRICS_PORT", "8001"))
+        try:
+            start_http_server(metrics_port)
+            logger.info("Prometheus metrics server running on port %s", metrics_port)
+        except Exception as exc:  # pragma: no cover - metrics optional
+            logger.warning(f"Metrics server start failed: {exc}")
         loss_lim = float(env_loader.get_env("LOSS_LIMIT", "0"))
         err_lim = int(env_loader.get_env("ERROR_LIMIT", "0"))
         self.safety = SafetyTrigger(loss_limit=loss_lim, error_limit=err_lim)


### PR DESCRIPTION
## Summary
- expose Prometheus metrics at `/metrics` in the FastAPI app
- start a Prometheus server in the job runner (configurable via `METRICS_PORT`)
- document metrics monitoring in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68446110804c8333858044cf5aa12052