### PR TITLE
Add async news analyzer with LLM fallback

### DIFF
--- a/ai/macro_analyzer.py
+++ b/ai/macro_analyzer.py
@@ -1,11 +1,13 @@
 """FRED と GDELT からニュースを取得して要約するモジュール"""
 from __future__ import annotations
 
+import asyncio
 import requests
 from typing import Any
+import httpx
 
 from backend.utils import env_loader
-from ai.local_model import ask_model
+from ai.local_model import ask_model, ask_model_async
 from ai.prompt_templates import get_template
 
 
@@ -33,6 +35,23 @@ class MacroAnalyzer:
         data = resp.json()
         return data.get("observations", [])
 
+    async def fetch_fred_series_async(self, series_id: str, limit: int = 10) -> list[dict]:
+        """非同期で FRED データを取得する"""
+        if not self.fred_api_key:
+            raise RuntimeError("FRED_API_KEY not set")
+        url = "https://api.stlouisfed.org/fred/series/observations"
+        params = {
+            "series_id": series_id,
+            "api_key": self.fred_api_key,
+            "file_type": "json",
+            "limit": limit,
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("observations", [])
+
     # ------------------------------------------------------------
     # GDELT API
     # ------------------------------------------------------------
@@ -48,11 +67,45 @@ class MacroAnalyzer:
         resp.raise_for_status()
         return resp.json().get("articles", [])
 
+    async def fetch_gdelt_articles_async(self, query: str, maxrecords: int = 10) -> list[dict]:
+        """非同期で GDELT ニュースを取得する"""
+        url = "https://api.gdeltproject.org/api/v2/doc/doc"
+        params = {
+            "query": query,
+            "mode": "ArtList",
+            "format": "json",
+            "maxrecords": maxrecords,
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+            return resp.json().get("articles", [])
+
     def summarize_articles(self, articles: list[dict]) -> str:
         headlines = [a.get("title") or a.get("semtitle") or "" for a in articles]
         text = "\n".join(headlines)
         prompt = get_template("news_summary").format(text=text)
         result = ask_model(prompt)
+        if isinstance(result, dict):
+            return result.get("summary") or result.get("text", "")
+        return str(result)
+
+    async def analyze_sentiment_async(self, summary: str) -> str:
+        """ニュース要約からリスクオン/オフを判定する"""
+        prompt = (
+            "Classify the following news summary as 'risk_on' or 'risk_off' only.\n" + summary
+        )
+        result = await ask_model_async(prompt)
+        if isinstance(result, dict):
+            return result.get("sentiment") or result.get("text", "")
+        return str(result)
+
+    async def summarize_articles_async(self, articles: list[dict]) -> str:
+        """LLM を用いてニュースの要約を非同期に取得する"""
+        headlines = [a.get("title") or a.get("semtitle") or "" for a in articles]
+        text = "\n".join(headlines)
+        prompt = get_template("news_summary").format(text=text)
+        result = await ask_model_async(prompt)
         if isinstance(result, dict):
             return result.get("summary") or result.get("text", "")
         return str(result)
@@ -72,9 +125,33 @@ class MacroAnalyzer:
         except Exception:
             articles = []
         summary = ""
+        sentiment = None
         if articles:
             try:
                 summary = self.summarize_articles(articles)
+                sentiment = asyncio.run(self.analyze_sentiment_async(summary))
             except Exception:
                 summary = ""
-        return {"fred": fred, "summary": summary, "articles": articles}
+                sentiment = None
+        return {"fred": fred, "summary": summary, "articles": articles, "sentiment": sentiment}
+
+    async def get_market_summary_async(
+        self, query: str = "economy", series_id: str = "UNRATE"
+    ) -> dict[str, Any]:
+        """非同期版 ``get_market_summary``"""
+        try:
+            fred_task = self.fetch_fred_series_async(series_id, 5)
+            news_task = self.fetch_gdelt_articles_async(query, 5)
+            fred, articles = await asyncio.gather(fred_task, news_task)
+        except Exception:
+            fred, articles = [], []
+        summary = ""
+        sentiment = None
+        if articles:
+            try:
+                summary = await self.summarize_articles_async(articles)
+                sentiment = await self.analyze_sentiment_async(summary)
+            except Exception:
+                summary = ""
+                sentiment = None
+        return {"fred": fred, "summary": summary, "articles": articles, "sentiment": sentiment}

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -991,11 +991,14 @@ def get_trade_plan(
     candles_d1 = candles_dict.get("D1", candles_dict.get("D", []))
 
     macro_summary = ""
+    macro_sentiment = None
     try:
         macro = macro_analyzer.get_market_summary()
         macro_summary = macro.get("summary", "")
+        macro_sentiment = macro.get("sentiment")
     except Exception:
         macro_summary = ""
+        macro_sentiment = None
 
     pattern_name = None
     if patterns:
@@ -1033,6 +1036,7 @@ def get_trade_plan(
         hist_stats,
         pattern_line,
         macro_summary,
+        macro_sentiment,
         allow_delayed_entry=allow_delayed_entry,
         higher_tf_direction=higher_tf_direction,
         trend_prompt_bias=trend_prompt_bias,

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -46,6 +46,7 @@ def build_trade_plan_prompt(
     hist_stats: dict | None,
     pattern_line: str | None,
     macro_summary: str | None = None,
+    macro_sentiment: str | None = None,
     *,
     allow_delayed_entry: bool = False,
     higher_tf_direction: str | None = None,
@@ -288,6 +289,8 @@ Pivot: {ind_m5.get('pivot')}, R1: {ind_m5.get('pivot_r1')}, S1: {ind_m5.get('piv
 
 ### Macro News Summary
 {macro_summary if macro_summary else 'N/A'}
+### Macro Sentiment
+{macro_sentiment if macro_sentiment else 'N/A'}
 
 Your task:
 1. Clearly classify the current regime as "trend" or "range". If "trend", specify direction as "long" or "short". Output this at JSON key "regime".

--- a/backend/utils/openai_client.py
+++ b/backend/utils/openai_client.py
@@ -7,6 +7,7 @@ except ModuleNotFoundError as exc:
 from backend.utils import env_loader
 import json
 import logging
+import asyncio
 
 # env_loader automatically loads default .env files at import time
 
@@ -70,3 +71,28 @@ def ask_openai(
         raise RuntimeError("Invalid JSON response") from exc
     except APIError as e:
         raise RuntimeError(f"OpenAI API request failed: {e}") from e
+
+
+async def ask_openai_async(
+    prompt: str,
+    system_prompt: str = "You are a helpful assistant.",
+    model: str | None = None,
+    *,
+    max_tokens: int = 512,
+    temperature: float = 0.7,
+    response_format: dict | None = None,
+) -> dict:
+    """Non-blocking wrapper around ``ask_openai``."""
+
+    return await asyncio.to_thread(
+        ask_openai,
+        prompt,
+        system_prompt=system_prompt,
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+    )
+
+
+__all__ = ["ask_openai", "ask_openai_async", "AI_MODEL"]


### PR DESCRIPTION
## Summary
- implement async wrapper `ask_openai_async`
- add `ask_model_async` with local model fallback
- enhance `MacroAnalyzer` with async fetch and sentiment detection
- pass macro sentiment through trade-plan prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kafka')*

------
https://chatgpt.com/codex/tasks/task_e_68446104d8388333a6bc4ff8c8253580