### PR TITLE
Add order flow regime features and training script

### DIFF
--- a/backend/indicators/rolling.py
+++ b/backend/indicators/rolling.py
@@ -162,9 +162,25 @@ class RollingKeltner:
         return outside
 
 
+class RollingVolumeRatio:
+    """出来高比率を返す簡易クラス."""
+
+    def __init__(self, window: int = 20) -> None:
+        self.window = window
+        self.volumes: Deque[float] = deque(maxlen=window)
+
+    def update(self, tick: Dict[str, Any]) -> float:
+        """``volume`` 値から現在値/平均値を計算する."""
+        vol = float(tick.get("volume", 0.0))
+        self.volumes.append(vol)
+        avg = sum(self.volumes) / len(self.volumes) if self.volumes else 0.0
+        return (vol / avg) if avg else 1.0
+
+
 __all__ = [
     "RollingATR",
     "RollingADX",
     "RollingBBWidth",
     "RollingKeltner",
+    "RollingVolumeRatio",
 ]

--- a/backend/market_data/tick_fetcher.py
+++ b/backend/market_data/tick_fetcher.py
@@ -7,7 +7,7 @@ OANDA_API_URL = env_loader.get_env('OANDA_API_URL', 'https://api-fxtrade.oanda.c
 OANDA_API_KEY = env_loader.get_env('OANDA_API_KEY')
 OANDA_ACCOUNT_ID = env_loader.get_env('OANDA_ACCOUNT_ID')
 
-def fetch_tick_data(instrument: str | None = None):
+def fetch_tick_data(instrument: str | None = None, *, include_liquidity: bool = False):
     """Fetch the latest tick (pricing) data from the OANDA API.
 
     Parameters
@@ -15,6 +15,9 @@ def fetch_tick_data(instrument: str | None = None):
     instrument : str | None
         The instrument to fetch (e.g. ``"USD_JPY"``). If ``None`` the value of
         ``DEFAULT_PAIR`` from the environment is used.
+
+    include_liquidity : bool
+        If ``True`` the request includes order book liquidity information.
 
     Returns
     -------
@@ -32,7 +35,7 @@ def fetch_tick_data(instrument: str | None = None):
     params = {
         "instruments": instrument,
         "since": None,
-        "includeUnitsAvailable": "false"
+        "includeUnitsAvailable": str(include_liquidity).lower(),
     }
     try:
         response = requests.get(url, headers=headers, params=params, timeout=10)

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -783,12 +783,19 @@ class JobRunner:
                     logger.info(f"Running job at {now.isoformat()}")
 
                     # ティックデータ取得（発注用）
-                    tick_data = fetch_tick_data(DEFAULT_PAIR)
+                    tick_data = fetch_tick_data(DEFAULT_PAIR, include_liquidity=True)
                     # ティックデータ詳細はDEBUGレベルで出力
                     logger.debug(f"Tick data fetched: {tick_data}")
                     try:
                         price = float(tick_data["prices"][0]["bids"][0]["price"])
-                        tick = {"high": price, "low": price, "close": price}
+                        bid_liq = float(tick_data["prices"][0]["bids"][0].get("liquidity", 0))
+                        ask_liq = float(tick_data["prices"][0]["asks"][0].get("liquidity", 0))
+                        tick = {
+                            "high": price,
+                            "low": price,
+                            "close": price,
+                            "volume": bid_liq + ask_liq,
+                        }
                         rd_res = self.regime_detector.update(tick)
                         if rd_res.get("transition"):
                             self.last_ai_call = datetime.min

--- a/regime/features.py
+++ b/regime/features.py
@@ -6,7 +6,12 @@ from typing import Any, Dict
 
 import numpy as np
 
-from backend.indicators.rolling import RollingATR, RollingADX, RollingBBWidth
+from backend.indicators.rolling import (
+    RollingATR,
+    RollingADX,
+    RollingBBWidth,
+    RollingVolumeRatio,
+)
 
 
 class RegimeFeatureExtractor:
@@ -16,13 +21,15 @@ class RegimeFeatureExtractor:
         self.atr = RollingATR(window)
         self.adx = RollingADX(window)
         self.bbwidth = RollingBBWidth(window=window)
+        self.volume = RollingVolumeRatio(window)
 
     def update(self, tick: Dict[str, Any]) -> np.ndarray:
         """tick データから特徴量を生成する."""
         atr_ratio = self.atr.update(tick)
         adx_val, _ = self.adx.update(tick)
         bw_ratio = self.bbwidth.update(tick)
-        return np.array([atr_ratio, adx_val, bw_ratio], dtype=float)
+        vol_ratio = self.volume.update(tick)
+        return np.array([atr_ratio, adx_val, bw_ratio, vol_ratio], dtype=float)
 
     def process_all(self, data: list[Dict[str, Any]]) -> np.ndarray:
         """複数データポイントから特徴量行列を作成する."""

--- a/tests/test_volume_ratio.py
+++ b/tests/test_volume_ratio.py
@@ -1,0 +1,14 @@
+from regime.features import RegimeFeatureExtractor
+
+
+def test_volume_ratio_feature():
+    extractor = RegimeFeatureExtractor(window=3)
+    ticks = [
+        {"high": 1, "low": 1, "close": 1, "volume": 2},
+        {"high": 1, "low": 1, "close": 1, "volume": 4},
+        {"high": 1, "low": 1, "close": 1, "volume": 6},
+    ]
+    feats = extractor.process_all(ticks)
+    assert feats.shape == (3, 4)
+    assert abs(feats[-1, 3] - 1.5) < 0.01
+

--- a/training/train_regime_model.py
+++ b/training/train_regime_model.py
@@ -1,0 +1,46 @@
+import csv
+import pickle
+from pathlib import Path
+import sys
+
+from regime.features import RegimeFeatureExtractor
+from regime.gmm_detector import GMMRegimeDetector
+
+
+def load_data(path: Path) -> list[dict]:
+    data = []
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                item = {
+                    "high": float(row.get("high", row.get("h", 0)) or 0),
+                    "low": float(row.get("low", row.get("l", 0)) or 0),
+                    "close": float(row.get("close", row.get("c", 0)) or 0),
+                    "volume": float(row.get("volume", row.get("v", 0)) or 0),
+                }
+            except Exception:
+                continue
+            data.append(item)
+    return data
+
+
+def main() -> None:
+    csv_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("tests/data/range_sample.csv")
+    model_path = Path("models/regime_gmm.pkl")
+    rows = load_data(csv_path)
+    if not rows:
+        print("No data loaded")
+        return
+    extractor = RegimeFeatureExtractor()
+    feats = extractor.process_all(rows)
+    detector = GMMRegimeDetector(n_components=3, random_state=42)
+    detector.fit(feats)
+    model_path.parent.mkdir(exist_ok=True)
+    with open(model_path, "wb") as f:
+        pickle.dump(detector.model, f)
+    print(f"Model saved to {model_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- integrate `RollingVolumeRatio` indicator
- extend regime feature extraction to include volume ratio
- feed liquidity data from OANDA API in job runner
- allow tick fetcher to request liquidity info
- add offline training script for regime model
- test volume ratio feature

## Testing
- `pytest tests/test_volume_ratio.py tests/test_gmm_detector.py tests/test_hdbscan_detector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6844606a6790833396308d8eb3cbae8e