### PR TITLE
Add offline policy learning components

### DIFF
--- a/ai/policy_trainer.py
+++ b/ai/policy_trainer.py
@@ -1,0 +1,62 @@
+"""Offline RL trainer for strategy selection."""
+
+import sqlite3
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+import numpy as np
+from d3rlpy.algos import DiscreteCQL
+from d3rlpy.dataset import MDPDataset
+
+DB_PATH = Path(__file__).resolve().parents[1] / "trades.db"
+MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "policy_model.d3"
+
+
+def _vec(state: Dict[str, Any]) -> list[float]:
+    """Convert state dict to numeric vector."""
+    return [float(state.get(k, 0.0)) for k in sorted(state.keys())]
+
+
+def load_dataset(conn: sqlite3.Connection):
+    cur = conn.cursor()
+    cur.execute("SELECT state, action, reward FROM policy_transitions")
+    rows = cur.fetchall()
+    if not rows:
+        return None, None
+    observations = []
+    actions = []
+    rewards = []
+    for s_json, action, reward in rows:
+        state = json.loads(s_json)
+        observations.append(_vec(state))
+        actions.append(action)
+        rewards.append(float(reward))
+    arm_index = {a: i for i, a in enumerate(sorted(set(actions)))}
+    action_idxs = [arm_index[a] for a in actions]
+    dataset = MDPDataset(
+        observations=np.array(observations, dtype=np.float32),
+        actions=np.array(action_idxs, dtype=np.int64),
+        rewards=np.array(rewards, dtype=np.float32),
+        terminals=np.zeros(len(observations), dtype=np.float32),
+    )
+    return dataset, arm_index
+
+
+def train() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        dataset, arm_index = load_dataset(conn)
+    if dataset is None:
+        print("No data found for training")
+        return
+    algo = DiscreteCQL(use_gpu=False)
+    algo.fit(dataset, n_epochs=5, verbose=False)
+    MODEL_PATH.parent.mkdir(exist_ok=True)
+    algo.save(str(MODEL_PATH))
+    with open(MODEL_PATH.with_suffix(".json"), "w") as f:
+        json.dump({"actions": arm_index}, f)
+    print(f"Model saved to {MODEL_PATH}")
+
+
+if __name__ == "__main__":
+    train()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,3 +38,4 @@ mabwiser==2.7.4
 kafka-python==2.0.2
 prometheus-client==0.20.0
 hdbscan==0.8.33
+d3rlpy==2.1.0

--- a/backend/scheduler/policy_updater.py
+++ b/backend/scheduler/policy_updater.py
@@ -1,0 +1,40 @@
+"""Apply offline-learned policy to strategy selector."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+from d3rlpy.algos import DiscreteCQL
+
+MODEL_PATH = Path(__file__).resolve().parents[2] / "models" / "policy_model.d3"
+
+
+class OfflinePolicy:
+    def __init__(self, model_path: Path = MODEL_PATH):
+        self.model_path = Path(model_path)
+        self.algo: DiscreteCQL | None = None
+        self.actions: list[str] = []
+        self.load()
+
+    def load(self) -> None:
+        if not self.model_path.exists():
+            return
+        self.algo = DiscreteCQL.from_json(str(self.model_path))
+        actions_file = self.model_path.with_suffix(".json")
+        if actions_file.exists():
+            with open(actions_file) as f:
+                data = json.load(f)
+            self.actions = [k for k, _ in sorted(data["actions"].items(), key=lambda x: x[1])]
+
+    def _vec(self, context: Dict[str, Any]) -> np.ndarray:
+        return np.array([[float(context.get(k, 0.0)) for k in sorted(context.keys())]], dtype=np.float32)
+
+    def select(self, context: Dict[str, Any]) -> str | None:
+        if self.algo is None or not self.actions:
+            return None
+        q_values = self.algo.predict_value(self._vec(context))[0]
+        idx = int(np.argmax(q_values))
+        if idx < len(self.actions):
+            return self.actions[idx]
+        return None


### PR DESCRIPTION
## Summary
- add d3rlpy to backend requirements
- implement `ai/policy_trainer.py` for offline RL using DiscreteCQL
- provide `backend/scheduler/policy_updater.py` to load and select with trained policy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_684460d928fc83338adeac355aba8b4a