### PR TITLE
Implement strategy selector integration

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -88,6 +88,10 @@ from signals.composite_mode import decide_trade_mode, decide_trade_mode_detail
 
 from backend.utils.notification import send_line_message
 from backend.logs.trade_logger import log_trade, ExitReason
+from strategies import ScalpStrategy, TrendStrategy, StrategySelector
+from strategies.context_builder import build_context, recent_strategy_performance
+from backend.logs.log_manager import log_policy_transition
+import json
 try:
     from backend.logs.log_manager import log_entry_skip
 except Exception:  # pragma: no cover - test stubs may omit log_entry_skip
@@ -316,7 +320,13 @@ class JobRunner:
         )
         # 初期の SCALP_MODE 設定をログへ記録
         scalp_active = env_loader.get_env("SCALP_MODE", "false").lower() == "true"
+
         logger.info("Initial SCALP_MODE is %s", "ON" if scalp_active else "OFF")
+        self.strategy_selector = StrategySelector({"scalp": ScalpStrategy(), "trend": TrendStrategy()})
+        self.last_entry_context = None
+        self.last_entry_strategy = None
+        self.current_context = None
+        self.current_strategy_name = None
 
     def _get_cond_indicators(self) -> dict:
         """Return indicators for market condition check."""
@@ -351,6 +361,16 @@ class JobRunner:
             python = sys.executable
             # preserve module-based execution to keep import paths intact
             os.execv(python, [python, "-m", "backend.scheduler.job_runner", *sys.argv[1:]])
+
+    def _record_strategy_result(self, reward: float) -> None:
+        if self.last_entry_context and self.last_entry_strategy:
+            try:
+                log_policy_transition(json.dumps(self.last_entry_context), self.last_entry_strategy, float(reward))
+                self.strategy_selector.update(self.last_entry_strategy, self.last_entry_context, float(reward))
+            except Exception as exc:
+                logger.warning(f"Strategy update failed: {exc}")
+            self.last_entry_context = None
+            self.last_entry_strategy = None
 
     # ────────────────────────────────────────────────────────────
     #  Poll & renew pending LIMIT orders
@@ -885,9 +905,14 @@ class JobRunner:
                     new_mode, _score, reasons = decide_trade_mode_detail(
                         indicators, candles_m5
                     )
-                    if new_mode != self.trade_mode:
-                        self.reload_params_for_mode(new_mode)
-                        self.trade_mode = new_mode
+                    perf = recent_strategy_performance()
+                    self.current_context = build_context(self.regime_detector.state, indicators, perf)
+                    selected = self.strategy_selector.select(self.current_context)
+                    self.current_strategy_name = selected.name
+                    selected_mode = "trend_follow" if selected.name == "trend" else selected.name
+                    if selected_mode != self.trade_mode:
+                        self.reload_params_for_mode(selected_mode)
+                        self.trade_mode = selected_mode
                     self.mode_reason = "\n".join(f"- {r}" for r in reasons)
                     logger.info("Current trade mode: %s", self.trade_mode)
 
@@ -1082,6 +1107,7 @@ class JobRunner:
                                 send_line_message(
                                     f"【PEAK EXIT】{DEFAULT_PAIR} {current_price} で決済しました。PL={current_profit_pips:.1f}pips"
                                 )
+                                self._record_strategy_result(current_profit_pips)
                             except Exception as exc:
                                 logger.warning(f"Peak exit failed: {exc}")
                             self.max_profit_pips = 0.0
@@ -1207,6 +1233,7 @@ class JobRunner:
                                         send_line_message(
                                             f"【EXIT】{DEFAULT_PAIR} {current_price} で決済しました。PL={current_profit_pips:.1f}pips"
                                         )
+                                        self._record_strategy_result(current_profit_pips)
                                         self.scale_count = 0
                                     else:
                                         logger.info("AI decision was HOLD → No exit executed.")
@@ -1384,6 +1411,7 @@ class JobRunner:
                                 send_line_message(
                                     f"【EXIT】{DEFAULT_PAIR} {cur_price} で決済しました。PL={profit_pips * pip_size:.2f}"
                                 )
+                                self._record_strategy_result(profit_pips)
                                 self.scale_count = 0
                             else:
                                 logger.info("AI decision was HOLD → No exit executed.")
@@ -1652,6 +1680,8 @@ class JobRunner:
                             price = float(tick_data["prices"][0]["bids"][0]["price"])
                             send_line_message(f"【ENTRY】{DEFAULT_PAIR} {price} でエントリーしました。")
                             self.scale_count = 0
+                            self.last_entry_context = self.current_context
+                            self.last_entry_strategy = self.current_strategy_name
                         else:
                             logger.info("Filter NG → AI entry decision skipped.")
                             self.last_position_review_ts = None

--- a/strategies/context_builder.py
+++ b/strategies/context_builder.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Utility functions to build context vectors for strategy selection."""
+
+
+from backend.logs.log_manager import get_db_connection
+
+
+def recent_strategy_performance(limit: int = 10) -> Dict[str, float]:
+    """Return average reward for each strategy over recent transitions."""
+    perf: Dict[str, list[float]] = {}
+    with get_db_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT action, reward FROM policy_transitions ORDER BY id DESC LIMIT ?",
+            (limit,),
+        )
+        rows = cur.fetchall()
+    for action, reward in rows:
+        perf.setdefault(action, []).append(float(reward))
+    return {k: sum(v) / len(v) for k, v in perf.items() if v}
+
+
+def build_context(regime: str, indicators: Dict[str, Any], perf: Dict[str, float] | None = None) -> Dict[str, float]:
+    """Assemble context dictionary for StrategySelector."""
+    ctx: Dict[str, float] = {
+        "regime_trend": 1.0 if regime == "TREND" else 0.0,
+    }
+    try:
+        adx_series = indicators.get("adx")
+        if adx_series is not None:
+            val = adx_series.iloc[-1] if hasattr(adx_series, "iloc") else adx_series[-1]
+            ctx["adx"] = float(val)
+    except Exception:
+        pass
+    try:
+        atr_series = indicators.get("atr")
+        if atr_series is not None:
+            val = atr_series.iloc[-1] if hasattr(atr_series, "iloc") else atr_series[-1]
+            ctx["atr"] = float(val)
+    except Exception:
+        pass
+    if perf:
+        for k, v in perf.items():
+            ctx[f"{k}_perf"] = float(v)
+    return ctx
+
+
+__all__ = ["build_context", "recent_strategy_performance"]


### PR DESCRIPTION
## Summary
- add context builder for strategy selector
- integrate `StrategySelector` in job runner
- track strategy performance using policy transitions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kafka')*

------
https://chatgpt.com/codex/tasks/task_e_684460801a408333a22850137af83a9c