### PR TITLE
Fix docker build and add docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend /app/backend
 COPY analysis /app/analysis
+COPY ai /app/ai
 COPY signals /app/signals
 COPY indicators /app/indicators
+COPY monitoring /app/monitoring
+COPY risk /app/risk
 COPY config /app/config
 
 # create an empty SQLite database if not provided

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -222,3 +222,11 @@ SCALE_TRIGGER_ATR=0.5
 ■ OANDA_MATCH_SEC
   ローカルトレードと OANDA 取引を照合するときの許容秒数。デフォルトは60秒。
 
+
+## 追加環境変数
+- USE_LOCAL_MODEL: OpenAI APIの代わりにローカルモデルを使用するか (true/false)
+- LOCAL_MODEL_NAME: 使用するローカルモデル名 (例: distilgpt2)
+- USE_LOCAL_PATTERN: チャートパターン検出をローカルで行うか (true/false)
+- FRED_API_KEY: 米国経済指標取得に使用するFRED APIキー
+- KAFKA_SERVERS: Kafkaブローカーの接続先リスト (例: localhost:9092)
+- METRICS_TOPIC: メトリクス送信用のKafkaトピック名

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,3 +39,4 @@ kafka-python==2.0.2
 prometheus-client==0.20.0
 hdbscan==0.8.33
 d3rlpy==2.1.0
+transformers==4.41.2


### PR DESCRIPTION
## Summary
- include more project directories in Docker build
- document optional environment variables
- add missing dependency for local model support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684468c83ff88333b910dffee16ab198