### PR TITLE
Fix setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ loaded from environment variables and optional YAML files under `config/`.
    The indicator modules require **pandas**. If it is not installed, add it with:
    ```bash
    pip install pandas
+   # optional linting
+   pip install flake8
    ```
 3. **Environment variables**
    まず `backend/config/secret.env.example` をコピーして `.env` を作成するか、
@@ -572,6 +574,8 @@ virtual environment and execute:
 ```bash
 pytest
 ```
+Ensure all dependencies from `backend/requirements.txt` are installed before
+running tests.
 
 This will run all tests defined in the project to verify core modules and
 configuration loaders.


### PR DESCRIPTION
## Summary
- update README to include optional linting install
- add note that tests require requirements installed

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68446bef2c8883339cad8bcfa5949f9b