### PR TITLE
Update Dockerfile and docs for unified module entry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,16 @@ RUN apt-get update \
 
 WORKDIR /app
 
-COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Apple Silicon 向けにビルドする場合は下記のように `--platform` を指定してください
+# docker build --platform linux/amd64 -t piphawk-ai:dev .
 
-COPY backend /app/backend
-COPY analysis /app/analysis
-COPY ai /app/ai
-COPY signals /app/signals
-COPY indicators /app/indicators
-COPY monitoring /app/monitoring
-COPY risk /app/risk
-COPY strategies /app/strategies
-COPY regime /app/regime
-COPY config /app/config
 COPY pyproject.toml /app/pyproject.toml
 COPY piphawk_ai /app/piphawk_ai
+COPY ./backend ./analysis ./indicators ./config \
+     ./risk ./monitoring ./strategies ./regime ./piphawk-ui ./tests \
+     /app/
 
-# install project as package
+# install project as package via pyproject.toml
 RUN pip install --no-cache-dir .
 
 # create an empty SQLite database if not provided
@@ -33,4 +26,4 @@ RUN touch /app/trades.db
 ENV PYTHONUNBUFFERED=1
 ENV TZ=Asia/Tokyo
 
-CMD ["uvicorn", "backend.api.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["python", "-m", "piphawk_ai.main", "job"]

--- a/README.md
+++ b/README.md
@@ -310,9 +310,9 @@ EOF
 
 ## Running the API
 
-The API exposes endpoints for status checks, a simple dashboard and runtime settings. Start it with Uvicorn:
+The API exposes endpoints for status checks, a simple dashboard and runtime settings. Start it from the packaged module:
 ```bash
-uvicorn backend.api.main:app --host 0.0.0.0 --port 8080
+python -m piphawk_ai.main api
 ```
 
 ## LINE 通知設定
@@ -327,7 +327,7 @@ LINE_USER_ID=<your_line_user_id>
 次のコマンドで API を起動してください。
 
 ```bash
-uvicorn backend.api.main:app --host 0.0.0.0 --port 8080
+python -m piphawk_ai.main api
 ```
 
 テスト用エンドポイント `/notifications/send` を利用すると送信確認ができます。
@@ -341,16 +341,16 @@ curl -X POST http://localhost:8080/notifications/send
 
 ## Running the Job Scheduler
 
-The job runner performs market data collection, indicator calculation and trading decisions. Run it directly with Python:
+The job runner performs market data collection, indicator calculation and trading decisions. Start it via the packaged module:
 ```bash
-python3 -m backend.scheduler.job_runner
+python -m piphawk_ai.main job
 ```
 If the optional performance logger was added earlier, each job loop's timing
 will be appended to `backend/logs/perf_stats.jsonl`.
 
-Both the API and the job runner can run in a single container using `Dockerfile`.
-If you prefer two containers, build the same image twice and start each with the
-appropriate command.
+Both the API and the job runner can run from the same Docker image.
+For an API-only container, tag the build separately and override the command with
+`python -m piphawk_ai.main api`.
 
 ## Metrics Monitoring
 
@@ -372,6 +372,12 @@ are bundled into the image. When you start the job runner container, these
 parameters are loaded automatically.
 
 Use the same flag if building separate images for the API and job runner.
+The default tag launches the job scheduler. Create an API image with a custom
+tag and command override:
+```bash
+docker build --platform linux/amd64 -t piphawk-ai:api .
+docker run --rm piphawk-ai:api python -m piphawk_ai.main api
+```
 Running x86 containers under emulation can be slower and some dependencies may not behave exactly the same
 as on native x86 hardware.
 

--- a/piphawk_ai/main.py
+++ b/piphawk_ai/main.py
@@ -1,0 +1,4 @@
+from backend.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- simplify Dockerfile and install via `pyproject.toml`
- add Apple Silicon build comment and unify CMD to run job scheduler
- wrap CLI in `piphawk_ai.main`
- update README for new module commands and API tag instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `docker build --platform linux/amd64 -t piphawk-ai:dev .` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c09e37b8833385eef215c5e79828