### PR TITLE
Implement basic filter logic

### DIFF
--- a/backend/filters/extension_block.py
+++ b/backend/filters/extension_block.py
@@ -33,19 +33,15 @@ def _val(candle: Dict, key: str) -> float:
     return float(base.get(key))
 
 
-def extension_block(candles: Sequence[Dict], ratio: float) -> bool:
-    """Return ``True`` if the latest close deviates from EMA20 by ``ratio``×ATR."""
-    if ratio <= 0 or len(candles) < 20:
+def is_extension(candles: Sequence[Dict], atr: float) -> bool:
+    """最新足の実体が ATR×3 を超えていれば True."""
+    if atr <= 0 or not candles:
         return False
 
-    closes = [_val(c, "c") for c in candles[-20:]]
-    highs = [_val(c, "h") for c in candles[-14:]]
-    lows = [_val(c, "l") for c in candles[-14:]]
+    last = candles[-1]
+    open_v = _val(last, "o")
+    close_v = _val(last, "c")
+    body = abs(close_v - open_v)
+    return body > atr * 3
 
-    ema20 = _ema(closes[-20:], 20)
-    atr_val = _atr(highs, lows, closes, 14)
-    latest = closes[-1]
-
-    return abs(latest - ema20) >= ratio * atr_val
-
-__all__ = ["extension_block"]
+__all__ = ["is_extension"]

--- a/backend/tests/test_extension_block.py
+++ b/backend/tests/test_extension_block.py
@@ -16,12 +16,14 @@ class TestExtensionBlock(unittest.TestCase):
         return [_c(p) for p in prices]
 
     def test_block_true(self):
-        candles = self._make_candles([1.0] * 19 + [1.2])
-        self.assertTrue(self.eb.extension_block(candles, 1.5))
+        candles = self._make_candles([1.0] * 20)
+        candles[-1]["mid"]["c"] = "1.2"
+        self.assertTrue(self.eb.is_extension(candles, 0.05))
 
     def test_block_false(self):
-        candles = self._make_candles([1.0] * 19 + [1.05])
-        self.assertFalse(self.eb.extension_block(candles, 1.5))
+        candles = self._make_candles([1.0] * 20)
+        candles[-1]["mid"]["c"] = "1.05"
+        self.assertFalse(self.eb.is_extension(candles, 0.05))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_false_break_filter.py
+++ b/backend/tests/test_false_break_filter.py
@@ -36,9 +36,9 @@ class TestFalseBreakFilter(unittest.TestCase):
             self._c(1.03, 1.05, 1.02, 1.04),
             self._c(1.04, 1.06, 1.03, 1.05),
             self._c(1.05, 1.06, 1.04, 1.05),
-            self._c(1.055, 1.07, 1.04, 1.045),
+            self._c(1.06, 1.07, 1.03, 1.02),
         ]
-        self.assertTrue(should_skip(candles, lookback=5, threshold_ratio=0.4))
+        self.assertTrue(should_skip(candles, lookback=5))
 
     def test_should_skip_false_when_no_reversal(self):
         candles = [
@@ -47,9 +47,9 @@ class TestFalseBreakFilter(unittest.TestCase):
             self._c(1.03, 1.05, 1.02, 1.04),
             self._c(1.04, 1.06, 1.03, 1.05),
             self._c(1.05, 1.06, 1.04, 1.05),
-            self._c(1.055, 1.07, 1.05, 1.065),
+            self._c(1.06, 1.07, 1.05, 1.06),
         ]
-        self.assertFalse(should_skip(candles, lookback=5, threshold_ratio=0.4))
+        self.assertFalse(should_skip(candles, lookback=5))
 
 
 class FakeSeries:
@@ -114,7 +114,6 @@ class TestEntryLogicFalseBreak(unittest.TestCase):
 
         os.environ['PIP_SIZE'] = '0.01'
         os.environ['FALSE_BREAK_LOOKBACK'] = '5'
-        os.environ['FALSE_BREAK_RATIO'] = '0.4'
 
         import backend.strategy.entry_logic as el
         importlib.reload(el)
@@ -125,7 +124,6 @@ class TestEntryLogicFalseBreak(unittest.TestCase):
             sys.modules.pop(m, None)
         os.environ.pop('PIP_SIZE', None)
         os.environ.pop('FALSE_BREAK_LOOKBACK', None)
-        os.environ.pop('FALSE_BREAK_RATIO', None)
 
     def _c(self, o, h, l, c):
         return {'mid': {'o': str(o), 'h': str(h), 'l': str(l), 'c': str(c)}}
@@ -138,7 +136,7 @@ class TestEntryLogicFalseBreak(unittest.TestCase):
             self._c(1.03, 1.05, 1.02, 1.04),
             self._c(1.04, 1.06, 1.03, 1.05),
             self._c(1.05, 1.06, 1.04, 1.05),
-            self._c(1.055, 1.07, 1.04, 1.045),
+            self._c(1.06, 1.07, 1.03, 1.02),
         ]
         market_data = {'prices': [{'instrument': 'USD_JPY', 'bids': [{'price': '1.0'}], 'asks': [{'price': '1.01'}]}]}
         res = self.el.process_entry(

--- a/backend/tests/test_trend_pullback.py
+++ b/backend/tests/test_trend_pullback.py
@@ -103,6 +103,24 @@ class TestTrendPullback(unittest.TestCase):
         ]
         self.assertFalse(self.tp.should_enter_short(candles, indicators))
 
+    def test_should_skip_true(self):
+        candles = [
+            _c(1.0, 1.01, 0.99, 1.0),
+            _c(1.0, 1.01, 0.99, 1.0),
+            _c(1.0, 1.01, 0.99, 1.0),
+            _c(1.02, 1.03, 0.98, 0.99),
+        ]
+        self.assertTrue(self.tp.should_skip(candles, ema_period=3))
+
+    def test_should_skip_false(self):
+        candles = [
+            _c(1.0, 1.01, 0.99, 1.0),
+            _c(1.0, 1.01, 0.99, 1.0),
+            _c(1.0, 1.01, 0.99, 1.0),
+            _c(1.005, 1.02, 0.99, 0.99),
+        ]
+        self.assertFalse(self.tp.should_skip(candles, ema_period=3))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement real logic for false_break_filter, trend_pullback, and extension_block
- drop optional imports in entry_logic and use new filters
- adjust unit tests for new behaviours

## Testing
- `pytest backend/tests/test_extension_block.py backend/tests/test_false_break_filter.py backend/tests/test_trend_pullback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c0c3d4bc83339e0044ddde9f03fe