### PR TITLE
Fix markdownlint warnings in quick start docs

### DIFF
--- a/docs/quick_start_en.md
+++ b/docs/quick_start_en.md
@@ -5,7 +5,6 @@
    ```bash
    git clone https://github.com/yourname/piphawk-ai.git
    cd piphawk-ai
-
    ```
 
 2. Create .env from example
@@ -20,18 +19,14 @@
    ```bash
    docker build -t piphawk-ai .
    docker run --env-file .env -p 8080:8080 piphawk-ai
-
    ```
 
-
 4. Start the React UI
+
    ```bash
    cd piphawk-ui
-
-
    npm install
    npm start
    ```
-
 
 Past performance does not guarantee future results. Use at your own risk.

--- a/docs/quick_start_ja.md
+++ b/docs/quick_start_ja.md
@@ -2,35 +2,29 @@
 
 1. リポジトリをクローン
 
-
    ```bash
    git clone https://github.com/yourname/piphawk-ai.git
-
-
    cd piphawk-ai
-
    ```
+
 2. `.env` を作成
+
    ```bash
-
    cp backend/config/secret.env.example .env
-
    ```
 
    `.env` に OANDA と OpenAI の API キーを設定します。
 3. Docker イメージをビルド
 
    ```bash
-
-
    docker build -t piphawk-ai .
    docker run --env-file .env -p 8080:8080 piphawk-ai
    ```
 
 4. React UI を起動
+
    ```bash
    cd piphawk-ui
-
    npm install
    npm start
    ```


### PR DESCRIPTION
## Summary
- fix spacing in QuickStart docs to satisfy markdownlint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx -y markdownlint-cli2 docs/quick_start_en.md docs/quick_start_ja.md`

------
https://chatgpt.com/codex/tasks/task_e_6844cd9e58b4833384f1cc1b3629755b