### PR TITLE
Fix Docker torch install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ COPY ./backend ./analysis ./indicators ./config \
      ./risk ./monitoring ./strategies ./regime ./piphawk-ui ./tests \
      /app/
 
-# install project as package via pyproject.toml
+# PyTorch を CPU 版でインストール
+RUN pip install --no-cache-dir torch==2.3.0+cpu -f https://download.pytorch.org/whl/cpu
+# pyproject.toml を利用してパッケージをインストール
 RUN pip install --no-cache-dir .
 
 # create an empty SQLite database if not provided

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,3 +40,4 @@ prometheus-client==0.20.0
 hdbscan==0.8.33  # optional
 d3rlpy==2.1.0
 transformers==4.41.2
+torch==2.3.0+cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "hdbscan==0.8.33",
     "d3rlpy==2.1.0",
     "transformers==4.41.2",
+    "torch==2.3.0+cpu",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- install CPU-only PyTorch before project dependencies
- pin CPU torch in dependency lists

## Testing
- `pytest -q tests/test_entry_rules.py -k '' -vv`
- `pytest -q` *(fails: AttributeError: module 'pandas' has no attribute 'DataFrame')*

------
https://chatgpt.com/codex/tasks/task_e_68458fbfdc548333b995fe0f123e6641