### PR TITLE
Fix SCALP_MODE initialization

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -325,7 +325,8 @@ class JobRunner:
         self.trade_mode: str | None
         self.current_params_file: str
         mode_env = env_loader.get_env("SCALP_MODE")
-        if mode_env is None:
+        # 空文字や未設定の場合は None と同等に扱う
+        if not mode_env:
             self.trade_mode = None
             self.current_params_file = "config/strategy.yml"
         elif mode_env.lower() == "true":


### PR DESCRIPTION
## Summary
- treat empty `SCALP_MODE` like `None`

## Testing
- `pytest -q` *(fails: AttributeError: module 'pandas' has no attribute 'DataFrame')*

------
https://chatgpt.com/codex/tasks/task_e_68460ea63d748333b11ebcfecc7b21c5