### PR TITLE
Fix job runner module import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["piphawk_ai"]
+packages = ["piphawk_ai", "backend"]


### PR DESCRIPTION
## Summary
- add backend as an installed package so `backend.scheduler.job_runner` can be resolved

## Testing
- `python -m backend.scheduler.job_runner --help` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68461a9f7ec883338d4544bd4febf0e8