### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ WORKDIR /app
 # docker build --platform linux/amd64 -t piphawk-ai:dev .
 
 COPY pyproject.toml /app/pyproject.toml
+COPY backend /app/backend
 COPY piphawk_ai /app/piphawk_ai
-COPY ./backend ./analysis ./indicators ./config \
-     ./risk ./monitoring ./strategies ./regime ./piphawk-ui ./tests \
+COPY analysis indicators config \
+     risk monitoring strategies regime piphawk-ui tests \
      /app/
 
 # PyTorch を CPU 版でインストール


### PR DESCRIPTION
## Summary
- copy backend folder explicitly for Docker builds

## Testing
- `python3 -m build --wheel`
- `pip install --no-cache-dir .` *(fails: Could not find a version that satisfies the requirement torch==2.3.0+cpu)*

------
https://chatgpt.com/codex/tasks/task_e_68461bb1a278833389365a25a265dee1