### PR TITLE
Fix Docker build to include signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY pyproject.toml /app/pyproject.toml
 COPY backend /app/backend
 COPY piphawk_ai /app/piphawk_ai
-COPY analysis indicators config \
+COPY analysis indicators config signals \
      risk monitoring strategies regime piphawk-ui tests \
      /app/
 


### PR DESCRIPTION
## Summary
- include `signals` directory in Docker build

## Testing
- `pytest -k adx_mode -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684620c9b5908333894fe0c118f0c0fc