### PR TITLE
Fix torch dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "hdbscan==0.8.33",
     "d3rlpy==2.1.0",
     "transformers==4.41.2",
-    "torch==2.3.0+cpu",
+    "torch==2.3.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- fix torch dependency to avoid +cpu variant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -e .` *(failed or partially executed due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684625b6e74883338c7a7be775702914