### PR TITLE
Fix Python path for signals package

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,8 @@
+# プロジェクトルートを PYTHONPATH に追加
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+


### PR DESCRIPTION
## Summary
- ensure project root is added to `PYTHONPATH` in `backend.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68462789fb488333ac58faa0dfbb4711