### PR TITLE
Fix import path for signals package

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -60,7 +60,9 @@ from backend.risk_manager import (
 )
 from datetime import datetime, timezone
 from backend.utils import env_loader
-from signals.composite_mode import decide_trade_mode
+# signals パッケージはプロジェクト直下にあるため、
+# 絶対インポートで確実に読み込む
+from piphawk_ai.signals.composite_mode import decide_trade_mode
 import os
 import logging
 import json


### PR DESCRIPTION
## Summary
- fix absolute import of `signals` by referencing `piphawk_ai.signals`

## Testing
- `pytest tests/test_entry_rules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684628a95ad08333a3c3feb67ad082df