### PR TITLE
Fix package installation inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ WORKDIR /app
 # docker build --platform linux/amd64 -t piphawk-ai:dev .
 
 COPY pyproject.toml /app/pyproject.toml
-COPY backend piphawk_ai signals \
-     analysis indicators config \
-     risk monitoring strategies regime piphawk-ui tests \
-     /app/
+# プロジェクト全体をコピーして必要なパッケージを確実に含める
+COPY . /app
 
 # PyTorch を CPU 版でインストール
 RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,6 @@ dependencies = [
     "torch==2.3.0",
 ]
 
-[tool.setuptools]
-# signals パッケージを追加
-packages = ["piphawk_ai", "backend", "signals"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["piphawk_ai", "backend", "signals"]


### PR DESCRIPTION
## Summary
- ensure all source directories are copied during build
- use `setuptools` package discovery for packaging

## Testing
- `pip wheel . -w /tmp/piptest --no-deps`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68462b7ab2408333a158119825ac3f0e