### PR TITLE
Fix missing cvar module

### DIFF
--- a/piphawk_ai/risk/cvar.py
+++ b/piphawk_ai/risk/cvar.py
@@ -1,0 +1,4 @@
+"""Wrapper for CVaR calculation utilities."""
+from risk.cvar import calc_cvar
+
+__all__ = ["calc_cvar"]


### PR DESCRIPTION
## Summary
- add `piphawk_ai.risk.cvar` wrapper to expose CVaR utilities

## Testing
- `pytest tests/test_portfolio_risk_manager.py tests/test_cvar.py -q`
- `pip install fastapi numpy pandas pyyaml requests`
- `pip install prometheus-client`


------
https://chatgpt.com/codex/tasks/task_e_68462f21a45c8333adf5e597860fc497