### PR TITLE
Fix local variable name causing UnboundLocalError

### DIFF
--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -1671,8 +1671,8 @@ class JobRunner:
                                             logger.warning(
                                                 f"Failed to cancel pending LIMIT {pend['order_id']}: {exc}"
                                             )
-                                        for key, info in list(_pending_limits.items()):
-                                            if info.get("order_id") == pend["order_id"]:
+                                        for key, pend_info in list(_pending_limits.items()):
+                                            if pend_info.get("order_id") == pend["order_id"]:
                                                 _pending_limits.pop(key, None)
                                                 break
                                     else:


### PR DESCRIPTION
## Summary
- rename the `info` loop variable in `JobRunner.run` to avoid shadowing the imported `info` function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846559f379c8333adcc9f11b03a2240