### PR TITLE
Fix Kafka env config and auto-init DB

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 """Convenience entry point for running Piphawk components."""
 
 import argparse
+import logging
 
 from backend.utils import env_loader
+from backend.logs.log_manager import init_db
 
 import uvicorn
 
@@ -19,6 +21,12 @@ def main() -> None:
         help="Component to run: 'api' starts the FastAPI server, 'job' runs the job scheduler",
     )
     args = parser.parse_args()
+
+    # DBが初期化されていない場合はここで作成しておく
+    try:
+        init_db()
+    except Exception as exc:  # pragma: no cover - 初期化失敗はログ出力のみに留める
+        logging.getLogger(__name__).warning("init_db failed: %s", exc)
 
     if args.component == "api":
         port = int(env_loader.get_env("API_PORT", "8080"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - KAFKA_BROKER_URL=kafka:9092
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_SERVERS=kafka:9092
     depends_on:
       - kafka
     networks:

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -243,6 +243,7 @@ SCALE_TRIGGER_ATR=0.5
 - USE_LOCAL_PATTERN: チャートパターン検出をローカルで行うか (true/false)
 - FRED_API_KEY: 米国経済指標取得に使用するFRED APIキー
 - KAFKA_SERVERS: Kafkaブローカーの接続先リスト (例: localhost:9092)
+  - KAFKA_BROKER_URL や KAFKA_BOOTSTRAP_SERVERS でも同じ値を指定可能
 - METRICS_TOPIC: メトリクス送信用のKafkaトピック名
 - MAX_CVAR: ポートフォリオ許容CVaR上限 (例: 5.0)
 - LOSS_LIMIT: SafetyTriggerによる累積損失上限

--- a/monitoring/metrics_publisher.py
+++ b/monitoring/metrics_publisher.py
@@ -8,7 +8,13 @@ from prometheus_client import Gauge
 
 logger = logging.getLogger(__name__)
 
-KAFKA_SERVERS = os.getenv("KAFKA_SERVERS", "localhost:9092")
+# 環境変数名の揺れを吸収するため複数キーをチェック
+KAFKA_SERVERS = (
+    os.getenv("KAFKA_SERVERS")
+    or os.getenv("KAFKA_BROKER_URL")
+    or os.getenv("KAFKA_BOOTSTRAP_SERVERS")
+    or "localhost:9092"
+)
 METRICS_TOPIC = os.getenv("METRICS_TOPIC", "metrics")
 
 # Kafka producer is initialized lazily so unit tests can run without Kafka.


### PR DESCRIPTION
## Summary
- allow multiple env vars for Kafka server
- expose `KAFKA_SERVERS` in docker-compose
- initialize trades DB on startup
- document alternative Kafka env names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684676bfd1308333b452b3dd2ff5c7e6