### PR TITLE
Add kafka_brokers env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - KAFKA_BROKER_URL=kafka:9092
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - KAFKA_SERVERS=kafka:9092
+      - KAFKA_BROKERS=kafka:9092
     depends_on:
       - kafka
     networks:

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -243,7 +243,7 @@ SCALE_TRIGGER_ATR=0.5
 - USE_LOCAL_PATTERN: チャートパターン検出をローカルで行うか (true/false)
 - FRED_API_KEY: 米国経済指標取得に使用するFRED APIキー
 - KAFKA_SERVERS: Kafkaブローカーの接続先リスト (例: localhost:9092)
-  - KAFKA_BROKER_URL や KAFKA_BOOTSTRAP_SERVERS でも同じ値を指定可能
+  - KAFKA_BROKERS や KAFKA_BROKER_URL、KAFKA_BOOTSTRAP_SERVERS でも同じ値を指定可能
 - METRICS_TOPIC: メトリクス送信用のKafkaトピック名
 - MAX_CVAR: ポートフォリオ許容CVaR上限 (例: 5.0)
 - LOSS_LIMIT: SafetyTriggerによる累積損失上限

--- a/monitoring/metrics_publisher.py
+++ b/monitoring/metrics_publisher.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 # 環境変数名の揺れを吸収するため複数キーをチェック
 KAFKA_SERVERS = (
     os.getenv("KAFKA_SERVERS")
+    or os.getenv("KAFKA_BROKERS")
     or os.getenv("KAFKA_BROKER_URL")
     or os.getenv("KAFKA_BOOTSTRAP_SERVERS")
     or "localhost:9092"


### PR DESCRIPTION
## Summary
- support `KAFKA_BROKERS` in metrics_publisher
- document `KAFKA_BROKERS` usage
- set `KAFKA_BROKERS` env in docker-compose

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846811bf8d08333bbf489bf658f9d89