### PR TITLE
Update DB path env for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ piphawk-ai/
 
 The root also includes `Dockerfile` definitions for containerized deployment and
 `trades.db` as the default SQLite database path.
+When running inside Docker this file is located at `/app/trades.db` by default.
 
 ### Using strategy.yml
 

--- a/ai/policy_trainer.py
+++ b/ai/policy_trainer.py
@@ -5,11 +5,13 @@ import json
 from pathlib import Path
 from typing import Dict, Any
 
+from backend.utils import env_loader
+
 import numpy as np
 from d3rlpy.algos import DiscreteCQL
 from d3rlpy.dataset import MDPDataset
 
-DB_PATH = Path(__file__).resolve().parents[1] / "trades.db"
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "/app/trades.db"))
 MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "policy_model.d3"
 
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -1,7 +1,7 @@
 # === 基本設定 ===
 DEFAULT_PAIR=USD_JPY             # 取引する通貨ペア
 PIP_SIZE=0.01                    # 1pipあたりの値
-TRADES_DB_PATH=backend/logs/trades.db  # 取引履歴DBの保存先
+TRADES_DB_PATH=/app/trades.db  # 取引履歴DBの保存先
 
 # === テクニカル指標期間 ===
 RSI_PERIOD=14                    # RSI計算期間

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -1,5 +1,7 @@
 # Database Migration
 
+When running in Docker the default SQLite path is `/app/trades.db`.
+
 The `trades` table now stores the full AI response for each entry or exit.
 A new column `ai_response` has been added.  
 Additionally the table tracks take‑profit and stop‑loss distances (`tp_pips`,

--- a/training/offline_policy_learning.py
+++ b/training/offline_policy_learning.py
@@ -4,9 +4,11 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
+from backend.utils import env_loader
+
 import numpy as np
 
-DB_PATH = Path(__file__).resolve().parents[1] / "trades.db"
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "/app/trades.db"))
 MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "strategy_policy.pkl"
 
 class SimpleQ:


### PR DESCRIPTION
## Summary
- set TRADES_DB_PATH to `/app/trades.db`
- load the DB path from environment variables in policy trainer scripts
- mention `/app/trades.db` as the default Docker location in README and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6846811d324c8333b04836fc0721fd8f