### PR TITLE
Fix job runner logging and add DB init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         build-essential \
         git \
+        sqlite3 \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/backend/scheduler/strategy_selector.py
+++ b/backend/scheduler/strategy_selector.py
@@ -26,11 +26,15 @@ class StrategySelector:
     ) -> None:
         self.strategies = strategies
         arms = list(strategies.keys())
-        try:
-            self.bandit = MAB(arms=arms, learning_policy=LearningPolicy.LinUCB(alpha=alpha))
-            self.bandit.fit([], [], np.empty((0, 1)))
-        except Exception as exc:  # pragma: no cover - fallback on import issues
-            logger.warning("LinUCB init failed: %s", exc)
+        bandit_enabled = env_loader.get_env("BANDIT_ENABLED", "true").lower() == "true"
+        if bandit_enabled:
+            try:
+                self.bandit = MAB(arms=arms, learning_policy=LearningPolicy.LinUCB(alpha=alpha))
+                self.bandit.fit([], [], np.empty((0, 1)))
+            except Exception as exc:  # pragma: no cover - fallback on import issues
+                logger.warning("LinUCB init failed: %s", exc)
+                self.bandit = None
+        else:
             self.bandit = None
         if use_offline_policy is None:
             use_offline_policy = env_loader.get_env("USE_OFFLINE_POLICY", "false").lower() == "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     restart: always
     ports:
       - "8080:8080"
+    command: >
+      sh -c "test -f /app/.db_initialized || (sqlite3 /app/trades.db < /app/sql/schema.sql && touch /app/.db_initialized); python -m piphawk_ai.main job"
 
   kafka:
     image: bitnami/kafka:3.7

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,80 @@
+CREATE TABLE IF NOT EXISTS oanda_trades (
+    trade_id INTEGER PRIMARY KEY,
+    account_id TEXT,
+    instrument TEXT NOT NULL,
+    open_time TEXT NOT NULL,
+    close_time TEXT,
+    open_price REAL NOT NULL,
+    close_price REAL,
+    units INTEGER NOT NULL,
+    realized_pl REAL,
+    unrealized_pl REAL,
+    state TEXT NOT NULL,
+    tp_price REAL,
+    sl_price REAL
+);
+CREATE TABLE IF NOT EXISTS trades (
+    trade_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    instrument TEXT NOT NULL,
+    entry_time TEXT NOT NULL,
+    entry_price REAL NOT NULL,
+    exit_time TEXT,
+    exit_price REAL,
+    units INTEGER NOT NULL,
+    profit_loss REAL,
+    tp_pips REAL,
+    sl_pips REAL,
+    rrr REAL,
+    ai_dir TEXT,
+    local_dir TEXT,
+    final_side TEXT,
+    ai_reason TEXT,
+    ai_response TEXT,
+    entry_regime TEXT,
+    exit_reason TEXT,
+    is_manual INTEGER
+);
+CREATE TABLE IF NOT EXISTS ai_decisions (
+    decision_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    decision_type TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    ai_response TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS errors (
+    error_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    module TEXT NOT NULL,
+    error_message TEXT NOT NULL,
+    additional_info TEXT
+);
+CREATE TABLE IF NOT EXISTS param_changes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    param_name TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    reason TEXT
+);
+CREATE TABLE IF NOT EXISTS user_actions (
+    action_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    action_type TEXT NOT NULL,
+    action_details TEXT
+);
+CREATE TABLE IF NOT EXISTS entry_skips (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    side TEXT,
+    reason TEXT,
+    details TEXT
+);
+CREATE TABLE IF NOT EXISTS policy_transitions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    state TEXT NOT NULL,
+    action TEXT NOT NULL,
+    reward REAL NOT NULL
+);


### PR DESCRIPTION
## Summary
- prevent `info` name collisions by using a single logger instance
- add ability to disable bandit selector via `BANDIT_ENABLED`
- ensure database schema is created on first container start
- install `sqlite3` in the Docker image

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68468e8a0a1c83338e8645cf2b41f434