### PR TITLE
Add cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,20 @@ python3 backend/logs/show_param_history.py --param RSI_PERIOD --days 7
 python3 -m backend.logs.show_tables
 ```
 
+### Database cleanup
+
+The database and `exit_log.jsonl` can grow large over time. Run the cleanup script to shrink the database and remove old log entries:
+
+```bash
+python3 -m backend.logs.cleanup
+```
+
+Set the `DAYS` environment variable to keep more history:
+
+```bash
+DAYS=60 python3 -m backend.logs.cleanup
+```
+
 ## React UI
 
 The active React application lives in `piphawk-ui/` and was bootstrapped with Create React App. Run it locally with:

--- a/backend/logs/cleanup.py
+++ b/backend/logs/cleanup.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import os
+import json
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from backend.logs.log_manager import DB_PATH
+
+LOG_PATH = Path(__file__).resolve().parent / "exit_log.jsonl"
+DAYS = int(os.getenv("DAYS", "30"))
+
+# データベースをVACUUMして不要領域を解放する
+
+def vacuum_db() -> None:
+    if DB_PATH.exists():
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.execute("VACUUM")
+        print(f"vacuumed {DB_PATH}")
+    else:
+        print(f"{DB_PATH} not found")
+
+# 指定日数より古いExitログを削除する
+
+def prune_exit_log(days: int = DAYS) -> None:
+    if not LOG_PATH.exists():
+        print(f"{LOG_PATH} not found")
+        return
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    new_lines: list[str] = []
+    with LOG_PATH.open("r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+                ts = datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00"))
+                if ts >= cutoff:
+                    new_lines.append(line)
+            except Exception:
+                # 日付が解析できない行は破棄
+                pass
+    with LOG_PATH.open("w", encoding="utf-8") as f:
+        f.writelines(new_lines)
+    print(f"pruned {LOG_PATH} to {days} days")
+
+
+def main() -> None:
+    vacuum_db()
+    prune_exit_log(DAYS)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `cleanup.py` for VACUUM and exit log pruning
- document usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6847a211b2ec8333a8f1ee6d73c6a91d