### PR TITLE
Add system cleanup script and timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,18 @@ Set the `DAYS` environment variable to keep more history:
 DAYS=60 python3 -m backend.logs.cleanup
 ```
 
+### System cleanup
+
+Old cache files and log archives can consume disk space over time. Run the
+helper script below or enable the provided systemd timer for periodic cleanup:
+
+```bash
+python3 maintenance/system_cleanup.py
+```
+
+Copy `maintenance/system_cleanup.service` and `maintenance/system_cleanup.timer`
+to `/etc/systemd/system/` and enable the timer to automate these tasks.
+
 ## React UI
 
 The active React application lives in `piphawk-ui/` and was bootstrapped with Create React App. Run it locally with:

--- a/maintenance/system_cleanup.py
+++ b/maintenance/system_cleanup.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""System maintenance script"""
+
+import os
+import shutil
+import subprocess
+from datetime import datetime
+
+# 日本語でログ出力を行うヘルパー
+
+def log(msg: str) -> None:
+    print(f"{datetime.now().strftime('%F %T')}  [CLEAN] {msg}")
+
+
+def run(cmd: str) -> None:
+    """Run shell command ignoring failures."""
+    try:
+        subprocess.run(cmd, check=True, shell=True)
+    except FileNotFoundError:
+        return
+    except subprocess.CalledProcessError:
+        pass
+
+
+def main() -> None:
+    # 1) APTキャッシュを削除
+    log("Cleaning APT cache ...")
+    run("sudo apt-get clean -y")
+
+    # 2) 7日より古いジャーナルログを削除
+    log("Vacuum old journal logs (≥7d) ...")
+    run("sudo journalctl --vacuum-time=7d")
+
+    # 3) Dockerの不要リソースを削除
+    if shutil.which("docker"):
+        log("Pruning Docker images/containers/volumes ...")
+        run("sudo docker system prune -af --volumes")
+
+    # 4) pip関連キャッシュを削除
+    log("Removing pip cache ...")
+    run("rm -rf ~/.cache/pip ~/.cache/pypoetry ~/.cache/pypi")
+
+    # 5) 1GiB以上のログファイルを空にする
+    log("Truncating huge /var/log files (≥1GiB) ...")
+    for root, _dirs, files in os.walk("/var/log"):
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                if os.path.getsize(path) >= 1024 * 1024 * 1024:
+                    log(f"  -> truncating {path}")
+                    run(f"sudo truncate -s 0 {path}")
+            except FileNotFoundError:
+                continue
+
+    # 6) /tmp配下の30日以上前のファイルを削除
+    log("Cleaning old /tmp files ...")
+    run("sudo find /tmp -type f -mtime +30 -delete")
+
+    # 7) 最終的なディスク使用量を表示
+    log("Done.  Disk usage after cleanup:")
+    run("df -h /")
+
+
+if __name__ == "__main__":
+    main()

--- a/maintenance/system_cleanup.service
+++ b/maintenance/system_cleanup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Piphawk AI system cleanup
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /opt/piphawk/maintenance/system_cleanup.py
+
+[Install]
+WantedBy=multi-user.target

--- a/maintenance/system_cleanup.timer
+++ b/maintenance/system_cleanup.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Piphawk AI cleanup weekly
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add Python-based system cleanup helper
- provide systemd service and timer units
- document cleanup usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6847b1ac29508333923932984ce30c54