### PR TITLE
Add disk guard cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,16 @@ python3 maintenance/system_cleanup.py
 Copy `maintenance/system_cleanup.service` and `maintenance/system_cleanup.timer`
 to `/etc/systemd/system/` and enable the timer to automate these tasks.
 
+### Disk guard
+
+`maintenance/disk_guard.py` checks the root filesystem usage and triggers
+`system_cleanup.py` automatically when the usage is 80% or higher.  Invoke it in
+the main loop or run it manually:
+
+```bash
+python3 maintenance/disk_guard.py
+```
+
 ## React UI
 
 The active React application lives in `piphawk-ui/` and was bootstrapped with Create React App. Run it locally with:

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - optional dependency or test stub
         return None
 
 from backend.utils import env_loader, trade_age_seconds
+from maintenance.disk_guard import maybe_cleanup
 
 try:
     from config import params_loader
@@ -903,6 +904,7 @@ class JobRunner:
         log.info("Job Runner started.")
         while not self._stop:
             try:
+                maybe_cleanup()
                 timer = PerfTimer("job_loop")
                 now = datetime.now(timezone.utc)
                 # ---- Market‑hours guard ---------------------------------

--- a/maintenance/disk_guard.py
+++ b/maintenance/disk_guard.py
@@ -1,0 +1,27 @@
+"""Call this from your main loop (or run standalone).
+If '/' usage >= 80 %, execute system_cleanup.run()."""
+import shutil
+import logging
+import maintenance.system_cleanup as sc
+
+THRESHOLD = 80  # %
+
+# ルートFS使用率を返す
+
+def root_usage_pct() -> int:
+    total, used, _ = shutil.disk_usage("/")
+    return used * 100 // total
+
+# 必要ならクリーンアップを実行
+
+def maybe_cleanup() -> int:
+    pct = root_usage_pct()
+    logging.info("root-fs usage = %s%% (threshold %s%%)", pct, THRESHOLD)
+    if pct >= THRESHOLD:
+        logging.warning("Disk almost full \u2013 running cleanup ...")
+        sc.main()
+        logging.info("Cleanup finished (%s%% \u2794 %s%%)", pct, root_usage_pct())
+    return pct
+
+if __name__ == "__main__":
+    maybe_cleanup()


### PR DESCRIPTION
## Summary
- add maintenance/disk_guard.py for automated cleanup when rootfs is >80%
- call `maybe_cleanup()` in JobRunner loop
- document the new script in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: linebot)*

------
https://chatgpt.com/codex/tasks/task_e_6847b45f28408333aec0cba9cbf37532