### PR TITLE
Set AI_RETRY_ON_NO default

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -254,6 +254,7 @@ SCALP_TP_PIPS=4                  # スキャルプ時のTP幅
 SCALP_SL_PIPS=4                  # スキャルプ時のSL幅
 SCALP_COND_TF=S10                 # 市場判定に使う時間足(M1/M5等)
 SCALP_PROMPT_BIAS=aggressive     # AIプロンプトの攻め姿勢
+AI_RETRY_ON_NO=true              # AIが"no"の場合は積極モードで再評価
 TREND_COND_TF=M5                 # トレンドモード判定に使う時間足
 ADX_TREND_MIN=30                 # トレンド移行に必要なADX
 SCALP_OVERRIDE_RANGE=false

--- a/docs/aggressive_scalp.md
+++ b/docs/aggressive_scalp.md
@@ -19,6 +19,7 @@
 - `SCALP_TP_PIPS=4`
 - `SCALP_SL_PIPS=4`
 - `SCALP_PROMPT_BIAS=aggressive`
+- `AI_RETRY_ON_NO=true`
 
 ## 反映手順
 


### PR DESCRIPTION
## Summary
- enable retry on `side:no` in settings.env
- document the new setting in aggressive scalp guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847b4921e708333937b4f4325cabf7a