### PR TITLE
Handle bandit prediction failures

### DIFF
--- a/backend/scheduler/strategy_selector.py
+++ b/backend/scheduler/strategy_selector.py
@@ -97,7 +97,21 @@ class StrategySelector:
                     arm = self.bandit.predict(ctx)
                     return self.strategies[arm]
             except Exception as exc:  # pragma: no cover
-                logger.warning("Bandit prediction failed: %s", exc)
+                dim = len(ctx[0])
+                num_features = getattr(getattr(self.bandit, "_imp", None), "num_features", None)
+                logger.warning(
+                    "Bandit prediction failed: %s dim=%s num_features=%s",
+                    exc,
+                    dim,
+                    num_features,
+                )
+                try:
+                    self._ensure_bandit_ready(ctx)
+                    if self.bandit is not None:
+                        arm = self.bandit.predict(ctx)
+                        return self.strategies[arm]
+                except Exception as exc2:  # pragma: no cover
+                    logger.warning("Bandit prediction failed after retry: %s", exc2)
         # Fallback to first strategy
         return next(iter(self.strategies.values()))
 

--- a/tests/test_strategy_selector_dynamic.py
+++ b/tests/test_strategy_selector_dynamic.py
@@ -1,5 +1,6 @@
 import sys
 import importlib
+import logging
 
 orig_pandas = sys.modules.get("pandas")
 try:
@@ -20,6 +21,38 @@ try:
         # should not raise even though dimension differs
         result = selector.select(ctx2)
         assert result in strategies.values()
+
+    def test_predict_retry(monkeypatch, caplog):
+        strategies = {"scalp": ScalpStrategy(), "trend": TrendStrategy()}
+        selector = StrategySelector(strategies)
+        ctx = {"a": 1.0}
+
+        call = {"n": 0}
+
+        def flaky_predict(_):
+            if call["n"] == 0:
+                call["n"] += 1
+                raise ValueError("boom")
+            return "scalp"
+
+        monkeypatch.setattr(selector.bandit, "predict", flaky_predict)
+
+        ensure_count = {"n": 0}
+
+        orig_ensure = selector._ensure_bandit_ready
+
+        def count_ensure(c):
+            ensure_count["n"] += 1
+            orig_ensure(c)
+
+        monkeypatch.setattr(selector, "_ensure_bandit_ready", count_ensure)
+
+        caplog.set_level(logging.WARNING)
+        result = selector.select(ctx)
+        assert result.name == "scalp"
+        assert call["n"] == 1
+        assert ensure_count["n"] == 2
+        assert any("num_features" in r.getMessage() for r in caplog.records)
 finally:
     if orig_pandas is not None:
         sys.modules["pandas"] = orig_pandas


### PR DESCRIPTION
## Summary
- retry bandit prediction after reinitializing
- log `dim` and `num_features` on failure
- test recovery when first prediction fails

## Testing
- `pytest -q tests/test_strategy_selector_dynamic.py::test_selector_dimension_change tests/test_strategy_selector_dynamic.py::test_predict_retry`

------
https://chatgpt.com/codex/tasks/task_e_6847e94572f48333808ed54d8faa708c