### PR TITLE
Update trades DB default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ piphawk-ai/
 
 The root also includes `Dockerfile` definitions for containerized deployment and
 `trades.db` as the default SQLite database path.
-When running inside Docker this file is located at `/app/trades.db` by default.
+When running inside Docker this file is located at `/app/backend/logs/trades.db` by default.
 
 ### Using strategy.yml
 
@@ -438,7 +438,7 @@ as on native x86 hardware.
 
 Trade history is stored in `trades.db` (SQLite) at the repository root by default.
 You can override the path with the environment variable `TRADES_DB_PATH`.
-When running inside Docker this defaults to `/app/trades.db`.
+When running inside Docker this defaults to `/app/backend/logs/trades.db`.
 
 SQLite uses WAL (Write-Ahead Logging) mode. For existing databases run:
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -1,7 +1,7 @@
 # === 基本設定 ===
 DEFAULT_PAIR=USD_JPY             # 取引する通貨ペア
 PIP_SIZE=0.01                    # 1pipあたりの値
-TRADES_DB_PATH=/app/trades.db  # 取引履歴DBの保存先
+TRADES_DB_PATH=/app/backend/logs/trades.db  # 取引履歴DBの保存先
 
 # === テクニカル指標期間 ===
 RSI_PERIOD=14                    # RSI計算期間

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -1,6 +1,6 @@
 # Database Migration
 
-When running in Docker the default SQLite path is `/app/trades.db`.
+When running in Docker the default SQLite path is `/app/backend/logs/trades.db`.
 
 The `trades` table now stores the full AI response for each entry or exit.
 A new column `ai_response` has been added.  


### PR DESCRIPTION
## Summary
- update `TRADES_DB_PATH` in `backend/config/settings.env`
- document new default DB location in README and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847eb7ee788833387dfe4af495aa92d