### PR TITLE
Update log volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ loaded from environment variables and optional YAML files under `config/`.
 
    ```bash
    docker build -t piphawk-ai .
-   docker run --env-file .env -p 8080:8080 piphawk-ai
+   docker run --env-file .env -p 8080:8080 \
+     -v $(pwd)/backend/logs:/app/backend/logs piphawk-ai
    ```
 
 4. Start the React UI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./models:/app/models
       - ./trades.db:/app/trades.db
+      - ./backend/logs:/app/backend/logs
     env_file:
       - .env
     environment:

--- a/docs/quick_start_en.md
+++ b/docs/quick_start_en.md
@@ -18,7 +18,8 @@
 
    ```bash
    docker build -t piphawk-ai .
-   docker run --env-file .env -p 8080:8080 piphawk-ai
+   docker run --env-file .env -p 8080:8080 \
+     -v $(pwd)/backend/logs:/app/backend/logs piphawk-ai
    ```
 
 4. Start the React UI

--- a/docs/quick_start_ja.md
+++ b/docs/quick_start_ja.md
@@ -18,7 +18,8 @@
 
    ```bash
    docker build -t piphawk-ai .
-   docker run --env-file .env -p 8080:8080 piphawk-ai
+   docker run --env-file .env -p 8080:8080 \
+     -v $(pwd)/backend/logs:/app/backend/logs piphawk-ai
    ```
 
 4. React UI を起動


### PR DESCRIPTION
## Summary
- mount backend logs in docker-compose
- update QuickStart docs to mount backend/logs when running the container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847eb85b92c8333aa15b29bb6d04dae