### PR TITLE
Add TRADES_DB_PATH env docs

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -4,6 +4,12 @@
 
 取引対象とする通貨ペア（例: USD_JPY）
 
+### TRADES_DB_PATH
+
+取引履歴を保存するSQLiteファイルのパス。デフォルトではプロジェクトルートの
+`trades.db` を利用し、Docker環境では `/app/trades.db` が使用されます。
+環境変数 `TRADES_DB_PATH` で別のパスを指定できます。
+
 ### INITIAL_TP_PIPS / INITIAL_SL_PIPS
 
 初期の利確（TP）・損切り（SL）幅（単位: pips）


### PR DESCRIPTION
## Summary
- document `TRADES_DB_PATH` in env vars guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6847eb8967508333b51ff8e41669c23e