### PR TITLE
Improve entry prompt and debug logging

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1277,6 +1277,7 @@ Respond with **one-line valid JSON** exactly as:
             log_ai_decision("ERROR", instrument, json.dumps(raw, ensure_ascii=False))
         except Exception as exc:  # pragma: no cover - ignore logging failure
             logger.warning("log_ai_decision failed: %s", exc)
+        logger.info("Invalid JSON response: %s", raw)
         return {"entry": {"side": "no"}, "raw": raw}
 
     entry_conf = plan.get("entry_confidence")
@@ -1363,6 +1364,7 @@ Respond with **one-line valid JSON** exactly as:
             total = p + q
             if total > 1.0 + PROB_MARGIN or total < 1.0 - PROB_MARGIN:
                 logger.warning("Probabilities invalid — skipping plan")
+                logger.info("Plan with invalid probabilities: %s", json.dumps(plan, ensure_ascii=False))
                 plan["entry"]["side"] = "no"
                 return plan
 

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -294,8 +294,8 @@ Pivot: {ind_m5.get('pivot')}, R1: {ind_m5.get('pivot_r1')}, S1: {ind_m5.get('piv
 
 Your task:
 1. Clearly classify the current regime as "trend" or "range". If "trend", specify direction as "long" or "short". Output this at JSON key "regime".
-2. Decide whether to open a trade now, strictly adhering to the above criteria. Return JSON key "entry" with: {{ "side":"long"|"short"|"no", "rationale":"…" }}. Also include numeric key "entry_confidence" between 0 and 1 representing your confidence.
-3. If side is not "no", propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included.
+2. Decide whether to open a trade now, strictly adhering to the above criteria. Return JSON key "entry" with: {{ "side":"long"|"short"|"no", "rationale":"…" }}. Also include numeric key "entry_confidence" between 0 and 1 representing your confidence. Additionally return key "probs" as {{"long":float,"short":float,"no":float}} where all values sum to 1.
+3. If side is not "no", propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included. Use decimals for all probability values.
    - Constraints:
     • tp_prob must be ≥ {MIN_TP_PROB:.2f}
     • Expected value (tp_pips*tp_prob - sl_pips*sl_prob) must be positive
@@ -304,7 +304,7 @@ Your task:
     • If constraints are not met, set side to "no".
 
 Respond with **one-line valid JSON** exactly as:
-{{"regime":{{...}},"entry":{{...}},"risk":{{...}},"entry_confidence":0.0}}
+{{"regime":{{...}},"entry":{{...}},"risk":{{...}},"entry_confidence":0.0,"probs":{{"long":0.5,"short":0.5,"no":0.0}}}}
 """
     bias = trend_prompt_bias or TREND_PROMPT_BIAS
     bias_note = ""


### PR DESCRIPTION
## Summary
- clarify JSON format in OpenAI entry prompt
- log invalid JSON responses and invalid probabilities for easier debugging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apscheduler', 'linebot', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847e915eb6c8333832416ba690d400f