### PR TITLE
Update disk guard threshold

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,9 @@ BYPASS_PULLBACK_ADX_MIN=
 
 AI_COOLDOWN_SEC=30
 
+# Disk guard
+CLEANUP_THRESHOLD=80
+
 # Example environment variables
 # Copy this file to .env and adjust as needed
 COMPOSITE_MIN=0.7

--- a/README.md
+++ b/README.md
@@ -512,7 +512,9 @@ to `/etc/systemd/system/` and enable the timer to automate these tasks.
 ### Disk guard
 
 `maintenance/disk_guard.py` checks the root filesystem usage and triggers
-`system_cleanup.py` automatically when the usage is 80% or higher.  Invoke it in
+`system_cleanup.py` automatically when the usage reaches the threshold.
+Set the `CLEANUP_THRESHOLD` environment variable to adjust it (default 80%).
+Invoke it in
 the main loop or run it manually:
 
 ```bash

--- a/backend/config/secret.env.example
+++ b/backend/config/secret.env.example
@@ -2,3 +2,6 @@ OPENAI_API_KEY=
 OANDA_API_KEY=
 OANDA_ACCOUNT_ID=
 # OANDA_API_URL=https://api-fxpractice.oanda.com/v3
+
+# Disk guard threshold
+CLEANUP_THRESHOLD=80

--- a/maintenance/disk_guard.py
+++ b/maintenance/disk_guard.py
@@ -3,8 +3,9 @@ If '/' usage >= 80 %, execute system_cleanup.run()."""
 import shutil
 import logging
 import maintenance.system_cleanup as sc
+from backend.utils import env_loader
 
-THRESHOLD = 80  # %
+THRESHOLD = int(env_loader.get_env("CLEANUP_THRESHOLD", "80"))  # %
 
 # ルートFS使用率を返す
 


### PR DESCRIPTION
## Summary
- make disk guard threshold configurable via `CLEANUP_THRESHOLD`
- document usage of `CLEANUP_THRESHOLD`
- add variable to example environment files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847f526099483338bb1a259b96e106e