### PR TITLE
Add LinUCB rule selector

### DIFF
--- a/selector_fast.py
+++ b/selector_fast.py
@@ -12,15 +12,27 @@ class RuleSelector:
 
     def __init__(self, rules: Dict[str, Callable[[Dict[str, Any]], str | None]], alpha: float = 1.0) -> None:
         self.rules = rules
+        self.alpha = alpha
         arms = list(rules.keys())
         self.bandit = MAB(arms=arms, learning_policy=LearningPolicy.LinUCB(alpha=alpha))
         self.bandit.fit([], [], np.empty((0, 1)))
+
+    def _ensure_bandit_ready(self, ctx: list[list[float]]) -> None:
+        """コンテキスト次元に合わせてバンディットを初期化する."""
+        dim = len(ctx[0])
+        if not getattr(self.bandit, "_is_initial_fit", False):
+            self.bandit.fit([], [], np.empty((0, dim)))
+        elif getattr(self.bandit._imp, "num_features", None) != dim:
+            self.bandit = MAB(arms=list(self.rules.keys()), learning_policy=LearningPolicy.LinUCB(alpha=self.alpha))
+            self.bandit.fit([], [], np.empty((0, dim)))
 
     def _vec(self, ctx: Dict[str, Any]) -> list[float]:
         return [float(ctx.get(k, 0.0)) for k in sorted(ctx.keys())]
 
     def choose_rule(self, ctx: Dict[str, Any]) -> str:
-        arm = self.bandit.predict([self._vec(ctx)])
+        arr = [self._vec(ctx)]
+        self._ensure_bandit_ready(arr)
+        arm = self.bandit.predict(arr)
         return arm
 
     def evaluate(self, ctx: Dict[str, Any]) -> str | None:
@@ -28,4 +40,53 @@ class RuleSelector:
         return self.rules[arm](ctx)
 
     def update_reward(self, arm: str, ctx: Dict[str, Any], reward: float) -> None:
-        self.bandit.partial_fit([arm], [reward], [self._vec(ctx)])
+        arr = [self._vec(ctx)]
+        self._ensure_bandit_ready(arr)
+        self.bandit.partial_fit([arm], [reward], arr)
+
+
+def build_entry_context(data: Dict[str, Any]) -> Dict[str, float]:
+    """エントリールール選択用のコンテキストを生成するユーティリティ."""
+    ctx: Dict[str, float] = {}
+    spread = data.get("spread")
+    if spread is not None:
+        try:
+            ctx["spread"] = float(spread)
+        except Exception:
+            pass
+    mid = data.get("mid")
+    upper = data.get("upper_band")
+    lower = data.get("lower_band")
+    if mid is not None and upper is not None:
+        try:
+            ctx["dist_upper"] = float(upper) - float(mid)
+        except Exception:
+            pass
+    if mid is not None and lower is not None:
+        try:
+            ctx["dist_lower"] = float(mid) - float(lower)
+        except Exception:
+            pass
+    price = data.get("price")
+    high = data.get("range_high")
+    low = data.get("range_low")
+    if price is not None and high is not None:
+        try:
+            ctx["dist_high"] = float(high) - float(price)
+        except Exception:
+            pass
+    if price is not None and low is not None:
+        try:
+            ctx["dist_low"] = float(price) - float(low)
+        except Exception:
+            pass
+    adx_val = data.get("adx")
+    if adx_val is not None:
+        try:
+            ctx["adx"] = float(adx_val)
+        except Exception:
+            pass
+    return ctx
+
+
+__all__ = ["RuleSelector", "build_entry_context"]

--- a/tests/test_rule_selector.py
+++ b/tests/test_rule_selector.py
@@ -1,0 +1,51 @@
+import unittest
+from selector_fast import RuleSelector, build_entry_context
+from strategies.scalp import entry_rules
+
+
+class TestRuleSelector(unittest.TestCase):
+    def test_basic_selection(self):
+        rules = {
+            "long": entry_rules.rule_scalp_long,
+            "short": entry_rules.rule_scalp_short,
+            "breakout": entry_rules.rule_breakout,
+        }
+        selector = RuleSelector(rules, alpha=0.1)
+        ctx_raw = {
+            "mid": 1.0,
+            "spread": 0.01,
+            "lower_band": 1.0,
+            "upper_band": 1.1,
+            "range_high": 1.2,
+            "range_low": 0.9,
+            "price": 1.21,
+            "adx": 25,
+        }
+        ctx = build_entry_context(ctx_raw)
+        selector.update_reward("long", ctx, 1.0)
+        selector.update_reward("short", ctx, 0.0)
+        side = selector.evaluate(ctx_raw)
+        self.assertEqual(side, "long")
+
+    def test_context_builder(self):
+        data = {
+            "spread": 0.02,
+            "mid": 1.1,
+            "upper_band": 1.3,
+            "lower_band": 1.0,
+            "price": 1.2,
+            "range_high": 1.25,
+            "range_low": 1.0,
+            "adx": 30,
+        }
+        ctx = build_entry_context(data)
+        self.assertAlmostEqual(ctx["spread"], 0.02)
+        self.assertAlmostEqual(ctx["dist_upper"], 0.2)
+        self.assertAlmostEqual(ctx["dist_lower"], 0.1)
+        self.assertAlmostEqual(ctx["dist_high"], 0.05)
+        self.assertAlmostEqual(ctx["dist_low"], 0.2)
+        self.assertAlmostEqual(ctx["adx"], 30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `RuleSelector` with dynamic feature handling
- provide `build_entry_context` helper
- add unit test for rule selector

## Testing
- `pytest tests/test_rule_selector.py tests/test_entry_rules.py -q`
- `pytest -q` *(fails: ImportError: module signals.composite_mode not in sys.modules and others)*

------
https://chatgpt.com/codex/tasks/task_e_6847f99713f0833386658c1611757828