### PR TITLE
Improve entry decision bias

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -44,7 +44,7 @@ AI_REGIME_COOLDOWN_SEC: int = int(env_loader.get_env("AI_REGIME_COOLDOWN_SEC", A
 # --- Threshold for AI‑proposed TP probability ---
 MIN_TP_PROB: float = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
 TP_PROB_HOURS: int = int(env_loader.get_env("TP_PROB_HOURS", "24"))
-PROB_MARGIN: float = float(env_loader.get_env("PROB_MARGIN", "0.02"))
+PROB_MARGIN: float = float(env_loader.get_env("PROB_MARGIN", "0.1"))
 LIMIT_THRESHOLD_ATR_RATIO: float = float(env_loader.get_env("LIMIT_THRESHOLD_ATR_RATIO", "0.3"))
 MAX_LIMIT_AGE_SEC: int = int(env_loader.get_env("MAX_LIMIT_AGE_SEC", "180"))
 MIN_NET_TP_PIPS: float = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -311,6 +311,7 @@ Respond with **one-line valid JSON** exactly as:
     if bias == "aggressive":
         bias_note = (
             "\nBe proactive: when signals are mixed, favor taking a position rather than returning 'no'."
+            "\nIf conditions are ambiguous, prefer 'long' or 'short' rather than 'no'."
         )
     prompt += bias_note
     return prompt, comp_val


### PR DESCRIPTION
## Summary
- allow looser probability sums by default
- tweak aggressive bias text to encourage taking a position

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684812638080833390cab56060b814ab