### PR TITLE
Improve entry prompt bias

### DIFF
--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -309,8 +309,10 @@ Respond with **one-line valid JSON** exactly as:
     bias = trend_prompt_bias or TREND_PROMPT_BIAS
     bias_note = ""
     if bias == "aggressive":
+        # 条件が曖昧な場合はなるべくエントリー方向を示すように促す
         bias_note = (
-            "\nBe proactive: when signals are mixed, favor taking a position rather than returning 'no'."
+            "\nBe proactive: when signals are mixed, favor taking a position rather than returning 'no'. "
+            "If conditions are ambiguous, prefer 'long' or 'short' rather than 'no'."
         )
     prompt += bias_note
     return prompt, comp_val


### PR DESCRIPTION
## Summary
- encourage LLM to pick a direction when conditions are unclear

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6848125cbe74833399a5b2cac15f1976