### PR TITLE
Add docker cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,12 @@ the main loop or run it manually:
 python3 maintenance/disk_guard.py
 ```
 
+`docker_cleanup.sh` も用意しており、ジョブランナーや cron から直接呼び出せます。しきい値は環境変数 `THRESHOLD` で調整可能です。
+
+```bash
+THRESHOLD=80 bash maintenance/docker_cleanup.sh
+```
+
 ### Kafka log retention
 
 `docker-compose.yml` sets Kafka's `log.retention.hours` and

--- a/maintenance/disk_guard.py
+++ b/maintenance/disk_guard.py
@@ -7,6 +7,9 @@ from backend.utils import env_loader
 
 THRESHOLD = int(env_loader.get_env("CLEANUP_THRESHOLD", "80"))  # %
 
+if not 1 <= THRESHOLD <= 100:
+    raise ValueError("CLEANUP_THRESHOLD must be between 1 and 100")
+
 # ルートFS使用率を返す
 
 def root_usage_pct() -> int:

--- a/maintenance/docker_cleanup.sh
+++ b/maintenance/docker_cleanup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# しきい値は環境変数 THRESHOLD で指定（デフォルト 80）
+THRESHOLD="${THRESHOLD:-80}"
+
+used=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+
+if [ "$used" -ge "$THRESHOLD" ]; then
+  echo "[docker-cleanup] rootfs ${used}% \u2265 ${THRESHOLD}%. Cleaning…" | logger
+
+  docker image prune -a -f
+  docker builder prune -af
+  rm -rf "$HOME/.vscode-server/bin/"*
+
+  new_used=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+  echo "[docker-cleanup] Done. (${used}% \u2794 ${new_used}%)" | logger
+fi


### PR DESCRIPTION
## Summary
- add `docker_cleanup.sh` for cron/job runners
- validate cleanup threshold in `disk_guard.py`
- document docker cleanup script in README

## Testing
- `pytest -q` *(fails: FakeSeries object has no attribute 'rolling', ImportError: module backend.orders.order_manager not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_68481290ae5c83338155c29e48f8830e