### PR TITLE
Fix torch install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY backend/requirements.txt /app/backend/requirements.txt
 
 # 依存関係を先にインストール
 RUN pip install --no-cache-dir -r backend/requirements.txt \
- && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.3.0
+ && pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu torch==2.3.0
 
 # アプリケーションコードを後からコピーしてレイヤーを分離
 COPY . /app

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,4 +40,4 @@ prometheus-client==0.20.0
 hdbscan==0.8.33  # optional
 d3rlpy==2.1.0
 transformers==4.41.2
-torch==2.3.0+cpu
+torch==2.3.0


### PR DESCRIPTION
## Summary
- update `torch` version in requirements
- use `--extra-index-url` when installing torch in Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi, numpy, requests, yaml, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68481880465c8333a5ee5ac480c8fec5