### PR TITLE
Switch to CPU-only torch and update Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ COPY pyproject.toml /app/pyproject.toml
 COPY backend/requirements.txt /app/backend/requirements.txt
 
 # 依存関係を先にインストール
-RUN pip install --no-cache-dir -r backend/requirements.txt \
- && pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu torch==2.3.0
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
 
 # アプリケーションコードを後からコピーしてレイヤーを分離
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
-   pip install -r backend/requirements.txt
+   pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
    ```
 
    The indicator modules require **pandas**. If it is not installed, add it with:

--- a/backend/Dockerfile.api
+++ b/backend/Dockerfile.api
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Copy requirements from the build‑context root (backend/)
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
 
 # Copy the backend source code into the image
 COPY . /app/backend

--- a/backend/Dockerfile.job
+++ b/backend/Dockerfile.job
@@ -11,7 +11,7 @@ WORKDIR /app
 # requirements.txt はbackend配下
 COPY backend/requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
 
 # backendごと/appにコピー
 COPY backend /app/backend

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,4 +40,5 @@ prometheus-client==0.20.0
 hdbscan==0.8.33  # optional
 d3rlpy==2.1.0
 transformers==4.41.2
-torch==2.3.0
+# CPU-only build
+torch==2.3.0+cpu

--- a/pipelines/walk_forward/Dockerfile
+++ b/pipelines/walk_forward/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY backend/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
 
 COPY . .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "hdbscan==0.8.33",
     "d3rlpy==2.1.0",
     "transformers==4.41.2",
-    "torch==2.3.0",
+    "torch==2.3.0+cpu",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- use CPU-only PyTorch in backend requirements and pyproject
- update Dockerfiles to install from PyTorch CPU wheels
- document CPU-only install in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `docker build -t piphawk-ai:test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481ea2a10c8333a73727eb88ff8abc