### PR TITLE
Modify prompts and skip TF alignment in scalp

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 - `TREND_COND_TF` … トレンドフォロー時の市場判定に使う時間足 (デフォルト `M5`)
 - `SCALP_OVERRIDE_RANGE` … true ならレンジ判定を無視してスキャルを優先
 - `SCALP_PROMPT_BIAS` … `aggressive` にするとスキャルプAIが積極的にエントリー判断
+- スキャルプモードではマルチTF整合チェックを自動的にスキップ
 - `ADX_SCALP_MIN` … ADX がこの値以上でスキャルプモード
 - `ADX_TREND_MIN` … ADX がこの値以上でトレンドフォローモード
 - `TREND_PROMPT_BIAS` … `aggressive` にするとトレンドフォローAIがより積極的

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1010,24 +1010,34 @@ class JobRunner:
                     if self.indicators_S10:
                         indicators["S10"] = self.indicators_S10
 
-                    align = is_multi_tf_aligned(
-                        {
-                            "M1": self.indicators_M1 or {},
-                            "M5": self.indicators_M5 or {},
-                            "H1": self.indicators_H1 or {},
-                        }
+                    skip_align = self.trade_mode in (
+                        "scalp",
+                        "scalp_momentum",
+                        "scalp_range",
                     )
-                    if align is None and env_loader.get_env(
-                        "ALIGN_STRICT", env_loader.get_env("STRICT_TF_ALIGN", "false")
-                    ).lower() == "true":
-                        log.info("Multi‑TF alignment missing → skip entry")
-                        log_entry_skip(DEFAULT_PAIR, None, "tf_align")
-                        self.last_run = now
-                        update_oanda_trades()
-                        time.sleep(self.interval_seconds)
-                        timer.stop()
-                        continue
-                    log.info(f"Multi‑TF alignment: {align}")
+                    if skip_align:
+                        align = None
+                        log.debug("Multi‑TF alignment skipped in scalp mode")
+                    else:
+                        align = is_multi_tf_aligned(
+                            {
+                                "M1": self.indicators_M1 or {},
+                                "M5": self.indicators_M5 or {},
+                                "H1": self.indicators_H1 or {},
+                            }
+                        )
+                        if align is None and env_loader.get_env(
+                            "ALIGN_STRICT",
+                            env_loader.get_env("STRICT_TF_ALIGN", "false"),
+                        ).lower() == "true":
+                            log.info("Multi‑TF alignment missing → skip entry")
+                            log_entry_skip(DEFAULT_PAIR, None, "tf_align")
+                            self.last_run = now
+                            update_oanda_trades()
+                            time.sleep(self.interval_seconds)
+                            timer.stop()
+                            continue
+                        log.info(f"Multi‑TF alignment: {align}")
 
                     log.info("Indicators calculation successful.")
 

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -309,10 +309,10 @@ Respond with **one-line valid JSON** exactly as:
     bias = trend_prompt_bias or TREND_PROMPT_BIAS
     bias_note = ""
     if bias == "aggressive":
-        # 条件が曖昧な場合はなるべくエントリー方向を示すように促す
+        # 条件が曖昧な場合でも積極的にポジションを示すよう指示
         bias_note = (
-            "\nBe proactive: when signals are mixed, favor taking a position rather than returning 'no'. "
-            "If conditions are ambiguous, prefer 'long' or 'short' rather than 'no'."
+            "\nBe strongly proactive: unless risk rules clearly prohibit, choose 'long' or 'short' instead of 'no'. "
+            "Return 'no' only when absolutely no valid setup exists."
         )
     prompt += bias_note
     return prompt, comp_val

--- a/backend/strategy/openai_scalp_analysis.py
+++ b/backend/strategy/openai_scalp_analysis.py
@@ -33,7 +33,7 @@ def get_scalp_plan(indicators: dict, candles: list, *, higher_tf_direction: str 
     bias_note = ""
     if SCALP_PROMPT_BIAS == "aggressive":
         bias_note = (
-            "\nWhen conditions are unclear, prefer taking a position rather than returning 'no'."
+            "\nAct decisively: choose 'long' or 'short' whenever possible. Return 'no' only if no valid setup exists."
         )
     prompt = (
         "You are a forex scalping assistant.\n"


### PR DESCRIPTION
## Summary
- skip multi-timeframe alignment check while in scalp modes
- strengthen aggressive prompt wording to reduce `no` answers
- encourage scalp AI to choose a side whenever possible
- document that scalp mode skips multi-TF alignment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68482373aa34833383d20110a4bd15c2