### PR TITLE
Fix missing sys import in job_runner

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -5,6 +5,7 @@ from logging import getLogger
 import logging
 import json
 import os
+import sys
 try:
     from prometheus_client import start_http_server
 except Exception:  # pragma: no cover - optional dependency or test stub


### PR DESCRIPTION
## Summary
- add missing `import sys` in `job_runner.py`

## Testing
- `pip install -q -r backend/requirements.txt` *(fails: No matching distribution found for torch)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68482791beb0833386ff7417640b50d9