### PR TITLE
Expose DEFAULT_PAIR attribute in JobRunner

### DIFF
--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -230,6 +230,8 @@ class JobRunner:
         self.interval_seconds = interval_seconds
         self.last_run = None
         self._stop = False
+        # DEFAULT_PAIR を属性に保持して外部モジュールから参照できるようにする
+        self.DEFAULT_PAIR = DEFAULT_PAIR
         # Start Prometheus metrics server
         metrics_port = int(env_loader.get_env("METRICS_PORT", "8001"))
         try:


### PR DESCRIPTION
## Summary
- expose `DEFAULT_PAIR` as `self.DEFAULT_PAIR` within `JobRunner`
- run subset of tests to verify core runner functions

## Testing
- `pytest backend/api/test_control_endpoints.py backend/api/test_panic_stop.py backend/api/test_recent_trades.py tests/test_force_close.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684831a20d54833388bc5696e5d0102f