### PR TITLE
Fix missing DEFAULT_PAIR attribute

### DIFF
--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -270,6 +270,8 @@ class JobRunner:
         # 注文マネージャーとパターン名リストを属性化
         self.order_mgr = order_mgr
         self.PATTERN_NAMES = PATTERN_NAMES
+        # DEFAULT_PAIR を属性として保持
+        self.DEFAULT_PAIR = DEFAULT_PAIR
         # ----- Additional runtime state --------------------------------
         # Toggle for higher‑timeframe reference levels (daily / H4)
         self.higher_tf_enabled = env_loader.get_env("HIGHER_TF_ENABLED", "true").lower() == "true"


### PR DESCRIPTION
## Summary
- store `DEFAULT_PAIR` on JobRunner instance to avoid AttributeError

## Testing
- `pytest -q` *(fails: module import errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684833232f108333a160865da1880860