### PR TITLE
Fix TP rejection handling

### DIFF
--- a/backend/logs/initial_fetch_oanda_trades.py
+++ b/backend/logs/initial_fetch_oanda_trades.py
@@ -28,7 +28,11 @@ def initial_fetch_oanda_trades():
 
     base_url = f"{OANDA_API_URL}/v3/accounts/{OANDA_ACCOUNT_ID}/transactions"
     params = {
-        "type": "ORDER_FILL,STOP_LOSS_ORDER,TAKE_PROFIT_ORDER,MARKET_ORDER",
+        "type": (
+            "ORDER_FILL,STOP_LOSS_ORDER,TAKE_PROFIT_ORDER,MARKET_ORDER," 
+            "STOP_LOSS_ORDER_REJECT,TAKE_PROFIT_ORDER_REJECT,"
+            "ORDER_CANCEL"
+        ),
         "from": (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "to": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "pageSize": 1000

--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -79,8 +79,12 @@ def update_oanda_trades():
 
     base_url = f"{OANDA_API_URL}/v3/accounts/{OANDA_ACCOUNT_ID}/transactions/sinceid"
     params = {
-        "type": "ORDER_FILL,STOP_LOSS_ORDER,TAKE_PROFIT_ORDER",
-        "id": str(int(last_transaction_id) + 1)
+        "type": (
+            "ORDER_FILL,STOP_LOSS_ORDER,TAKE_PROFIT_ORDER,"
+            "STOP_LOSS_ORDER_REJECT,TAKE_PROFIT_ORDER_REJECT,"
+            "ORDER_CANCEL"
+        ),
+        "id": str(int(last_transaction_id) + 1),
     }
 
     logger.info(f"Making API request to URL: {base_url} with params: {params}")

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -124,10 +124,12 @@ class OrderManager:
         }
         if tp_price and sl_price:
             payload["order"]["takeProfitOnFill"] = {
-                "price": format_price(instrument, tp_price)
+                "price": format_price(instrument, tp_price),
+                "timeInForce": "GTC",
             }
             payload["order"]["stopLossOnFill"] = {
-                "price": format_price(instrument, sl_price)
+                "price": format_price(instrument, sl_price),
+                "timeInForce": "GTC",
             }
 
         url = f"{OANDA_API_URL}/accounts/{OANDA_ACCOUNT_ID}/orders"
@@ -537,10 +539,12 @@ class OrderManager:
                 sl_price = entry_price + float(sl_pips) * pip
 
             order_body["order"]["takeProfitOnFill"] = {
-                "price": format_price(instrument, tp_price)
+                "price": format_price(instrument, tp_price),
+                "timeInForce": "GTC",
             }
             order_body["order"]["stopLossOnFill"] = {
-                "price": format_price(instrument, sl_price)
+                "price": format_price(instrument, sl_price),
+                "timeInForce": "GTC",
             }
 
         response = requests.post(url, json=order_body, headers=HEADERS)


### PR DESCRIPTION
## Summary
- send take-profit and stop-loss orders with `timeInForce: GTC`
- monitor rejected/cancelled OANDA transactions

## Testing
- `pytest -q` *(fails: 165 failed, 85 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68483dd93b5c83338074db1939f0bc45