### PR TITLE
Enable dynamic scalp TP/SL

### DIFF
--- a/tests/test_scalp_manager_dynamic_tp.py
+++ b/tests/test_scalp_manager_dynamic_tp.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+import types
+
+import execution.scalp_manager as sm
+
+class DummyOM:
+    def __init__(self):
+        self.params = None
+
+    def place_market_with_tp_sl(self, instrument, units, side, tp_pips, sl_pips, comment_json=None):
+        self.params = {
+            "tp": tp_pips,
+            "sl": sl_pips,
+        }
+        return {"lastTransactionID": "t1", "orderFillTransaction": {"price": "1"}}
+
+    def close_position(self, *a, **k):
+        return None
+
+class FakeSeries:
+    def __init__(self, val):
+        class _IL:
+            def __getitem__(self, idx):
+                return val
+        self.iloc = _IL()
+        self._val = val
+
+    def __getitem__(self, idx):
+        return self._val
+
+
+def test_dynamic_tp_sl(monkeypatch):
+    importlib.reload(sm)
+    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
+    sm.order_mgr = sm.OrderManager()
+
+    fetch_mod = types.SimpleNamespace(fetch_candles=lambda *a, **k: [{}] * 30)
+    ind_mod = types.SimpleNamespace(calculate_indicators=lambda *a, **k: {"atr": FakeSeries(0.04)})
+    scalp_mod = types.SimpleNamespace(get_scalp_plan=lambda *a, **k: {"tp_pips": 2.0, "sl_pips": 1.0})
+
+    sys.modules["backend.market_data.candle_fetcher"] = fetch_mod
+    sys.modules["backend.indicators.calculate_indicators"] = ind_mod
+    sys.modules["backend.strategy.openai_scalp_analysis"] = scalp_mod
+
+    sm.enter_scalp_trade("USD_JPY", "long")
+    assert sm.order_mgr.params["tp"] == 2.0
+    assert sm.order_mgr.params["sl"] == 1.0


### PR DESCRIPTION
## Summary
- compute take-profit and stop-loss for `enter_scalp_trade` using OpenAI scalp plan
- fall back to ATR-based multipliers when no AI values are available
- add regression test for dynamic TP/SL handling

## Testing
- `pytest tests/test_scalp_manager.py::test_auto_exit_on_timeout tests/test_scalp_manager_dynamic_tp.py::test_dynamic_tp_sl -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6848413edd8c83338e088ce12b92ba86