### PR TITLE
Improve TP/SL debug logging

### DIFF
--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -97,6 +97,10 @@ def update_oanda_trades():
 
         updated_count = 0
         for transaction in transactions:
+            if transaction.get("type", "").endswith("_REJECT"):
+                logger.warning(
+                    f"\u274c {transaction['type']} reason={transaction.get('rejectReason')}"
+                )
             transaction_type = transaction['type']
             transaction_id = transaction.get('id')
             open_time = transaction.get('time', '')

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -255,6 +255,9 @@ class OrderManager:
         sl_price = (
             price - sl_pips * pip if side == "long" else price + sl_pips * pip
         )
+        logger.debug(
+            f"\u25b6\u25b6\u25b6 PLACE_MARKET_WITH_TPSL trade_id={trade_id} tp={tp_price} sl={sl_price}"
+        )
         self.adjust_tp_sl(instrument, trade_id, new_tp=tp_price, new_sl=sl_price)
         return res
 
@@ -282,6 +285,9 @@ class OrderManager:
             }
             if entry_uuid:
                 tp_payload["order"]["clientExtensions"] = {"comment": entry_uuid}
+            logger.debug(
+                f"\u25b6\u25b6\u25b6 ADJUST_TP_SL TP payload: {tp_payload}"
+            )
 
         if new_tp is not None:
             for attempt in range(3):
@@ -313,6 +319,9 @@ class OrderManager:
                     "timeInForce": "GTC",
                 }
             }
+            logger.debug(
+                f"\u25b6\u25b6\u25b6 ADJUST_TP_SL SL payload: {sl_payload}"
+            )
             for attempt in range(3):
                 resp = requests.post(url, json=sl_payload, headers=HEADERS)
                 if resp.status_code == 201:


### PR DESCRIPTION
## Summary
- log TP/SL request payloads for market orders
- show rejection reasons in transaction polling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install .` *(fails: No matching distribution found for torch==2.3.0+cpu)*

------
https://chatgpt.com/codex/tasks/task_e_684844ae80e8833389e11b0627a25ac5