### PR TITLE
Add extra debug logging for orders and rejections

### DIFF
--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -97,11 +97,16 @@ def update_oanda_trades():
 
         updated_count = 0
         for transaction in transactions:
-            if transaction.get("type", "").endswith("_REJECT"):
+            tx_type = transaction.get("type", "")
+            if tx_type.endswith("_REJECT"):
                 logger.warning(
-                    f"\u274c {transaction['type']} reason={transaction.get('rejectReason')}"
+                    f"\u274c {tx_type} reason={transaction.get('rejectReason')}"
                 )
-            transaction_type = transaction['type']
+            if tx_type in ("TAKE_PROFIT_ORDER_REJECT", "ORDER_CANCEL"):
+                logger.warning(
+                    f"[DEBUG] {tx_type} rejectReason={transaction.get('rejectReason')}"
+                )
+            transaction_type = tx_type
             transaction_id = transaction.get('id')
             open_time = transaction.get('time', '')
 

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -219,6 +219,7 @@ class OrderManager:
         if comment_json:
             order["clientExtensions"]["comment"] = comment_json
         data = {"order": order}
+        logger.debug(f"[DEBUG] place_market_order body: {data}")
         response = _SESSION.post(url, json=data, headers=HEADERS)
         logger.debug(f"Market order response: {response.status_code} {response.text}")
         if response.status_code != 201:


### PR DESCRIPTION
## Summary
- log market order request body for debugging
- expose rejectReason for TAKE_PROFIT_ORDER_REJECT and ORDER_CANCEL in trade updater

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6848472775388333ae97b3253ef89463