### PR TITLE
Fix trade ID usage for TP/SL reattach

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -245,7 +245,11 @@ class OrderManager:
         res = self.place_market_order(
             instrument, units, comment_json=comment_json
         )
-        trade_id = res.get("lastTransactionID")
+        trade_id = (
+            res.get("orderFillTransaction", {})
+            .get("tradeOpened", {})
+            .get("tradeID")
+        )
         if not trade_id:
             return res
         price = float(res.get("orderFillTransaction", {}).get("price", 0.0))

--- a/execution/scalp_manager.py
+++ b/execution/scalp_manager.py
@@ -81,7 +81,11 @@ def enter_scalp_trade(instrument: str, side: str = "long") -> None:
         sl_pips=sl_pips,
         comment_json=json.dumps({"mode": "scalp"}),
     )
-    trade_id = res.get("lastTransactionID")
+    trade_id = (
+        res.get("orderFillTransaction", {})
+        .get("tradeOpened", {})
+        .get("tradeID")
+    )
     if trade_id:
         _open_scalp_trades[trade_id] = time.time()
         # TP が付いているか確認し、無ければ再設定する

--- a/tests/test_scalp_manager_dynamic_tp.py
+++ b/tests/test_scalp_manager_dynamic_tp.py
@@ -13,7 +13,13 @@ class DummyOM:
             "tp": tp_pips,
             "sl": sl_pips,
         }
-        return {"lastTransactionID": "t1", "orderFillTransaction": {"price": "1"}}
+        return {
+            "lastTransactionID": "t1",
+            "orderFillTransaction": {
+                "price": "1",
+                "tradeOpened": {"tradeID": "t1"},
+            },
+        }
 
     def close_position(self, *a, **k):
         return None


### PR DESCRIPTION
## Summary
- correct trade ID source when attaching TP/SL after order fill
- reattach logic reads `tradeOpened.tradeID`
- update unit test dummy response to include trade ID

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_68484a96bbf08333ae4c7efbb91deff9