### PR TITLE
Modify adjust_tp_sl to use update_trade_sl

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -316,30 +316,12 @@ class OrderManager:
                 time.sleep(1)
 
         if new_sl is not None:
-            sl_payload = {
-                "order": {
-                    "type": "STOP_LOSS",
-                    "tradeID": trade_id,
-                    "price": format_price(instrument, new_sl),
-                    "timeInForce": "GTC",
-                }
-            }
             logger.debug(
-                f"\u25b6\u25b6\u25b6 ADJUST_TP_SL SL payload: {sl_payload}"
+                f"\u25b6\u25b6\u25b6 ADJUST_TP_SL calling update_trade_sl: {trade_id} -> {new_sl}"
             )
-            for attempt in range(3):
-                resp = requests.post(url, json=sl_payload, headers=HEADERS)
-                if resp.status_code == 201:
-                    results["sl"] = resp.json()
-                    break
-                if attempt == 2:
-                    code, msg = _extract_error_details(resp)
-                    log_error(
-                        "order_manager",
-                        f"SL adjustment failed: {code} {msg}",
-                        resp.text,
-                    )
-                time.sleep(1)
+            sl_result = self.update_trade_sl(trade_id, instrument, new_sl)
+            if sl_result is not None:
+                results["sl"] = sl_result
 
         return results if results else None
 

--- a/backend/tests/test_update_trade_sl.py
+++ b/backend/tests/test_update_trade_sl.py
@@ -36,6 +36,7 @@ class TestUpdateTradeSL(unittest.TestCase):
             return DummyResponse(status_code=200, json_data={"ok": True})
         req.post = lambda *a, **k: DummyResponse()
         req.put = put
+        req.Session = lambda: types.SimpleNamespace()
         req.get = lambda *a, **k: DummyResponse()
         add("requests", req)
 
@@ -46,6 +47,7 @@ class TestUpdateTradeSL(unittest.TestCase):
         def log_error(module, code, message=None):
             self.log_calls.append((code, message))
         log_stub.log_error = log_error
+        log_stub.log_policy_transition = lambda *a, **k: None
         add("backend.logs.log_manager", log_stub)
 
         os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")


### PR DESCRIPTION
## Summary
- refactor SL adjustment logic in `OrderManager.adjust_tp_sl`
- update `test_adjust_tp_sl` to check SL update behavior
- ensure request stubs provide `Session` and RL logging stubbed out

## Testing
- `pytest -q backend/tests/test_adjust_tp_sl.py backend/tests/test_update_trade_sl.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ab6ffd9c83338a9ba44cf025486b