### PR TITLE
Fix README and CI install step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
           pip install pytest
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -746,8 +746,13 @@ virtual environment and execute:
 pytest
 ```
 
-Ensure all dependencies from `backend/requirements.txt` are installed before
-running tests.
+Ensure all dependencies from `backend/requirements.txt` are installed before running tests.
+
+You can install them with:
+
+```bash
+pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
+```
 
 This will run all tests defined in the project to verify core modules and
 configuration loaders.


### PR DESCRIPTION
## Summary
- add explicit `pip install` command in README
- install dependencies from backend requirements in CI

## Testing
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt`
- `pytest -q` *(fails: ImportError: ...)*)

------
https://chatgpt.com/codex/tasks/task_e_6848ab71e2dc8333af18ba45330740da