### PR TITLE
Adjust scalp stop-loss sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ TRADES_DB_PATH=trades-002.db
 `AI_PROFIT_TRIGGER_RATIO` defines what portion of the take-profit target must
 be reached before an AI exit check occurs. The default value is `0.5` (50%).
 `SCALE_LOT_SIZE` sets how many lots are added when the AI exit decision is `SCALE`.
-`MIN_SL_PIPS` enforces a minimum stop-loss size. If the AI suggests a smaller value the system uses this floor instead (default `8`). OpenAI プラン生成時にもこの値を下回らないよう補正し、ATR と直近スイング幅から算出される動的下限も適用される。
+`MIN_SL_PIPS` enforces a minimum stop-loss size. If the AI suggests a smaller value the system uses this floor instead (default `8`). OpenAI プラン生成時にもこの値を下回らないよう補正し、ATR と直近スイング幅から算出される動的下限も適用される。またスキャルピングモードでもこの下限が尊重されるようになった。
 `SL_COOLDOWN_SEC` is the waiting period after a stop-loss exit before another entry in the same direction is allowed. Default is `300` seconds.
 `AI_COOLDOWN_SEC_OPEN` sets the minimum interval in seconds between AI calls while a position is open.
 `AI_COOLDOWN_SEC_FLAT` defines the cooldown when no position is held.

--- a/execution/scalp_manager.py
+++ b/execution/scalp_manager.py
@@ -72,6 +72,13 @@ def enter_scalp_trade(instrument: str, side: str = "long") -> None:
     if sl_pips is None:
         sl_pips = SCALP_SL_PIPS
 
+    min_sl = float(os.getenv("MIN_SL_PIPS", "0"))
+    dyn_min = 0.0
+    if atr_pips is not None:
+        mult = float(os.getenv("ATR_SL_MULTIPLIER", "2.0"))
+        dyn_min = atr_pips * mult
+    sl_pips = max(sl_pips, min_sl, dyn_min)
+
     units = SCALP_UNIT_SIZE if side == "long" else -SCALP_UNIT_SIZE
     res = order_mgr.place_market_with_tp_sl(
         instrument,

--- a/tests/test_scalp_manager_dynamic_tp.py
+++ b/tests/test_scalp_manager_dynamic_tp.py
@@ -1,6 +1,9 @@
 import importlib
 import sys
 import types
+import os
+os.environ.setdefault("OANDA_API_KEY", "x")
+os.environ.setdefault("OANDA_ACCOUNT_ID", "x")
 
 import execution.scalp_manager as sm
 
@@ -49,6 +52,9 @@ def test_dynamic_tp_sl(monkeypatch):
     sys.modules["backend.indicators.calculate_indicators"] = ind_mod
     sys.modules["backend.strategy.openai_scalp_analysis"] = scalp_mod
 
+    monkeypatch.setenv("MIN_SL_PIPS", "5")
+    monkeypatch.setenv("ATR_SL_MULTIPLIER", "0")
+
     sm.enter_scalp_trade("USD_JPY", "long")
     assert sm.order_mgr.params["tp"] == 2.0
-    assert sm.order_mgr.params["sl"] == 1.0
+    assert sm.order_mgr.params["sl"] == 5.0


### PR DESCRIPTION
## Summary
- enforce MIN_SL_PIPS in scalp_manager and account for ATR based floor
- reflect new behaviour in tests
- mention that scalping also respects MIN_SL_PIPS in docs

## Testing
- `pytest tests/test_scalp_manager.py tests/test_scalp_manager_dynamic_tp.py -q`
- `pytest tests/test_scalp_manager_dynamic_tp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848adc736d88333a9d4e40f92b9b71b