### PR TITLE
Fix composite scoring tests

### DIFF
--- a/tests/test_composite_scoring.py
+++ b/tests/test_composite_scoring.py
@@ -17,8 +17,6 @@ def test_mode_scores_trend(monkeypatch):
     monkeypatch.setenv("MODE_VOL_MA_MIN", "80")
     monkeypatch.setenv("MODE_VOL_RATIO_MIN", "1")
     monkeypatch.setenv("MODE_VOL_RATIO_STRONG", "2")
-    monkeypatch.setenv("MODE_EMA_DIFF_MIN", "0.1")
-    monkeypatch.setenv("MODE_EMA_DIFF_STRONG", "0.3")
     monkeypatch.setenv("MODE_ATR_PIPS_MIN", "5")
     monkeypatch.setenv("MODE_BONUS_START_JST", "0")
     monkeypatch.setenv("MODE_BONUS_END_JST", "0")
@@ -34,12 +32,8 @@ def test_mode_scores_trend(monkeypatch):
         "volume": [200, 200, 200, 200, 200],
     }
     mode, score, _ = cm.decide_trade_mode_detail(inds)
-
     assert mode == "strong_trend"
     assert score > 0.9
-
-    assert mode == "trend_follow"
-    assert score >= 0.8
 
 
 def test_mode_scores_scalp(monkeypatch):
@@ -48,8 +42,6 @@ def test_mode_scores_scalp(monkeypatch):
     monkeypatch.setenv("MODE_EMA_SLOPE_MIN", "0.1")
     monkeypatch.setenv("MODE_VOL_MA_MIN", "80")
     monkeypatch.setenv("MODE_ATR_PIPS_MIN", "5")
-    monkeypatch.setenv("MODE_EMA_DIFF_MIN", "0.1")
-    monkeypatch.setenv("MODE_EMA_DIFF_STRONG", "0.3")
     monkeypatch.setenv("MODE_BONUS_START_JST", "0")
     monkeypatch.setenv("MODE_BONUS_END_JST", "0")
     monkeypatch.setenv("MODE_PENALTY_START_JST", "0")
@@ -69,8 +61,6 @@ def test_mode_scores_scalp(monkeypatch):
 
 
 def test_mode_scores_strong_trend(monkeypatch):
-def test_trend_follow_with_large_ema_diff(monkeypatch):
-
     monkeypatch.setenv("MODE_ADX_MIN", "25")
     monkeypatch.setenv("MODE_ADX_STRONG", "40")
     monkeypatch.setenv("MODE_DI_DIFF_MIN", "10")
@@ -82,9 +72,6 @@ def test_trend_follow_with_large_ema_diff(monkeypatch):
     monkeypatch.setenv("MODE_VOL_RATIO_STRONG", "2")
     monkeypatch.setenv("MODE_ATR_PIPS_MIN", "5")
     monkeypatch.setenv("MODE_STRONG_TREND_THRESH", "0.9")
-    monkeypatch.setenv("MODE_EMA_DIFF_MIN", "0.2")
-    monkeypatch.setenv("MODE_EMA_DIFF_STRONG", "0.5")
-    monkeypatch.setenv("MODE_ATR_PIPS_MIN", "5")
     monkeypatch.setenv("MODE_BONUS_START_JST", "0")
     monkeypatch.setenv("MODE_BONUS_END_JST", "0")
     monkeypatch.setenv("MODE_PENALTY_START_JST", "0")
@@ -101,14 +88,3 @@ def test_trend_follow_with_large_ema_diff(monkeypatch):
     mode, score, _ = cm.decide_trade_mode_detail(inds)
     assert mode == "strong_trend"
     assert score >= 0.9
-        "adx": [15],
-        "plus_di": [55],
-        "minus_di": [5],
-        "ema_slope": [0.05],
-        "ema14": [100, 101],
-        "ema50": [100, 100.2],
-        "volume": [200, 200, 200, 200, 200],
-    }
-    mode, score, _ = cm.decide_trade_mode_detail(inds)
-    assert mode == "trend_follow"
-


### PR DESCRIPTION
## Summary
- resolve merge leftovers in `tests/test_composite_scoring.py`
- keep tests for trend, scalp and strong trend modes

## Testing
- `pytest tests/test_composite_scoring.py -vv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6848b23695e083338268eaf5ee75dee5