### PR TITLE
Implement restart rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ YAML ファイルの変更は `settings.env` と同様、ジョブランナー�
 
 ジョブランナーは ADX の値からスキャルプかトレンドフォローかを判断し、モードが
 切り替わった際に `config/<mode>.yml` を自動で再読み込みします。環境変数
-`AUTO_RESTART=true` を設定しておくと、読み込み後にプロセスを `os.execv()` で
-再起動して設定を完全に反映させることも可能です。
+`AUTO_RESTART=true` を設定すると、読み込み後にプロセスを `os.execv()` で
+再起動します。このとき `RESTART_MIN_INTERVAL` で最小再起動間隔を指定可能です。
 
 ### Switching OANDA accounts
 

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -222,6 +222,9 @@ SCALE_TRIGGER_ATR=0.5
 ■ OANDA_MATCH_SEC
   ローカルトレードと OANDA 取引を照合するときの許容秒数。デフォルトは60秒。
 
+■ RESTART_MIN_INTERVAL
+  AUTO_RESTART が有効な場合に、プロセス再起動を行う最小間隔(秒)。
+
 
 ## 追加環境変数
 - USE_LOCAL_MODEL: OpenAI APIの代わりにローカルモデルを使用するか (true/false)

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -260,6 +260,7 @@ ADX_TREND_MIN=30                 # トレンド移行に必要なADX
 SCALP_OVERRIDE_RANGE=false
 
 AUTO_RESTART=true
+RESTART_MIN_INTERVAL=60      # 最小再起動間隔(秒)
 # === Trade mode matrix ===
 ATR_HIGH_RATIO=1.4
 ATR_LOW_RATIO=0.8

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -5,6 +5,8 @@ import logging
 import json
 import os
 import sys
+
+_LAST_RESTART: float = 0.0
 try:
     from prometheus_client import start_http_server
 except Exception:  # pragma: no cover - optional dependency or test stub
@@ -488,10 +490,20 @@ class JobRunner:
             logger.error("Param reload failed: %s", exc)
             return
         if os.getenv("AUTO_RESTART", "false").lower() == "true":
-            logger.info("AUTO_RESTART enabled – restarting process")
-            python = sys.executable
-            # preserve module-based execution to keep import paths intact
-            os.execv(python, [python, "-m", "backend.scheduler.job_runner", *sys.argv[1:]])
+            interval = float(os.getenv("RESTART_MIN_INTERVAL", "60"))
+            now = time.time()
+            global _LAST_RESTART
+            if now - _LAST_RESTART >= interval:
+                logger.info("AUTO_RESTART enabled – restarting process")
+                _LAST_RESTART = now
+                python = sys.executable
+                # preserve module-based execution to keep import paths intact
+                os.execv(
+                    python,
+                    [python, "-m", "backend.scheduler.job_runner", *sys.argv[1:]],
+                )
+            else:
+                logger.info("Restart suppressed to avoid rapid restarts")
 
     def _record_strategy_result(self, reward: float) -> None:
         if self.last_entry_context and self.last_entry_strategy:


### PR DESCRIPTION
## Summary
- prevent rapid process restarts by introducing `RESTART_MIN_INTERVAL`
- document new environment variable
- update README on restart behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6848b80242788333ba3d84e186b757f2