### PR TITLE
Add dev requirements and mention in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
    python3 -m venv .venv
    source .venv/bin/activate
    pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
+   pip install -r requirements-dev.txt
    ```
 
    The indicator modules require **pandas**. If it is not installed, add it with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+mabwiser
+scikit-learn


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` with packages for testing
- update setup instructions in README to install dev requirements

## Testing
- `pip install -r requirements-dev.txt`
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt`
- `pytest -q` *(fails: ImportError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6848c01f86b8833399ec050cc7773c9d