### PR TITLE
Improve auto-restart throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ YAML ファイルの変更は `settings.env` と同様、ジョブランナー�
 切り替わった際に `config/<mode>.yml` を自動で再読み込みします。環境変数
 `AUTO_RESTART=true` を設定すると、読み込み後にプロセスを `os.execv()` で
 再起動します。このとき `RESTART_MIN_INTERVAL` で最小再起動間隔を指定可能です。
+`RESTART_STATE_PATH` でタイムスタンプを書き込むファイルを指定すると、連続再起動を
+防ぎます。
 
 ### Switching OANDA accounts
 

--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -238,3 +238,4 @@ SCALE_TRIGGER_ATR=0.5
 - ERROR_LIMIT: 許容エラー回数の上限
 - USE_OFFLINE_POLICY: オフライン学習ポリシーを利用するか (true/false)
 - PATTERN_TFS: パターン検出を行う時間足一覧 (例: M5,M15)
+- RESTART_STATE_PATH: 最終再起動時刻を保存するファイルパス (デフォルト /tmp/piphawk_last_restart)

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,3 +1,4 @@
 from .ai_parse import parse_json_answer
 
 from .trade_time import trade_age_seconds
+from .restart_guard import can_restart

--- a/backend/utils/restart_guard.py
+++ b/backend/utils/restart_guard.py
@@ -1,0 +1,26 @@
+"""Restart guard to prevent excessive self-restarts."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+import logging
+
+from . import env_loader
+
+_STATE_PATH = Path(env_loader.get_env("RESTART_STATE_PATH", "/tmp/piphawk_last_restart"))
+
+
+def can_restart(interval: float) -> bool:
+    """Return True if enough time has passed since the last restart."""
+    now = time.time()
+    try:
+        last = float(_STATE_PATH.read_text())
+    except Exception:
+        last = 0.0
+    if now - last >= interval:
+        try:
+            _STATE_PATH.write_text(str(now))
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.getLogger(__name__).warning("Failed to record restart time: %s", exc)
+        return True
+    return False

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -6,7 +6,6 @@ import json
 import os
 import sys
 
-_LAST_RESTART: float = 0.0
 try:
     from prometheus_client import start_http_server
 except Exception:  # pragma: no cover - optional dependency or test stub
@@ -14,6 +13,7 @@ except Exception:  # pragma: no cover - optional dependency or test stub
         return None
 
 from backend.utils import env_loader, trade_age_seconds
+from backend.utils.restart_guard import can_restart
 
 try:
     from config import params_loader
@@ -491,13 +491,9 @@ class JobRunner:
             return
         if os.getenv("AUTO_RESTART", "false").lower() == "true":
             interval = float(os.getenv("RESTART_MIN_INTERVAL", "60"))
-            now = time.time()
-            global _LAST_RESTART
-            if now - _LAST_RESTART >= interval:
+            if can_restart(interval):
                 logger.info("AUTO_RESTART enabled – restarting process")
-                _LAST_RESTART = now
                 python = sys.executable
-                # preserve module-based execution to keep import paths intact
                 os.execv(
                     python,
                     [python, "-m", "backend.scheduler.job_runner", *sys.argv[1:]],


### PR DESCRIPTION
## Summary
- add `restart_guard.can_restart` to persist last restart time
- use restart guard in job runner and core
- document `RESTART_STATE_PATH` env var

## Testing
- `pytest -q` *(fails: module import errors and attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848c0617ee08333990bedc405f75ef7