### PR TITLE
Fix CI deps for CPU PyTorch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,9 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install -r backend/requirements.txt
+          pip install --upgrade pip
+          # PyTorch の CPU ホイールを取得するために専用インデックスを追加
+          pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
           pytest -q
 
   build-and-push:


### PR DESCRIPTION
## Summary
- update CI to install pip first
- add PyTorch CPU index when installing requirements

## Testing
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt`
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848c1a0ab7c8333bdd23ac100d78566