### PR TITLE
Fix probability normalization and DB rowcount logging

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1363,7 +1363,17 @@ Respond with **one-line valid JSON** exactly as:
             risk["sl_prob"] = q
             total = p + q
             if total > 1.0 + PROB_MARGIN or total < 1.0 - PROB_MARGIN:
-                logger.warning("Probabilities invalid — skipping plan")
+                logger.warning("Probabilities invalid — adjusting")
+                if total > 0:
+                    p /= total
+                    q /= total
+                else:
+                    p, q = 0.6, 0.4
+                risk["tp_prob"] = p
+                risk["sl_prob"] = q
+                total = p + q
+            if total > 1.0 + PROB_MARGIN or total < 1.0 - PROB_MARGIN:
+                logger.warning("Probabilities still invalid — skipping plan")
                 logger.info("Plan with invalid probabilities: %s", json.dumps(plan, ensure_ascii=False))
                 plan["entry"]["side"] = "no"
                 plan["reason"] = "PROB_INVALID"


### PR DESCRIPTION
## Summary
- adjust AI probability normalization to avoid invalid plans
- compute rowcount using connection changes in OANDA trade updater

## Testing
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848c39e1cb483338d9af0cacc7631f2