### PR TITLE
Fix CI dependencies and disable auto restart in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
-          pip install pytest
+          pip install -r backend/requirements-dev.txt
       - name: Run tests
         run: pytest -q

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,4 @@
+fastapi>=0.95.0
+httpx
+pytest
+pytest-asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import pytest
+
+@pytest.fixture(autouse=True, scope="session")
+def set_auto_restart_false():
+    os.environ["AUTO_RESTART"] = "false"


### PR DESCRIPTION
## Summary
- add `backend/requirements-dev.txt` for test dependencies
- update workflow to install new dev requirements
- disable AUTO_RESTART during testing

## Testing
- `pytest backend/api/test_control_endpoints.py::test_scheduler_control -q`
- `pytest backend/api/test_recent_trades.py::test_get_recent_trades -q`


------
https://chatgpt.com/codex/tasks/task_e_6848c77587b08333b7d1a87163b3a7f4