### PR TITLE
Implement sync_state table for transaction tracking

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -177,6 +177,13 @@ def init_db():
             )
         ''')
 
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS sync_state (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            )
+        ''')
+
 def log_trade(
     instrument,
     entry_time,


### PR DESCRIPTION
## Summary
- add `sync_state` table creation in `log_manager`
- track last transaction ID in `update_oanda_trades`
- persist largest processed ID after each sync

## Testing
- `python -m py_compile backend/logs/log_manager.py backend/logs/update_oanda_trades.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6848d4ded7a08333805a8d34af0c277d