### PR TITLE
Add tests for format_price rounding

### DIFF
--- a/tests/test_format_price.py
+++ b/tests/test_format_price.py
@@ -1,0 +1,10 @@
+import pytest
+from backend.utils.price import format_price
+
+
+def test_jpy_pair_rounding():
+    assert format_price("USD_JPY", 143.2509) == "143.251"
+
+
+def test_non_jpy_pair_rounding():
+    assert format_price("EUR_USD", 1.234567) == "1.23457"


### PR DESCRIPTION
## Summary
- verify rounding for JPY and non-JPY pairs in new tests

## Testing
- `pytest tests/test_format_price.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848df3121a08333bbb8744512368547