### PR TITLE
Add CORS origin env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 - `HTF_SLOPE_MIN` … 上位足 EMA 傾きチェック用のしきい値
 - `AI_MODEL` … OpenAI モデル名
 - `LINE_CHANNEL_TOKEN` / `LINE_USER_ID` … LINE 通知に使用する認証情報
+- `CORS_ALLOW_ORIGINS` … CORSで許可するオリジンをカンマ区切りで指定。
+
+例:
+
+```bash
+CORS_ALLOW_ORIGINS=http://localhost:3000
+```
 
 その他の変数は `backend/config/ENV_README.txt` を参照してください。
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -39,11 +39,16 @@ def metrics() -> Response:
 
 
 # --- CORS ---
-# Allow requests from any origin (frontend dev & Cloud Run UI).
-# Adjust `allow_origins` to a specific list when moving to production.
+# CORS許可オリジンを環境変数から読み込む。未設定時は全て許可。
+cors_origins_env = env_loader.get_env("CORS_ALLOW_ORIGINS")
+allow_origins = (
+    [o.strip() for o in cors_origins_env.split(",")]
+    if cors_origins_env
+    else ["*"]
+)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- let CORS origins be set via `CORS_ALLOW_ORIGINS`
- document the variable in README

## Testing
- `pytest backend/api/test_recent_trades.py backend/api/test_panic_stop.py backend/api/test_control_endpoints.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848df1c0d148333b24095c6a067da32