### PR TITLE
Improve AI entry frequency

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,7 +12,7 @@ CLEANUP_THRESHOLD=80
 
 # Example environment variables
 # Copy this file to .env and adjust as needed
-COMPOSITE_MIN=0.7
+COMPOSITE_MIN=0.2
 SCALP_OVERRIDE_RANGE=
 
 # Trade mode thresholds

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -53,7 +53,7 @@ BE_TRIGGER_R: float = float(env_loader.get_env("BE_TRIGGER_R", "0"))
 AI_LIMIT_CONVERT_MODEL: str = env_loader.get_env("AI_LIMIT_CONVERT_MODEL", "gpt-4.1-nano")
 MIN_RRR: float = float(env_loader.get_env("MIN_RRR", "0.8"))
 # --- Composite score threshold ---
-COMPOSITE_MIN: float = float(env_loader.get_env("COMPOSITE_MIN", "1.0"))
+COMPOSITE_MIN: float = float(env_loader.get_env("COMPOSITE_MIN", "0.2"))
 # --- Exit bias factor ---
 EXIT_BIAS_FACTOR: float = float(env_loader.get_env("EXIT_BIAS_FACTOR", "1.0"))
 

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -295,7 +295,7 @@ Pivot: {ind_m5.get('pivot')}, R1: {ind_m5.get('pivot_r1')}, S1: {ind_m5.get('piv
 Your task:
 1. Clearly classify the current regime as "trend" or "range". If "trend", specify direction as "long" or "short". Output this at JSON key "regime".
 2. Decide whether to open a trade now, strictly adhering to the above criteria. Return JSON key "entry" with: {{ "side":"long"|"short"|"no", "rationale":"…" }}. Also include numeric key "entry_confidence" between 0 and 1 representing your confidence. Additionally return key "probs" as {{"long":float,"short":float,"no":float}} where all values sum to 1.
-3. If side is not "no", propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included. Use decimals for all probability values.
+3. If side is not "no", propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included. Use decimals for all probability values. When you output side "long" or "short", the risk object must contain both "tp_pips" and "sl_pips" or the trade will be skipped.
    - Constraints:
     • tp_prob must be ≥ {MIN_TP_PROB:.2f}
     • Expected value (tp_pips*tp_prob - sl_pips*sl_prob) must be positive

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -168,7 +168,7 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 - MIN_VOL_MA / MIN_VOL_M1: ボリュームフィルタの最小値
 - ADX_SLOPE_LOOKBACK: ADX の傾き計算に使う本数
 - ADX_DYNAMIC_COEFF: BB 幅によって ADX しきい値を補正する係数
-- COMPOSITE_MIN: ADXとBB幅から算出するComposite Trend Scoreのしきい値
+- COMPOSITE_MIN: ADXとBB幅から算出するComposite Trend Scoreのしきい値。デフォルトは`0.2`で、値を下げるとエントリー判定が緩くなる。
 - MODE_ATR_PIPS_MIN / MODE_BBWIDTH_PIPS_MIN: トレードモード判定に使うボラティリティ基準
 - MODE_EMA_SLOPE_MIN / MODE_ADX_MIN: モメンタム判定のしきい値
 - MODE_VOL_MA_MIN: 流動性判定に使う出来高平均


### PR DESCRIPTION
## Summary
- lower COMPOSITE_MIN default to 0.2
- clarify risk requirement in AI prompt
- update environment template and docs for new default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6848e66b71cc8333a2ad3b2087717016