### PR TITLE
Add MIN_NET_TP_PIPS env var doc and unify defaults

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -47,7 +47,7 @@ TP_PROB_HOURS: int = int(env_loader.get_env("TP_PROB_HOURS", "24"))
 PROB_MARGIN: float = float(env_loader.get_env("PROB_MARGIN", "0.1"))
 LIMIT_THRESHOLD_ATR_RATIO: float = float(env_loader.get_env("LIMIT_THRESHOLD_ATR_RATIO", "0.3"))
 MAX_LIMIT_AGE_SEC: int = int(env_loader.get_env("MAX_LIMIT_AGE_SEC", "180"))
-MIN_NET_TP_PIPS: float = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))
+MIN_NET_TP_PIPS: float = float(env_loader.get_env("MIN_NET_TP_PIPS", "1"))
 BE_TRIGGER_PIPS: int = int(env_loader.get_env("BE_TRIGGER_PIPS", 10))
 BE_TRIGGER_R: float = float(env_loader.get_env("BE_TRIGGER_R", "0"))
 AI_LIMIT_CONVERT_MODEL: str = env_loader.get_env("AI_LIMIT_CONVERT_MODEL", "gpt-4.1-nano")
@@ -1252,7 +1252,7 @@ Your task:
     • tp_prob must be ≥ {MIN_TP_PROB:.2f}
     • Expected value (tp_pips*tp_prob - sl_pips*sl_prob) must be positive
     • Choose the take-profit level that maximises expected value = probability × pips, subject to RRR ≥ {MIN_RRR}
-    • (tp_pips - spread_pips) must be ≥ {env_loader.get_env("MIN_NET_TP_PIPS","2")} pips
+    • (tp_pips - spread_pips) must be ≥ {env_loader.get_env("MIN_NET_TP_PIPS","1")} pips
     • If constraints are not met, set side to "no".
 
 Respond with **one-line valid JSON** exactly as:

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -10,7 +10,7 @@ from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
 MIN_TP_PROB = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
 TP_PROB_HOURS = int(env_loader.get_env("TP_PROB_HOURS", "24"))
 MIN_RRR = float(env_loader.get_env("MIN_RRR", "0.8"))
-MIN_NET_TP_PIPS = float(env_loader.get_env("MIN_NET_TP_PIPS", "2"))
+MIN_NET_TP_PIPS = float(env_loader.get_env("MIN_NET_TP_PIPS", "1"))
 TREND_ADX_THRESH = float(env_loader.get_env("TREND_ADX_THRESH", "20"))
 TREND_PROMPT_BIAS = env_loader.get_env("TREND_PROMPT_BIAS", "normal").lower()
 # レンジ相場でのトレード方針を任意に追記できる環境変数
@@ -300,7 +300,7 @@ Your task:
     • tp_prob must be ≥ {MIN_TP_PROB:.2f}
     • Expected value (tp_pips*tp_prob - sl_pips*sl_prob) must be positive
     • Choose the take-profit level that maximises expected value = probability × pips, subject to RRR ≥ {MIN_RRR}
-    • (tp_pips - spread_pips) must be ≥ {env_loader.get_env("MIN_NET_TP_PIPS","2") } pips
+    • (tp_pips - spread_pips) must be ≥ {env_loader.get_env("MIN_NET_TP_PIPS","1") } pips
     • If constraints are not met, set side to "no".
 
 Respond with **one-line valid JSON** exactly as:

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -129,6 +129,10 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
   エントリー時に想定するスリッページ幅(pips)。
   MIN_RRR_AFTER_COST の計算に利用される。
 
+### MIN_NET_TP_PIPS
+
+  スプレッド控除後に許容される最小TP幅(pips)。デフォルトは1。
+
 # 以下は README に記載されていた追加の環境変数
 
 - RANGE_CENTER_BLOCK_PCT: ADX が ADX_RANGE_THRESHOLD 以下のとき、BB 中心付近のエントリーをどの程度ブロックするか (0.3 = 30%)


### PR DESCRIPTION
## Summary
- document `MIN_NET_TP_PIPS` in env var docs
- unify default `MIN_NET_TP_PIPS` to 1 across AI analysis modules
- adjust OpenAI prompt messages accordingly

## Testing
- `pytest backend/tests/test_entry_cost_guard.py backend/tests/test_risk_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ea23cda08333903c7e5bb080af75