### PR TITLE
Fix duplicate log patterns in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,8 +176,7 @@ cython_debug/
 .pypirc
 node_modules/
 
+# backendログファイルを無視
 backend/logs/*.db
-backend/logs/*.jsonl
 backend/logs/*.db*
 backend/logs/*.jsonl
-backend/logs/*.db*


### PR DESCRIPTION
## Summary
- deduplicate backend log patterns in `.gitignore`
- clarify that these patterns ignore log files

## Testing
- `pytest -q` *(fails: module import errors and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_6848f0996d30833383f045d38f0314ef