### PR TITLE
Add score_version column with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,9 @@ sqlite3 trades.db "PRAGMA journal_mode=WAL;"
 ```
 
 The table now includes an `ai_response` column which stores the full text returned
-by the AI when opening or closing a trade.
+by the AI when opening or closing a trade. In addition `score_version` records
+the scoring algorithm version used for that trade. Run `init_db()` once to add
+the column to older databases.
 
 If you need a clean database locally, copy the example file if available:
 

--- a/backend/logs/trade_logger.py
+++ b/backend/logs/trade_logger.py
@@ -5,6 +5,7 @@ from typing import Any
 import json
 
 from .log_manager import log_trade as _log_trade, log_policy_transition
+from backend.utils import env_loader
 
 
 class ExitReason(Enum):
@@ -29,6 +30,8 @@ def log_trade(
         kwargs["exit_reason"] = exit_reason.value
     if is_manual is not None:
         kwargs["is_manual"] = is_manual
+    if "score_version" not in kwargs:
+        kwargs["score_version"] = int(env_loader.get_env("SCORE_VERSION", "1"))
     _log_trade(**kwargs)
     if strategy_name and state is not None and reward is not None:
         log_policy_transition(json.dumps(state), strategy_name, float(reward))

--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -66,3 +66,17 @@ ALTER TABLE oanda_trades ADD COLUMN open_price REAL;
 古いデータベースで `price` 列が残っている場合、`init_db()` を実行すると
 `open_price` 列にその値がコピーされます。`price` 列は削除されませんが、
 更新処理で値がセットされるためエラーは発生しなくなります。
+
+## `score_version` 列の追加
+
+`trades` テーブルはスコア計算のバージョン管理用に `score_version` 列を
+持ちます。バージョン 1 以降で初めて導入されたため、既存のデータベース
+ではこの列が存在しません。
+
+以下の SQL か `init_db()` を一度実行して列を追加してください。既存行
+には `1` が自動的に設定されます。
+
+```sql
+ALTER TABLE trades ADD COLUMN score_version INTEGER DEFAULT 1;
+UPDATE trades SET score_version = 1;
+```

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS trades (
     ai_response TEXT,
     entry_regime TEXT,
     exit_reason TEXT,
-    is_manual INTEGER
+    is_manual INTEGER,
+    score_version INTEGER DEFAULT 1
 );
 CREATE TABLE IF NOT EXISTS ai_decisions (
     decision_id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- extend `trades` schema with `score_version`
- save score version in trade logs
- document DB migration for the new column

## Testing
- `pytest -q` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848f70de29c8333acdb157528961b06