### PR TITLE
Normalize weights and add tests

### DIFF
--- a/analysis/signal_filter.py
+++ b/analysis/signal_filter.py
@@ -82,6 +82,13 @@ def is_multi_tf_aligned(
             except ValueError:
                 continue
 
+    total_w = sum(weights.values())
+    if total_w != 0:
+        if abs(total_w - 1.0) > 0.1:
+            logger.warning("TF_EMA_WEIGHTS sum %.2f, normalizing", total_w)
+        for k in list(weights.keys()):
+            weights[k] = weights[k] / total_w
+
     adx_weight = float(env_loader.get_env("ALIGN_ADX_WEIGHT", "0"))
     min_adx = float(env_loader.get_env("MIN_ALIGN_ADX", "20"))
 

--- a/backend/tests/test_tf_weight_normalization.py
+++ b/backend/tests/test_tf_weight_normalization.py
@@ -1,0 +1,45 @@
+import os
+import importlib
+import unittest
+
+
+class FakeSeries:
+    def __init__(self, data=None):
+        self._data = list(data or [])
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+
+class TestTfWeightNormalization(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        os.environ["TF_EMA_WEIGHTS"] = "M5:0.1,M15:0.1,H1:0.1"
+        os.environ["AI_ALIGN_WEIGHT"] = "0"
+        os.environ["ALIGN_BYPASS_ADX"] = "0"
+        import analysis.signal_filter as sf
+        importlib.reload(sf)
+        self.sf = sf
+
+    def tearDown(self):
+        for k in ["TF_EMA_WEIGHTS", "AI_ALIGN_WEIGHT", "ALIGN_BYPASS_ADX"]:
+            os.environ.pop(k, None)
+
+    def test_normalization_changes_result(self):
+        indicators = {
+            "M5": {"ema_fast": FakeSeries([1, 1.1]), "ema_slow": FakeSeries([1, 1])},
+            "M15": {"ema_fast": FakeSeries([1, 1.1]), "ema_slow": FakeSeries([1, 1])},
+            "H1": {"ema_fast": FakeSeries([1, 1.1]), "ema_slow": FakeSeries([1, 1])},
+        }
+        self.assertEqual(self.sf.is_multi_tf_aligned(indicators), "long")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize time-frame EMA weights and warn if off-sum
- normalize OpenAI analysis consistency weights and warn when needed
- ensure invalid weights fall back to defaults
- add tests covering normalization behaviour

## Testing
- `pytest -q backend/tests/test_consistency_weights.py backend/tests/test_tf_weight_normalization.py backend/tests/test_consistency_normalization.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'linebot')*

------
https://chatgpt.com/codex/tasks/task_e_6848f70831c483338ced32e8afff1e39