### PR TITLE
Implement async tick stream with backoff

### DIFF
--- a/backend/market_data/tick_stream.py
+++ b/backend/market_data/tick_stream.py
@@ -6,6 +6,8 @@ import json
 from typing import Iterable, Callable
 
 import requests
+import httpx
+import asyncio
 from backend.utils import env_loader
 
 STREAM_URL = env_loader.get_env("OANDA_STREAM_URL", "https://stream-fxtrade.oanda.com/v3")
@@ -13,8 +15,8 @@ ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
 API_KEY = env_loader.get_env("OANDA_API_KEY")
 
 
-def start_stream(pairs: Iterable[str], callback: Callable[[dict], None]) -> None:
-    """指定ペアのストリームを開始し、各ティックをコールバックへ渡す."""
+def start_stream_sync(pairs: Iterable[str], callback: Callable[[dict], None]) -> None:
+    """同期版ストリーム取得."""
     url = f"{STREAM_URL}/accounts/{ACCOUNT_ID}/pricing/stream"
     headers = {"Authorization": f"Bearer {API_KEY}"}
     params = {"instruments": ",".join(pairs)}
@@ -29,3 +31,28 @@ def start_stream(pairs: Iterable[str], callback: Callable[[dict], None]) -> None
                 except json.JSONDecodeError:
                     continue
                 callback(data)
+
+
+async def start_stream(pairs: Iterable[str], callback: Callable[[dict], None]) -> None:
+    """非同期にティックストリームを取得し、切断時は指数バックオフで再接続する."""
+    url = f"{STREAM_URL}/accounts/{ACCOUNT_ID}/pricing/stream"
+    headers = {"Authorization": f"Bearer {API_KEY}"}
+    params = {"instruments": ",".join(pairs)}
+    backoff = 1
+    while True:
+        try:
+            async with httpx.AsyncClient(timeout=None) as client:
+                async with client.stream("GET", url, headers=headers, params=params) as r:
+                    r.raise_for_status()
+                    async for line in r.aiter_lines():
+                        if not line:
+                            continue
+                        try:
+                            data = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        callback(data)
+            backoff = 1
+        except Exception:
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 60)


### PR DESCRIPTION
## Summary
- add `start_stream_sync` using the original logic
- implement new `start_stream` as async
- reconnect with exponential backoff via `httpx.AsyncClient`

## Testing
- `pip install -r requirements-dev.txt`
- `pip install fastapi openai`
- `pip install apscheduler`
- `pip install line-bot-sdk`
- `pip install prometheus_client`
- `pytest -q` *(fails: ImportError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6848f90a08308333a633e0d6d2a947bf