### PR TITLE
Fix get_market_summary event loop handling

### DIFF
--- a/ai/macro_analyzer.py
+++ b/ai/macro_analyzer.py
@@ -6,7 +6,7 @@ import requests
 from typing import Any
 import httpx
 
-from backend.utils import env_loader
+from backend.utils import env_loader, run_async
 from piphawk_ai.ai.local_model import ask_model, ask_model_async
 from piphawk_ai.ai.prompt_templates import get_template
 
@@ -129,7 +129,7 @@ class MacroAnalyzer:
         if articles:
             try:
                 summary = self.summarize_articles(articles)
-                sentiment = asyncio.run(self.analyze_sentiment_async(summary))
+                sentiment = run_async(self.analyze_sentiment_async(summary))
             except Exception:
                 summary = ""
                 sentiment = None

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -2,3 +2,4 @@ from .ai_parse import parse_json_answer
 
 from .trade_time import trade_age_seconds
 from .restart_guard import can_restart
+from .async_helper import run_async

--- a/backend/utils/async_helper.py
+++ b/backend/utils/async_helper.py
@@ -1,0 +1,20 @@
+import asyncio
+from typing import Any, Coroutine, TypeVar
+
+
+T = TypeVar("T")
+
+
+def run_async(coro: Coroutine[Any, Any, T]) -> T:
+    """非同期関数を同期的に実行するユーティリティ"""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        new_loop = asyncio.new_event_loop()
+        try:
+            task = new_loop.create_task(coro)
+            return new_loop.run_until_complete(task)
+        finally:
+            new_loop.close()


### PR DESCRIPTION
## Summary
- add `run_async` helper to execute async coroutines even when a loop is running
- use `run_async` in `MacroAnalyzer.get_market_summary`

## Testing
- `pytest -q` *(fails: 171 failed, 91 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6848f90c68e88333b95aa35d5fdebe9e