### PR TITLE
Fix CVaR indexing

### DIFF
--- a/risk/cvar.py
+++ b/risk/cvar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """CVaR (Expected Shortfall) 計算ユーティリティ."""
 
 from typing import Sequence
+import math
 
 
 def calc_cvar(returns: Sequence[float], alpha: float = 0.05) -> float:
@@ -12,7 +13,7 @@ def calc_cvar(returns: Sequence[float], alpha: float = 0.05) -> float:
     if not 0 < alpha <= 1:
         raise ValueError("alpha must be in (0,1]")
     sorted_returns = sorted(returns)
-    idx = max(1, int(len(sorted_returns) * alpha))
+    idx = max(1, math.ceil(len(sorted_returns) * alpha))
     tail = sorted_returns[:idx]
     return sum(tail) / len(tail)
 

--- a/tests/test_cvar.py
+++ b/tests/test_cvar.py
@@ -8,6 +8,12 @@ def test_calc_cvar_basic():
     assert result == pytest.approx((-4.0 - 2.0)/2)
 
 
+def test_calc_cvar_rounding():
+    returns = [1.0, -2.0, -1.0, 3.0, -4.0]
+    result = calc_cvar(returns, alpha=0.3)
+    assert result == pytest.approx((-4.0 - 2.0) / 2)
+
+
 def test_calc_cvar_errors():
     with pytest.raises(ValueError):
         calc_cvar([])


### PR DESCRIPTION
## Summary
- update CVaR calculation to use `math.ceil`
- add rounding test for CVaR

## Testing
- `pytest tests/test_cvar.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68490933ff14833382551cb905b133be