### PR TITLE
Add shared HTTP retry helper

### DIFF
--- a/backend/orders/position_manager.py
+++ b/backend/orders/position_manager.py
@@ -1,5 +1,6 @@
 import requests
 from backend.utils import env_loader
+from backend.utils.http_client import request_with_retries
 import logging
 import time
 
@@ -27,40 +28,26 @@ HEADERS = {
 def get_margin_used(retries: int = 2, delay: float = 1.0) -> Optional[float]:
     """Return current marginUsed from account summary."""
     url = f"{OANDA_API_URL}/accounts/{OANDA_ACCOUNT_ID}/summary"
-    for attempt in range(retries + 1):
-        try:
-            response = requests.get(url, headers=HEADERS, timeout=10)
-            response.raise_for_status()
-            account = response.json().get("account", {})
-            return float(account.get("marginUsed", 0.0))
-        except Exception as exc:
-            if attempt < retries:
-                logger.warning(
-                    f"get_margin_used attempt {attempt + 1} failed: {exc}; retrying"
-                )
-                time.sleep(delay)
-            else:
-                logger.warning(f"get_margin_used failed: {exc}")
-    return None
+    try:
+        resp = request_with_retries("get", url, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        account = resp.json().get("account", {})
+        return float(account.get("marginUsed", 0.0))
+    except Exception as exc:
+        logger.warning(f"get_margin_used failed: {exc}")
+        return None
 
 def get_account_balance(retries: int = 2, delay: float = 1.0) -> Optional[float]:
     """Return current account balance."""
     url = f"{OANDA_API_URL}/accounts/{OANDA_ACCOUNT_ID}/summary"
-    for attempt in range(retries + 1):
-        try:
-            response = requests.get(url, headers=HEADERS, timeout=10)
-            response.raise_for_status()
-            account = response.json().get("account", {})
-            return float(account.get("balance", 0.0))
-        except Exception as exc:
-            if attempt < retries:
-                logger.warning(
-                    f"get_account_balance attempt {attempt + 1} failed: {exc}; retrying"
-                )
-                time.sleep(delay)
-            else:
-                logger.warning(f"get_account_balance failed: {exc}")
-    return None
+    try:
+        resp = request_with_retries("get", url, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        account = resp.json().get("account", {})
+        return float(account.get("balance", 0.0))
+    except Exception as exc:
+        logger.warning(f"get_account_balance failed: {exc}")
+        return None
 
 def get_open_positions() -> Optional[List[Dict[str, Any]]]:
     """

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -3,3 +3,4 @@ from .ai_parse import parse_json_answer
 from .trade_time import trade_age_seconds
 from .restart_guard import can_restart
 from .async_helper import run_async
+from .http_client import request_with_retries

--- a/backend/utils/http_client.py
+++ b/backend/utils/http_client.py
@@ -1,0 +1,45 @@
+import os
+import time
+import logging
+import requests
+
+# Global HTTP session to leverage connection pooling
+_SESSION = requests.Session()
+
+# Retry/backoff settings from environment
+HTTP_MAX_RETRIES = int(os.getenv("HTTP_MAX_RETRIES", "3"))
+HTTP_BACKOFF_CAP_SEC = int(os.getenv("HTTP_BACKOFF_CAP_SEC", "8"))
+HTTP_TIMEOUT_SEC = int(os.getenv("HTTP_TIMEOUT_SEC", "10"))
+
+logger = logging.getLogger(__name__)
+
+def request_with_retries(method: str, url: str, **kwargs) -> requests.Response:
+    """HTTPリクエストをリトライ付きで実行するユーティリティ"""
+    wait = 1
+    for attempt in range(HTTP_MAX_RETRIES):
+        try:
+            resp = _SESSION.request(
+                method,
+                url,
+                headers=kwargs.pop("headers", None),
+                timeout=kwargs.pop("timeout", HTTP_TIMEOUT_SEC),
+                **kwargs,
+            )
+        except requests.RequestException as exc:
+            if attempt == HTTP_MAX_RETRIES - 1:
+                raise
+            logger.warning(f"Request error: {exc} – retrying in {wait}s")
+        else:
+            if resp.status_code not in (429,) and not 500 <= resp.status_code < 600:
+                return resp
+            if attempt == HTTP_MAX_RETRIES - 1:
+                return resp
+            logger.warning(
+                "HTTP %s returned %s – retrying in %ss",
+                method.upper(),
+                resp.status_code,
+                wait,
+            )
+        time.sleep(min(wait, HTTP_BACKOFF_CAP_SEC))
+        wait = min(wait * 2, HTTP_BACKOFF_CAP_SEC)
+    return resp


### PR DESCRIPTION
## Summary
- add `backend/utils/http_client.py` with `request_with_retries`
- export new helper in `backend/utils/__init__`
- refactor `OrderManager` to use new module
- refactor `position_manager` retry logic to use helper

## Testing
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684909346bec8333b4052d5ec9c0f984