### PR TITLE
Add debug logging for trade mode reasons

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -166,9 +166,10 @@ def build_exit_context(position, tick_data, indicators, indicators_m1=None) -> d
 
 
 # ログフォーマットとレベルを統一
+log_level = env_loader.get_env("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
-    level=os.getenv("LOG_LEVEL", "INFO"),
+    level=getattr(logging, log_level, logging.INFO),
 )
 log = getLogger(__name__)
 
@@ -1062,6 +1063,10 @@ class JobRunner:
                     # 指標からトレードモードを判定
                     new_mode, _score, reasons = decide_trade_mode_detail(
                         indicators, candles_m5
+                    )
+                    log.debug(
+                        "Trade mode reasons:\n%s",
+                        "\n".join(reasons),
                     )
                     perf = recent_strategy_performance()
                     self.current_context = build_context(self.regime_detector.state, indicators, perf)


### PR DESCRIPTION
## Summary
- log trade mode reasons in `job_runner`
- make log level configurable via `LOG_LEVEL`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi, numpy, pandas, requests, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68490cd3700c8333bde2604fc0b3ce1a