### PR TITLE
Fix logging config duplicate keyword

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -170,7 +170,6 @@ log_level = env_loader.get_env("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
     level=getattr(logging, log_level, logging.INFO),
-    level=env_loader.get_env("LOG_LEVEL", "INFO"),
 
 )
 log = getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove duplicate `level` argument when configuring logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684910fe859883339b1b7f70c134c0f6