### PR TITLE
Disable static pullback filter and tweak prompt

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -5,11 +5,7 @@ from backend.strategy.risk_manager import calc_lot_size
 import importlib
 
 from backend.filters.false_break_filter import should_skip as false_break_skip
-from backend.filters.trend_pullback import (
-    should_enter_long as should_enter_long_trend,
-    should_enter_short as should_enter_short_trend,
-    should_skip as trend_pullback_skip,
-)
+# trend_pullback filter removed – AI handles pullback assessment
 
 try:
     scalp_mod = importlib.import_module("backend.filters.scalp_entry")
@@ -636,28 +632,10 @@ def process_entry(
         logging.debug(f"[process_entry] breakout check failed: {exc}")
 
     try:
-        filter_long = should_enter_long_scalp if scalp_mode else should_enter_long_trend
-        if (
-            not is_break
-            and side == "long"
-            and not breakout_entry
-            and not filter_long(candles_dict.get("M5", candles), indicators)
-        ):
-            logging.info("Trend pullback conditions not met → skip entry")
-            return False
-        filter_short = (
-            should_enter_short_scalp if scalp_mode else should_enter_short_trend
-        )
-        if (
-            not is_break
-            and side == "short"
-            and not breakout_entry
-            and not filter_short(candles_dict.get("M5", candles), indicators)
-        ):
-            logging.info("Trend pullback conditions not met → skip entry")
-            return False
+        # --- static pullback filter disabled; rely on AI judgment ---
+        pass
     except Exception as exc:
-        logging.debug(f"[process_entry] trend-pullback check failed: {exc}")
+        logging.debug(f"[process_entry] trend-pullback check skipped: {exc}")
 
     # --- dynamic pullback threshold ---------------------------------
     pullback_needed = None

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1169,7 +1169,7 @@ Allow short-term counter-trend trades only when all of the following are true:
 - TP kept small (5–10 pips) and risk tightly controlled.
 
 📈【Trend Entry Clarification】
-Once a TREND is confirmed, prioritize entries on pullbacks. Shorts enter after price rises {pullback_needed:.1f} pips above the latest low, longs after price drops {pullback_needed:.1f} pips below the latest high. This pullback rule overrides RSI extremes.{no_pullback_msg}
+Once a TREND is confirmed, prioritize entries on pullbacks. Use recent volatility (ATR or Bollinger width) to gauge the pullback depth. Shorts enter after price rises {pullback_needed:.1f} pips above the latest low, longs after price drops {pullback_needed:.1f} pips below the latest high. This pullback rule overrides RSI extremes.{no_pullback_msg}
 """ + (
     "\n\n⏳【Trend Overshoot Handling】\n"
     "When RSI exceeds 70 in an uptrend or falls below 30 in a downtrend, do not immediately set side to 'no'.\n"

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -195,7 +195,7 @@ Price has just printed multiple upper shadows and ADX(S10) fell >30% from its pe
 Evaluate if a short scalp is favorable given potential exhaustion.
 
 📈【Trend Entry Clarification】
-Once a TREND is confirmed, prioritize entries on pullbacks. Shorts enter after price rises {pullback_needed:.1f} pips above the latest low, longs after price drops {pullback_needed:.1f} pips below the latest high. This pullback rule overrides RSI extremes.{no_pullback_msg}""" + (
+Once a TREND is confirmed, prioritize entries on pullbacks. Use recent volatility (ATR or Bollinger width) to gauge the pullback depth. Shorts enter after price rises {pullback_needed:.1f} pips above the latest low, longs after price drops {pullback_needed:.1f} pips below the latest high. This pullback rule overrides RSI extremes.{no_pullback_msg}""" + (
         "\n\n⏳【Trend Overshoot Handling】\n"
         "When RSI exceeds 70 in an uptrend or falls below 30 in a downtrend, do not immediately set side to 'no'.\n"
         "If momentum is still strong you may follow the trend. Otherwise respond with mode:'wait' so the system rechecks after a pullback of about {pullback_needed:.1f} pips.\n"


### PR DESCRIPTION
## Summary
- drop rule-based pullback check in `process_entry`
- mention volatility-based pullbacks in AI prompts

## Testing
- `pytest -q` *(fails: ImportError and AttributeError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_684932a20bdc8333ab8928184fdf7e05