### PR TITLE
Add MIN_EXPECTED_VALUE threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 
 - `DEFAULT_PAIR` … 取引する通貨ペア
 - `MIN_RRR` … 最低リスクリワード比。`ENFORCE_RRR` と併用すると常にこの比率を保ちます
+- `MIN_EXPECTED_VALUE` … TPとSLの期待値がこの値未満ならエントリーを行いません
 - `TREND_ADX_THRESH` … トレンド判定に使う ADX のしきい値 (デフォルト 20)
 - `SCALE_LOT_SIZE` … 追加エントリー時のロット数
 - `MIN_TRADE_LOT` / `MAX_TRADE_LOT` … 1 ロット = 1000 通貨。ここで許可するロット範囲を設定します

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -165,6 +165,7 @@ MM_DRAW_MAX_ATR_RATIO=2.0        # ATR倍率によるドローダウン許容幅
 MIN_TP_PROB=0.6                  # TP達成確率しきい値
 TP_PROB_HOURS=1                  # 確率計算に使う時間
 MIN_NET_TP_PIPS=1                # スプレッド控除後の最小TP
+MIN_EXPECTED_VALUE=0.0           # TPとSLの期待値下限
 
 # === 指値エントリー設定 ===
 LIMIT_THRESHOLD_ATR_RATIO=0.2    # 指値切替ATR比

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -45,6 +45,9 @@ AI_REGIME_COOLDOWN_SEC: int = int(env_loader.get_env("AI_REGIME_COOLDOWN_SEC", A
 MIN_TP_PROB: float = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
 TP_PROB_HOURS: int = int(env_loader.get_env("TP_PROB_HOURS", "24"))
 PROB_MARGIN: float = float(env_loader.get_env("PROB_MARGIN", "0.1"))
+MIN_EXPECTED_VALUE: float = float(
+    env_loader.get_env("MIN_EXPECTED_VALUE", "0.0")
+)
 LIMIT_THRESHOLD_ATR_RATIO: float = float(env_loader.get_env("LIMIT_THRESHOLD_ATR_RATIO", "0.3"))
 MAX_LIMIT_AGE_SEC: int = int(env_loader.get_env("MAX_LIMIT_AGE_SEC", "180"))
 MIN_NET_TP_PIPS: float = float(env_loader.get_env("MIN_NET_TP_PIPS", "1"))
@@ -980,7 +983,7 @@ def get_trade_plan(
 
     The function also performs local guards:
         • tp_prob ≥ MIN_TP_PROB
-        • expected value (tp*tp_prob – sl*sl_prob) > 0
+        • expected value (tp*tp_prob – sl*sl_prob) ≥ MIN_EXPECTED_VALUE
       If either guard fails, it forces ``side:"no"``.
     """
     if allow_delayed_entry is None:
@@ -1417,7 +1420,7 @@ Respond with **one-line valid JSON** exactly as:
             plan["reason"] = "RISK_PARSE_FAIL"
             return plan
 
-        if p < MIN_TP_PROB or (tp * p - sl * q) <= 0:
+        if p < MIN_TP_PROB or (tp * p - sl * q) < MIN_EXPECTED_VALUE:
             plan["entry"]["side"] = "no"
             plan.setdefault("reason", "PROB_TOO_LOW")
 


### PR DESCRIPTION
## Summary
- allow configuring minimum expected value via `MIN_EXPECTED_VALUE`
- enforce new check in `openai_analysis.py`
- document the new parameter in `README`
- update unit test stubs for new imports

## Testing
- `pytest backend/tests/test_risk_expected_value.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68496a5883048333b025f3257886400e