### PR TITLE
Add prompt logging and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,10 @@ by the AI when opening or closing a trade. In addition `score_version` records
 the scoring algorithm version used for that trade. Run `init_db()` once to add
 the column to older databases.
 
+`prompt_logs` テーブルも追加され、送信したプロンプトとモデルからの応答が保存されます。
+この履歴は将来の強化学習や戦略分析に利用できます。`init_db()` を実行すると自動
+作成されます。
+
 If you need a clean database locally, copy the example file if available:
 
 ```bash

--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -127,6 +127,17 @@ def init_db():
         ''')
 
         cursor.execute('''
+            CREATE TABLE IF NOT EXISTS prompt_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                instrument TEXT,
+                prompt TEXT NOT NULL,
+                response TEXT NOT NULL
+            )
+        ''')
+
+        cursor.execute('''
             CREATE TABLE IF NOT EXISTS errors (
                 error_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT NOT NULL,
@@ -263,6 +274,18 @@ def log_ai_decision(decision_type, instrument, ai_response):
             INSERT INTO ai_decisions (timestamp, decision_type, instrument, ai_response)
             VALUES (?, ?, ?, ?)
         ''', (datetime.now(timezone.utc).isoformat(), decision_type, instrument, ai_response))
+
+def log_prompt_response(decision_type: str, instrument: str, prompt: str, response: str) -> None:
+    """LLM への問い合わせ内容と返答を記録する"""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            INSERT INTO prompt_logs (timestamp, decision_type, instrument, prompt, response)
+            VALUES (?, ?, ?, ?, ?)
+        ''',
+            (datetime.now(timezone.utc).isoformat(), decision_type, instrument, prompt, response),
+        )
 
 def log_error(module, error_message, additional_info=None):
     """Record an error event.

--- a/tests/test_prompt_log.py
+++ b/tests/test_prompt_log.py
@@ -1,0 +1,20 @@
+import os
+import sqlite3
+from pathlib import Path
+
+from backend.logs.log_manager import init_db, log_prompt_response
+
+
+def test_log_prompt_response(tmp_path):
+    db_path = tmp_path / "test.db"
+    os.environ["TRADES_DB_PATH"] = str(db_path)
+    init_db()
+    log_prompt_response("ENTRY", "USD_JPY", "test prompt", "test response")
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT decision_type, instrument, prompt, response FROM prompt_logs"
+    )
+    row = cur.fetchone()
+    conn.close()
+    assert row == ("ENTRY", "USD_JPY", "test prompt", "test response")


### PR DESCRIPTION
## Summary
- record prompts and responses in new `prompt_logs` table
- add helper to write prompt log entries
- log prompt/response pairs for regime, entry, exit and limit conversion
- document new table in README
- test prompt logging logic

## Testing
- `python -m py_compile backend/logs/log_manager.py backend/strategy/openai_analysis.py tests/test_prompt_log.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68496aae9f008333b5a9fee50cf173b9