### PR TITLE
Add why field and risk constraints

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1290,6 +1290,11 @@ Respond with **one-line valid JSON** exactly as:
         logger.info("Invalid JSON response: %s", raw)
         return {"entry": {"side": "no"}, "raw": raw, "reason": "PARSE_FAIL"}
 
+    if plan.get("entry", {}).get("side") == "no":
+        why = plan.get("why") or plan.get("entry", {}).get("why")
+        if isinstance(why, str) and why:
+            plan["reason"] = why
+
     entry_conf = plan.get("entry_confidence")
     try:
         entry_conf = float(entry_conf) if entry_conf is not None else None

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -303,6 +303,9 @@ Your task:
     • (tp_pips - spread_pips) must be ≥ {env_loader.get_env("MIN_NET_TP_PIPS","1") } pips
     • If constraints are not met, set side to "no".
 
+4. When "entry.side" is "no", also return key "why" summarizing the reason.
+5. When "entry.side" is "yes", the "risk" object must include "tp_pips", "sl_pips", "tp_prob" and "sl_prob", and tp_prob must be ≥ 0.70.
+
 Respond with **one-line valid JSON** exactly as:
 {{"regime":{{...}},"entry":{{...}},"risk":{{...}},"entry_confidence":0.0,"probs":{{"long":0.5,"short":0.5,"no":0.0}}}}
 """

--- a/docs/quick_start_en.md
+++ b/docs/quick_start_en.md
@@ -31,3 +31,5 @@
    ```
 
 Past performance does not guarantee future results. Use at your own risk.
+
+When the AI returns `side: "no"`, the plan includes a `why` field briefly stating the reason. When it responds with `side: "yes"`, the `risk` object must contain `tp_pips`, `sl_pips`, `tp_prob` and `sl_prob`; `tp_prob` should be at least 0.70.

--- a/docs/quick_start_ja.md
+++ b/docs/quick_start_ja.md
@@ -41,3 +41,5 @@ INFO:root:Net TP 0.3 < 1.0 → skip entry
 ```
 
 プランには `"reason": "NET_TP_TOO_SMALL"` と記録されます。`MIN_NET_TP_PIPS` を 0.5 程度まで下げる、あるいはスプレッドが狭い時間帯を選ぶとエントリーされやすくなります。
+
+AI が `side: "no"` を返した場合は `why` フィールドに理由が英語で簡潔に記載されます。`side: "yes"` のときは `risk.tp_pips`, `risk.sl_pips` などが必須で、`tp_prob` は 0.70 以上である必要があります。


### PR DESCRIPTION
## Summary
- update prompt instructions to require `why` when `entry.side` is `no`
- ensure `risk` object is mandatory when `entry.side` is `yes`
- parse the new `why` field in analysis logic
- document the behaviour in quick start guides

## Testing
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt`
- `pytest -q` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68496a5a43d083338405f150e274730e