### PR TITLE
Add filter statistics helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,15 @@ Set the `DAYS` environment variable to keep more history:
 DAYS=60 python3 -m backend.logs.cleanup
 ```
 
+### Filter statistics
+
+`analysis/filter_statistics.py` を使うと、エントリーを阻止したフィルター理由の集計
+結果を表示できます。`TRADES_DB_PATH` が未指定の場合は `trades.db` を参照します。
+
+```bash
+python3 -m analysis.filter_statistics
+```
+
 ### System cleanup
 
 Old cache files and log archives can consume disk space over time. Run the

--- a/analysis/filter_statistics.py
+++ b/analysis/filter_statistics.py
@@ -1,0 +1,44 @@
+"""フィルター効果を集計する簡易スクリプト."""
+from __future__ import annotations
+
+import sqlite3
+from collections import Counter
+from pathlib import Path
+
+from backend.utils import env_loader
+
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "trades.db"))
+
+
+def summarize(db_path: Path = DB_PATH) -> dict:
+    """entry_skips と trades を読み込みフィルター発生回数を返す."""
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        c.execute("SELECT reason FROM entry_skips")
+        reasons = [r[0] for r in c.fetchall()]
+        c.execute("SELECT COUNT(*) FROM trades")
+        trade_total = c.fetchone()[0] or 0
+    counts = Counter(reasons)
+    return {
+        reason: {
+            "count": cnt,
+            "ratio": cnt / trade_total if trade_total else 0.0,
+        }
+        for reason, cnt in counts.items()
+    }
+
+
+def print_summary(stats: dict) -> None:
+    """集計結果を見やすく表示する."""
+    print("Filter Statistics")
+    print("-----------------")
+    for reason, data in sorted(stats.items(), key=lambda x: x[1]["count"], reverse=True):
+        pct = data["ratio"] * 100
+        print(f"{reason}: {data['count']} ({pct:.1f}% vs trades)")
+
+
+if __name__ == "__main__":
+    summary = summarize()
+    print_summary(summary)
+
+__all__ = ["summarize", "print_summary"]


### PR DESCRIPTION
## Summary
- add `filter_statistics.py` to tally entry skip reasons
- document script usage in README

## Testing
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt`
- `pip install -r backend/requirements-dev.txt`
- `pytest -q` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68496a7f53348333a39829d2871ef687