### PR TITLE
Improve entry logic and add scalp pattern check

### DIFF
--- a/signals/scalp_strategy.py
+++ b/signals/scalp_strategy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Sequence, Optional
 
 from indicators.bollinger import multi_bollinger
+from indicators.patterns import DoubleBottomSignal, DoubleTopSignal
 from backend.utils import env_loader
 
 
@@ -33,6 +34,7 @@ def should_enter_trade_s10(
     direction: str,
     closes: Sequence[float],
     bands_s10: dict,
+    candles: Sequence[dict] | None = None,
 ) -> Optional[str]:
     """Return order side ``"long"`` or ``"short"`` if conditions met."""
     if not closes:
@@ -50,8 +52,16 @@ def should_enter_trade_s10(
             return None
         prev = closes[-2]
         if prev < lower and price > lower:
+            if candles:
+                pattern = DoubleBottomSignal().evaluate(candles[-3:])
+                if pattern is None:
+                    return None
             return "long"
         if prev > upper and price < upper:
+            if candles:
+                pattern = DoubleTopSignal().evaluate(candles[-3:])
+                if pattern is None:
+                    return None
             return "short"
     return None
 

--- a/strategies/trend_strategy.py
+++ b/strategies/trend_strategy.py
@@ -10,6 +10,8 @@ from strategies.base import Strategy
 class TrendStrategy(Strategy):
     """単純なトレンドフォロー戦略."""
 
+    LOOKBACK = 5
+
     def __init__(self) -> None:
         super().__init__("trend")
 
@@ -17,6 +19,36 @@ class TrendStrategy(Strategy):
         closes = context.get("closes", [])
         if len(closes) < 2:
             return None
+
+        ema = (
+            context.get("ema50_h1")
+            or context.get("ema_fast_h1")
+            or context.get("ema_h1")
+        )
+        ema_slope = context.get("ema_slope_h1")
+        highs = context.get("highs")
+        lows = context.get("lows")
+
+        if (
+            ema is not None
+            and ema_slope is not None
+            and highs is not None
+            and lows is not None
+            and len(highs) >= self.LOOKBACK
+            and len(lows) >= self.LOOKBACK
+        ):
+            price = closes[-1]
+            prev_price = closes[-2]
+            recent_high = max(highs[-self.LOOKBACK :])
+            recent_low = min(lows[-self.LOOKBACK :])
+
+            if price > ema and ema_slope > 0:
+                if price > recent_high and prev_price <= recent_high:
+                    return "long"
+            if price < ema and ema_slope < 0:
+                if price < recent_low and prev_price >= recent_low:
+                    return "short"
+
         last = closes[-1]
         prev = closes[-2]
         if last > prev:

--- a/tests/test_scalp_strategy.py
+++ b/tests/test_scalp_strategy.py
@@ -33,3 +33,16 @@ def test_should_enter_trade_s10_trend_breakout():
     assert side == "long"
 
 
+def test_should_enter_trade_s10_range_with_pattern():
+    bands = {"upper": 1.4, "lower": 1.15}
+    candles = [
+        {"o": 1.2, "h": 1.25, "l": 1.0, "c": 1.1, "volume": 100},
+        {"o": 1.1, "h": 1.3, "l": 1.1, "c": 1.2, "volume": 110},
+        {"o": 1.2, "h": 1.24, "l": 1.0, "c": 1.1, "volume": 180},
+        {"o": 1.15, "h": 1.35, "l": 1.1, "c": 1.3, "volume": 160},
+    ]
+    closes = [candles[-2]["c"], candles[-1]["c"]]
+    side = should_enter_trade_s10("range", closes, bands, candles=candles)
+    assert side == "long"
+
+

--- a/tests/test_trend_strategy.py
+++ b/tests/test_trend_strategy.py
@@ -1,0 +1,26 @@
+import pytest
+from strategies.trend_strategy import TrendStrategy
+
+
+def test_trend_strategy_breakout_long():
+    strat = TrendStrategy()
+    context = {
+        "closes": [1.0, 1.05, 1.06, 1.07, 1.1],
+        "highs": [1.01, 1.06, 1.05, 1.06, 1.09],
+        "lows": [0.99, 1.03, 1.04, 1.05, 1.07],
+        "ema_fast_h1": 1.0,
+        "ema_slope_h1": 0.1,
+    }
+    assert strat.decide_entry(context) == "long"
+
+
+def test_trend_strategy_breakout_short():
+    strat = TrendStrategy()
+    context = {
+        "closes": [1.2, 1.15, 1.14, 1.13, 1.1],
+        "highs": [1.21, 1.2, 1.19, 1.18, 1.17],
+        "lows": [1.19, 1.16, 1.15, 1.14, 1.12],
+        "ema_fast_h1": 1.2,
+        "ema_slope_h1": -0.1,
+    }
+    assert strat.decide_entry(context) == "short"


### PR DESCRIPTION
## Summary
- refine TrendStrategy entry logic with breakout confirmation
- enhance should_enter_trade_s10 with optional pattern recognition
- test new scalp pattern trigger
- add tests for TrendStrategy breakout logic

## Testing
- `pytest -q` *(fails: ImportError and AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68496a4815948333b8091756ba93b8ed