### PR TITLE
Add trade label analysis

### DIFF
--- a/analysis/log_analysis.py
+++ b/analysis/log_analysis.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Utility functions for log analysis."""
+
+from typing import Dict
+from backend.logs.log_manager import get_db_connection
+
+
+def label_win_rates() -> Dict[str, float]:
+    """Return win rate for each label in ``trade_labels`` table."""
+    with get_db_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT l.label,
+                   COUNT(*) AS total,
+                   SUM(CASE WHEN t.profit_loss > 0 THEN 1 ELSE 0 END) AS wins
+            FROM trade_labels l
+            JOIN trades t ON t.trade_id = l.trade_id
+            GROUP BY l.label
+            """
+        )
+        rows = cur.fetchall()
+    return {r[0]: (r[2] / r[1]) if r[1] else 0.0 for r in rows}
+
+__all__ = ["label_win_rates"]

--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -182,6 +182,14 @@ def init_db():
                 reward REAL NOT NULL
             )
         ''')
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS trade_labels (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                trade_id INTEGER NOT NULL,
+                label TEXT NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+        ''')
 
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS sync_state (
@@ -243,6 +251,17 @@ def log_trade(
             is_manual,
             int(score_version if score_version is not None else env_loader.get_env("SCORE_VERSION", "1")),
         ))
+        trade_id = cursor.lastrowid
+        conn.commit()
+        return trade_id
+
+def add_trade_label(trade_id: int, label: str) -> None:
+    """Add descriptive label for a trade."""
+    with get_db_connection() as conn:
+        conn.execute(
+            'INSERT INTO trade_labels (trade_id, label, timestamp) VALUES (?, ?, ?)',
+            (trade_id, label, datetime.now(timezone.utc).isoformat()),
+        )
 
 def log_policy_transition(state: str, action: str, reward: float) -> None:
     """Store a (state, action, reward) tuple for offline RL."""

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -79,3 +79,9 @@ CREATE TABLE IF NOT EXISTS policy_transitions (
     action TEXT NOT NULL,
     reward REAL NOT NULL
 );
+CREATE TABLE IF NOT EXISTS trade_labels (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trade_id INTEGER NOT NULL,
+    label TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);

--- a/tests/test_log_analysis.py
+++ b/tests/test_log_analysis.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+import importlib
+from pathlib import Path
+
+class TestLogAnalysis(unittest.TestCase):
+    def setUp(self):
+        self.db_path = Path("test_log.db")
+        os.environ["TRADES_DB_PATH"] = str(self.db_path)
+        import backend.logs.log_manager as lm
+        importlib.reload(lm)
+        lm.init_db()
+        self.lm = lm
+        import analysis.log_analysis as la
+        importlib.reload(la)
+        self.la = la
+
+    def tearDown(self):
+        if self.db_path.exists():
+            self.db_path.unlink()
+
+    def test_label_win_rate(self):
+        trade_id = self.lm.log_trade(
+            instrument="EUR_USD",
+            entry_time="2024-01-01T00:00:00",
+            entry_price=1.0,
+            units=1,
+            ai_reason="test",
+        )
+        self.lm.add_trade_label(trade_id, "mode=trend")
+        conn = self.lm.get_db_connection()
+        conn.execute("UPDATE trades SET profit_loss = 1 WHERE trade_id=?", (trade_id,))
+        conn.commit()
+        stats = self.la.label_win_rates()
+        self.assertAlmostEqual(stats.get("mode=trend"), 1.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand DB schema with `trade_labels` table
- log trade IDs and add helper for attaching labels
- provide analysis util `label_win_rates`
- test log analysis logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68496ab4752c8333907c863b25ff9804