### PR TITLE
Update Python requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "piphawk-ai"
 version = "0.5.0.dev0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "annotated-types==0.7.0",
     "anyio==4.9.0",


### PR DESCRIPTION
## Summary
- bump `requires-python` to `>=3.11`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68496f7850648333b72eef34a0cd9d1b