### PR TITLE
Add packages to setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,21 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["piphawk_ai", "backend", "signals"]
+include = [
+    "piphawk_ai",
+    "backend",
+    "signals",
+    "ai",
+    "analysis",
+    "core",
+    "execution",
+    "indicators",
+    "monitoring",
+    "risk",
+    "strategies",
+    "policy",
+    "regime",
+    "runner",
+    "models",
+    "training",
+]


### PR DESCRIPTION
## Summary
- add missing packages to `include` list

## Testing
- `pip install -e . --no-deps`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68496f79c7d88333a74c39ed2ecab831