### PR TITLE
Add Kafka healthcheck and SafetyTrigger tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,12 @@ THRESHOLD=80 bash maintenance/docker_cleanup.sh
 automatically. By default, logs older than seven days or exceeding **10 GiB**
 are pruned without manual intervention.
 
+### Kafka healthcheck
+
+`docker-compose.yml` includes a healthcheck so the `piphawk` container waits for
+Kafka to become ready before connecting. This avoids `ECONNREFUSED` errors
+during startup races.
+
 ## React UI
 
 The active React application lives in `piphawk-ui/` and was bootstrapped with Create React App. Run it locally with:
@@ -774,20 +780,12 @@ TP/SL の組み合わせは複数候補から期待値を計算し、最も利�
 
 ## Running Tests
 
-The repository includes a set of unit tests under `tests/`. Activate your
-virtual environment and execute:
+The repository includes a set of unit tests under `tests/`. You can run them
+quickly using the helper script:
 
 ```bash
-pytest
+./run_tests.sh
 ```
 
-Ensure all dependencies from `backend/requirements.txt` are installed before running tests.
-
-You can install them with:
-
-```bash
-pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
-```
-
-This will run all tests defined in the project to verify core modules and
-configuration loaders.
+The script installs dependencies from `requirements-dev.txt` and then executes
+`pytest`. Pass any additional arguments to forward them to `pytest`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       - KAFKA_SERVERS=kafka:9092
       - KAFKA_BROKERS=kafka:9092
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
     networks:
       - piphawknet
     restart: always
@@ -42,6 +43,10 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
       - KAFKA_CFG_LOG_RETENTION_HOURS=168
       - KAFKA_CFG_LOG_RETENTION_BYTES=10737418240
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 5s
+      retries: 5
     ports:
       - "9092:9092"
     volumes:

--- a/monitoring/metrics_publisher.py
+++ b/monitoring/metrics_publisher.py
@@ -1,3 +1,5 @@
+"""Publish metrics to Kafka and expose Prometheus gauges."""
+
 import json
 import logging
 from datetime import datetime

--- a/monitoring/safety_trigger.py
+++ b/monitoring/safety_trigger.py
@@ -1,3 +1,5 @@
+"""Utilities for halting processes when loss or error counts exceed limits."""
+
 import logging
 from datetime import datetime, timedelta
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pip install -r requirements-dev.txt
+pytest "$@"

--- a/tests/test_safety_trigger.py
+++ b/tests/test_safety_trigger.py
@@ -1,0 +1,30 @@
+from monitoring.safety_trigger import SafetyTrigger
+
+
+def test_loss_limit_triggers():
+    triggered = []
+    st = SafetyTrigger(loss_limit=5)
+    st.attach(lambda: triggered.append(True))
+    st.record_loss(-6)
+    assert triggered
+
+
+def test_error_limit_triggers():
+    triggered = []
+    st = SafetyTrigger(error_limit=2)
+    st.attach(lambda: triggered.append(True))
+    st.record_error()
+    assert not triggered
+    st.record_error()
+    assert triggered
+
+
+def test_cooldown_prevents_retrigger():
+    triggered = []
+    st = SafetyTrigger(loss_limit=1, cooldown_sec=60)
+    st.attach(lambda: triggered.append(True))
+    st.record_loss(-1.5)
+    assert triggered == [True]
+    triggered.clear()
+    st.record_loss(-1.5)
+    assert triggered == []


### PR DESCRIPTION
## Summary
- wait for Kafka readiness in `docker-compose.yml`
- document health check use
- add docstrings to monitoring utilities
- provide helper script `run_tests.sh`
- include unit tests for `SafetyTrigger`

## Testing
- `pytest tests/test_safety_trigger.py -q`
- `./run_tests.sh` *(fails: 163 failed, 110 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6849784316c48333af0f28cd380541bc