### PR TITLE
Add Kafka health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,9 @@ THRESHOLD=80 bash maintenance/docker_cleanup.sh
 automatically. By default, logs older than seven days or exceeding **10 GiB**
 are pruned without manual intervention.
 
+The Kafka container includes a simple health check. `piphawk` waits for this
+check to succeed by using `depends_on` with `condition: service_healthy`.
+
 ## React UI
 
 The active React application lives in `piphawk-ui/` and was bootstrapped with Create React App. Run it locally with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       - KAFKA_SERVERS=kafka:9092
       - KAFKA_BROKERS=kafka:9092
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
     networks:
       - piphawknet
     restart: always
@@ -48,6 +49,11 @@ services:
       - kafka-data:/bitnami/kafka
     networks:
       - piphawknet
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 volumes:
   kafka-data:
     driver: local


### PR DESCRIPTION
## Summary
- add healthcheck to Kafka service so compose can verify readiness
- make piphawk depend on Kafka becoming healthy
- document Kafka health check in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68497b7327688333a92b844446107e20