### PR TITLE
Add test helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,3 +791,13 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/re
 
 This will run all tests defined in the project to verify core modules and
 configuration loaders.
+
+Alternatively, you can use the provided helper script which installs
+development dependencies before executing the tests:
+
+```bash
+./scripts/run_tests.sh
+```
+
+This script runs `pip install -r requirements-dev.txt` and then launches
+`pytest` automatically.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+pip install -r requirements-dev.txt
+pytest


### PR DESCRIPTION
## Summary
- provide a simple script `scripts/run_tests.sh` to install dev requirements and run pytest
- document how to use this script in the README "Running Tests" section

## Testing
- `./scripts/run_tests.sh` *(failed: Building wheel for hdbscan cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68497b741918833387c5c8cf3815442a