### PR TITLE
Add docstrings and tests for monitoring utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,4 +790,5 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/re
 ```
 
 This will run all tests defined in the project to verify core modules and
-configuration loaders.
+configuration loaders. Recent additions include tests for the monitoring
+utilities such as ``SafetyTrigger`` and ``metrics_publisher``.

--- a/monitoring/metrics_publisher.py
+++ b/monitoring/metrics_publisher.py
@@ -1,3 +1,5 @@
+"""Kafka と Prometheus へメトリクスを送信するユーティリティ."""
+
 import json
 import logging
 from datetime import datetime

--- a/monitoring/safety_trigger.py
+++ b/monitoring/safety_trigger.py
@@ -1,3 +1,5 @@
+"""損失やエラー発生数を監視して安全停止を行うためのモジュール."""
+
 import logging
 from datetime import datetime, timedelta
 

--- a/tests/test_metrics_publisher_basic.py
+++ b/tests/test_metrics_publisher_basic.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+import monitoring.metrics_publisher as mp
+
+
+class DummyProducer:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, topic, value):
+        self.sent.append((topic, value))
+
+
+class DummyGauge:
+    def __init__(self, *a, **k):
+        self.values = {}
+
+    def labels(self, **labels):
+        def setter(v):
+            self.values[tuple(labels.items())] = v
+        return SimpleNamespace(set=setter)
+
+
+def setup_module(module):
+    mp._gauges.clear()
+    mp._producer = None
+
+
+def test_publish(monkeypatch):
+    prod = DummyProducer()
+    monkeypatch.setattr(mp, "_get_producer", lambda: prod)
+    monkeypatch.setattr(mp, "Gauge", DummyGauge)
+    mp.publish("test", 2.0, {"k": "v"})
+    assert prod.sent
+    topic, data = prod.sent[0]
+    assert topic == mp.METRICS_TOPIC
+    assert data["metric"] == "test"
+    gauge = mp._gauges["test_k"]
+    assert list(gauge.values.values())[0] == 2.0
+
+
+def test_record_latency(monkeypatch):
+    prod = DummyProducer()
+    monkeypatch.setattr(mp, "_get_producer", lambda: prod)
+    monkeypatch.setattr(mp, "Gauge", DummyGauge)
+    mp.record_latency("lat", 0.0, 0.01)
+    assert prod.sent

--- a/tests/test_safety_trigger_basic.py
+++ b/tests/test_safety_trigger_basic.py
@@ -1,0 +1,19 @@
+from monitoring.safety_trigger import SafetyTrigger
+
+
+def test_safety_trigger_loss(monkeypatch):
+    called = []
+    st = SafetyTrigger(loss_limit=1.0)
+    st.attach(lambda: called.append(True))
+    st.record_loss(-1.5)
+    assert called == [True]
+
+
+def test_safety_trigger_error(monkeypatch):
+    called = []
+    st = SafetyTrigger(error_limit=2)
+    st.attach(lambda: called.append(True))
+    st.record_error()
+    assert not called
+    st.record_error()
+    assert called == [True]


### PR DESCRIPTION
## Summary
- document monitoring modules
- add unit tests for `SafetyTrigger` and `metrics_publisher`
- mention new tests in README

## Testing
- `pytest tests/test_metrics_publisher_basic.py tests/test_safety_trigger_basic.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68497b734e848333945d9220b9042fd0