### PR TITLE
Fix NameError in entry filter when Bollinger data missing

### DIFF
--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -546,6 +546,8 @@ def pass_entry_filter(
     band_width_ok = False
     bw_pips = None
     bw_thresh = float(env_loader.get_env("BAND_WIDTH_THRESH_PIPS", "4"))
+    # ボリンジャーバンドデータが無い場合はデフォルトで0.0を使用する
+    width_ratio = 0.0
     if bb_upper is not None and bb_lower is not None and len(bb_upper) and len(bb_lower):
         pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
         bw_pips = (bb_upper.iloc[-1] - bb_lower.iloc[-1]) / pip_size


### PR DESCRIPTION
## Summary
- ensure `width_ratio` is defined even if Bollinger Bands are unavailable in `pass_entry_filter`

## Testing
- `./run_tests.sh` *(fails: environment restrictions prevent installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68497e1685948333b66dc31657c07a51