### PR TITLE
Allow scalping entries in all modes

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -241,7 +241,8 @@ def process_entry(
     trade_mode = decide_trade_mode(indicators)
     logging.info("Trade mode decided: %s", trade_mode)
     strong_trend_mode = trade_mode == "strong_trend"
-    scalp_mode = trade_mode in ("scalp", "scalp_momentum") and adx_val is not None
+    # モードによらずスキャル条件を評価する
+    scalp_mode = adx_val is not None
     adx_max = float(env_loader.get_env("SCALP_SUPPRESS_ADX_MAX", "0"))
     if adx_val is not None and adx_max > 0 and adx_val > adx_max:
         scalp_mode = False

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -1534,7 +1534,7 @@ class JobRunner:
                                 time.sleep(self.interval_seconds)
                                 timer.stop()
                                 continue
-                            if self.trade_mode == "scalp_momentum" and not has_position:
+                            if not has_position:
                                 ema = indicators.get("ema_slope")
                                 if ema is not None:
                                     val = ema.iloc[-1] if hasattr(ema, "iloc") else ema[-1]


### PR DESCRIPTION
## Summary
- evaluate scalping condition regardless of trade mode
- remove trade-mode check before auto scalp entry

## Testing
- `./run_tests.sh` *(fails: ImportError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68497ea08aec8333a62d3c6fa2149c0d