### PR TITLE
Fix Kafka healthcheck duplicate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,10 +43,6 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
       - KAFKA_CFG_LOG_RETENTION_HOURS=168
       - KAFKA_CFG_LOG_RETENTION_BYTES=10737418240
-    healthcheck:
-      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
-      interval: 5s
-      retries: 5
     ports:
       - "9092:9092"
     volumes:


### PR DESCRIPTION
## Summary
- remove extra healthcheck block from the Kafka service

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68498751979c8333b1ae3e29288c7f53