### PR TITLE
Implement momentum loss exit

### DIFF
--- a/signals/scalp_momentum.py
+++ b/signals/scalp_momentum.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Scalp momentum utilities."""
+
+from typing import Any
+
+from backend.utils import env_loader
+from backend.indicators.ema import get_ema_gradient
+
+
+def exit_if_momentum_loss(indicators: dict[str, Any]) -> bool:
+    """Return True when EMA gradient turns down and RSI/MACD confirm weakness."""
+    ema_fast = indicators.get("ema_fast")
+    rsi_series = indicators.get("rsi")
+    macd_hist = indicators.get("macd_hist")
+    if ema_fast is None or rsi_series is None or macd_hist is None:
+        return False
+
+    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
+    try:
+        ema_dir = get_ema_gradient(ema_fast, pip_size=pip_size)
+    except Exception:
+        ema_dir = "flat"
+
+    try:
+        rsi_val = float(rsi_series.iloc[-1]) if hasattr(rsi_series, "iloc") else float(rsi_series[-1])
+        macd_val = float(macd_hist.iloc[-1]) if hasattr(macd_hist, "iloc") else float(macd_hist[-1])
+    except Exception:
+        return False
+
+    if ema_dir == "down" and rsi_val < 50 and macd_val < 0:
+        return True
+    return False
+
+
+__all__ = ["exit_if_momentum_loss"]

--- a/tests/test_scalp_momentum_exit.py
+++ b/tests/test_scalp_momentum_exit.py
@@ -1,0 +1,48 @@
+import importlib
+import time
+import sys
+from types import SimpleNamespace
+
+import os
+import pandas as pd
+
+os.environ.setdefault("OANDA_API_KEY", "x")
+os.environ.setdefault("OANDA_ACCOUNT_ID", "x")
+
+import execution.scalp_manager as sm
+
+
+class DummyOM:
+    def __init__(self):
+        self.closed = []
+
+    def close_position(self, instrument, side="both"):
+        self.closed.append(instrument)
+        return {"ok": True}
+
+
+def test_exit_on_momentum_loss(monkeypatch):
+    importlib.reload(sm)
+    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
+    sm.order_mgr = sm.OrderManager()
+    monkeypatch.setattr(
+        sm,
+        "get_open_positions",
+        lambda: [{"instrument": "USD_JPY", "id": "t1"}],
+    )
+    sm._open_scalp_trades["t1"] = time.time()
+
+    fetch_mod = SimpleNamespace(fetch_candles=lambda *a, **k: [{}] * 30)
+    indicators = {
+        "ema_fast": pd.Series([1.0, 0.99]),
+        "ema_slow": pd.Series([1.0, 0.995]),
+        "rsi": pd.Series([49.0]),
+        "macd_hist": pd.Series([-0.1]),
+    }
+    ind_mod = SimpleNamespace(calculate_indicators=lambda *a, **k: indicators)
+    sys.modules["backend.market_data.candle_fetcher"] = fetch_mod
+    sys.modules["backend.indicators.calculate_indicators"] = ind_mod
+    monkeypatch.setenv("PIP_SIZE", "0.01")
+
+    sm.monitor_scalp_positions()
+    assert sm.order_mgr.closed == ["USD_JPY"]


### PR DESCRIPTION
## Summary
- add `signals/scalp_momentum.py` with `exit_if_momentum_loss`
- monitor scalp positions for momentum loss and exit if triggered
- test momentum-loss exit behaviour

## Testing
- `bash run_tests.sh tests/test_scalp_momentum_exit.py -q`
- `bash run_tests.sh tests/test_scalp_manager.py::test_auto_exit_on_timeout tests/test_scalp_momentum_exit.py::test_exit_on_momentum_loss -q`

------
https://chatgpt.com/codex/tasks/task_e_68498e3e3384833385d8290a05da2eb2