### PR TITLE
Add dynamic scalp hold time

### DIFF
--- a/backend/config/ENV_README.txt
+++ b/backend/config/ENV_README.txt
@@ -215,6 +215,7 @@ SCALE_TRIGGER_ATR=0.5
   S10 を指定すると 10 秒足データも取得する
 - TREND_COND_TF: トレンドフォロー時に市場判定へ使う時間足 (デフォルト M5)
 - SCALP_OVERRIDE_RANGE: true でレンジ判定を無視してスキャルを実行
+- HOLD_TIME_MIN / HOLD_TIME_MAX: ATR から計算した保持時間の下限・上限
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
  - SCALP_MODE: スキャルプモードを強制したい場合に true/false を指定
 - ADX_SCALP_MIN: スキャルプ実行に必要なADX下限
@@ -223,6 +224,7 @@ SCALE_TRIGGER_ATR=0.5
 - SCALP_COND_TF: スキャルプ時に市場判定へ使う時間足 (デフォルト M1)
 - TREND_COND_TF: トレンドフォロー時に市場判定へ使う時間足 (デフォルト M5)
 - SCALP_OVERRIDE_RANGE: true でレンジ判定を無視してスキャルを実行
+- HOLD_TIME_MIN / HOLD_TIME_MAX: ATR から計算した保持時間の下限・上限
 ■ OANDA_MATCH_SEC
   ローカルトレードと OANDA 取引を照合するときの許容秒数。デフォルトは60秒。
 

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -266,6 +266,8 @@ AI_RETRY_ON_NO=true              # AIが"no"の場合は積極モードで再評
 TREND_COND_TF=M5                 # トレンドモード判定に使う時間足
 ADX_TREND_MIN=30                 # トレンド移行に必要なADX
 SCALP_OVERRIDE_RANGE=false
+HOLD_TIME_MIN=10                # スキャルプ保有時間の下限
+HOLD_TIME_MAX=120               # スキャルプ保有時間の上限
 
 AUTO_RESTART=false
 RESTART_MIN_INTERVAL=60      # 最小再起動間隔(秒)

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -264,6 +264,7 @@ SCALE_TRIGGER_ATR=0.5
   S10 を指定すると 10 秒足データも取得する
 - TREND_COND_TF: トレンドフォロー時に市場判定へ使う時間足 (デフォルト M5)
 - SCALP_OVERRIDE_RANGE: true でレンジ判定を無視してスキャルを実行
+- HOLD_TIME_MIN / HOLD_TIME_MAX: ATR から計算した保持時間の下限・上限
 - H1_BOUNCE_RANGE_PIPS: H1安値/高値からこのpips以内ならエントリーを見送る
 - SCALP_MODE: スキャルプモードを強制したい場合に true/false を指定
 - ADX_SCALP_MIN: スキャルプ実行に必要なADX下限

--- a/execution/scalp_manager.py
+++ b/execution/scalp_manager.py
@@ -33,10 +33,36 @@ except Exception:  # pragma: no cover - config optional
 SCALP_UNIT_SIZE = int(_CONFIG.get("unit_size", 1000))
 SCALP_TP_PIPS = float(_CONFIG.get("tp_pips", 1.5))
 SCALP_SL_PIPS = float(_CONFIG.get("sl_pips", 1.0))
-MAX_SCALP_HOLD_SECONDS = int(_CONFIG.get("max_hold_sec", 20))
 
 order_mgr = OrderManager()
 _open_scalp_trades: dict[str, float] = {}
+
+
+def get_dynamic_hold_seconds(instrument: str) -> int:
+    """Return hold time based on M1 ATR and env constraints."""
+    pip_size = get_pip_size(instrument)
+    try:
+        from backend.market_data.candle_fetcher import fetch_candles
+        from backend.indicators.atr import calculate_atr
+
+        candles = fetch_candles(
+            instrument, granularity="M1", count=30, allow_incomplete=True
+        )
+        highs = [float(c["mid"]["h"]) for c in candles]
+        lows = [float(c["mid"]["l"]) for c in candles]
+        closes = [float(c["mid"]["c"]) for c in candles]
+        atr_series = calculate_atr(highs, lows, closes)
+        atr_val = (
+            float(atr_series.iloc[-1]) if hasattr(atr_series, "iloc") else float(atr_series[-1])
+        )
+    except Exception as exc:  # pragma: no cover - network/parse failure
+        logger.debug("ATR fetch failed: %s", exc)
+        atr_val = pip_size  # fallback to 1 pip
+
+    hold = int(atr_val / pip_size / 0.006)
+    min_sec = int(env_loader.get_env("HOLD_TIME_MIN", "10"))
+    max_sec = int(env_loader.get_env("HOLD_TIME_MAX", "300"))
+    return max(min(hold, max_sec), min_sec)
 
 
 def enter_scalp_trade(instrument: str, side: str = "long") -> None:
@@ -145,9 +171,10 @@ def monitor_scalp_positions() -> None:
         start = _open_scalp_trades.get(str(trade_id))
         if start is None:
             continue
-        if now - start >= MAX_SCALP_HOLD_SECONDS:
+        hold_sec = get_dynamic_hold_seconds(pos["instrument"])
+        if now - start >= hold_sec:
             order_mgr.close_position(pos["instrument"])
             logger.info(
-                f"Exit SCALP {pos['instrument']} – timeout hit ({MAX_SCALP_HOLD_SECONDS}s)"
+                f"Exit SCALP {pos['instrument']} – timeout hit ({hold_sec}s)"
             )
             _open_scalp_trades.pop(str(trade_id), None)

--- a/tests/test_scalp_manager.py
+++ b/tests/test_scalp_manager.py
@@ -1,5 +1,6 @@
 import importlib
 import time
+import sys
 from types import SimpleNamespace
 
 import os
@@ -29,6 +30,43 @@ def test_auto_exit_on_timeout(monkeypatch):
     monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
     sm.order_mgr = sm.OrderManager()
     monkeypatch.setattr(sm, "get_open_positions", lambda: [{"instrument": "USD_JPY", "id": "t1"}])
-    sm._open_scalp_trades["t1"] = time.time() - sm.MAX_SCALP_HOLD_SECONDS - 1
+    monkeypatch.setattr(sm, "get_dynamic_hold_seconds", lambda _i: 1)
+    sm._open_scalp_trades["t1"] = time.time() - 2
     sm.monitor_scalp_positions()
     assert sm.order_mgr.closed == ["USD_JPY"]
+
+
+class FakeSeries:
+    def __init__(self, val):
+        class _IL:
+            def __getitem__(self, idx):
+                return val
+
+        self.iloc = _IL()
+        self._val = val
+
+    def __getitem__(self, idx):
+        return self._val
+
+
+def test_hold_seconds_varies_with_atr(monkeypatch):
+    importlib.reload(sm)
+    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
+    sm.order_mgr = sm.OrderManager()
+
+    candle = {"mid": {"h": "1.0", "l": "0.9", "c": "0.95"}, "complete": True}
+    fetch_mod = SimpleNamespace(fetch_candles=lambda *a, **k: [candle] * 20)
+    sys.modules["backend.market_data.candle_fetcher"] = fetch_mod
+
+    atr_mod_small = SimpleNamespace(calculate_atr=lambda *a, **k: FakeSeries(0.001))
+    sys.modules["backend.indicators.atr"] = atr_mod_small
+
+    monkeypatch.setenv("HOLD_TIME_MIN", "1")
+    monkeypatch.setenv("HOLD_TIME_MAX", "5000")
+    hold_small = sm.get_dynamic_hold_seconds("EUR_USD")
+
+    atr_mod_big = SimpleNamespace(calculate_atr=lambda *a, **k: FakeSeries(0.01))
+    sys.modules["backend.indicators.atr"] = atr_mod_big
+    hold_big = sm.get_dynamic_hold_seconds("EUR_USD")
+
+    assert hold_big > hold_small


### PR DESCRIPTION
## Summary
- compute scalp hold time dynamically using M1 ATR
- clamp hold time using new env vars `HOLD_TIME_MIN` and `HOLD_TIME_MAX`
- respect dynamic hold time when monitoring open scalp trades
- document the new environment variables
- test dynamic hold seconds calculation

## Testing
- `pytest -q tests/test_scalp_manager.py`
- `pytest -q` *(fails: ImportError and AttributeError across many tests)*

------
https://chatgpt.com/codex/tasks/task_e_68498e3e2b78833386f6757eb1fcdf0e