### PR TITLE
Fix ImportError handling in scalp_manager

### DIFF
--- a/execution/scalp_manager.py
+++ b/execution/scalp_manager.py
@@ -14,12 +14,8 @@ from backend.strategy.risk_manager import calc_lot_size
 
 try:
     from backend.orders.order_manager import OrderManager, get_pip_size
-except Exception:  # テストでモックが残っている場合のフォールバック
-    class OrderManager:
-        pass
-
-    def get_pip_size(instrument: str) -> float:
-        return 0.01 if instrument.endswith("_JPY") else 0.0001
+except ImportError as exc:  # pragma: no cover - raise for missing dependency
+    raise
 
 import inspect
 from backend.orders.position_manager import get_open_positions

--- a/tests/test_scalp_manager.py
+++ b/tests/test_scalp_manager.py
@@ -26,10 +26,16 @@ class DummyOM:
 
 
 def test_auto_exit_on_timeout(monkeypatch):
+    dummy_mod = SimpleNamespace(
+        OrderManager=DummyOM,
+        get_pip_size=lambda i: 0.01 if i.endswith("_JPY") else 0.0001,
+    )
+    monkeypatch.setitem(sys.modules, "backend.orders.order_manager", dummy_mod)
     importlib.reload(sm)
-    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
     sm.order_mgr = sm.OrderManager()
-    monkeypatch.setattr(sm, "get_open_positions", lambda: [{"instrument": "USD_JPY", "id": "t1"}])
+    monkeypatch.setattr(
+        sm, "get_open_positions", lambda: [{"instrument": "USD_JPY", "id": "t1"}]
+    )
     monkeypatch.setattr(sm, "get_dynamic_hold_seconds", lambda _i: 1)
     sm._open_scalp_trades["t1"] = time.time() - 2
     sm.monitor_scalp_positions()
@@ -50,8 +56,12 @@ class FakeSeries:
 
 
 def test_hold_seconds_varies_with_atr(monkeypatch):
+    dummy_mod = SimpleNamespace(
+        OrderManager=DummyOM,
+        get_pip_size=lambda i: 0.01 if i.endswith("_JPY") else 0.0001,
+    )
+    monkeypatch.setitem(sys.modules, "backend.orders.order_manager", dummy_mod)
     importlib.reload(sm)
-    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
     sm.order_mgr = sm.OrderManager()
 
     candle = {"mid": {"h": "1.0", "l": "0.9", "c": "0.95"}, "complete": True}

--- a/tests/test_scalp_manager_dynamic_tp.py
+++ b/tests/test_scalp_manager_dynamic_tp.py
@@ -40,8 +40,12 @@ class FakeSeries:
 
 
 def test_dynamic_tp_sl(monkeypatch):
+    dummy_mod = types.SimpleNamespace(
+        OrderManager=DummyOM,
+        get_pip_size=lambda i: 0.01 if i.endswith("_JPY") else 0.0001,
+    )
+    monkeypatch.setitem(sys.modules, "backend.orders.order_manager", dummy_mod)
     importlib.reload(sm)
-    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
     sm.order_mgr = sm.OrderManager()
 
     fetch_mod = types.SimpleNamespace(fetch_candles=lambda *a, **k: [{}] * 30)

--- a/tests/test_scalp_momentum_exit.py
+++ b/tests/test_scalp_momentum_exit.py
@@ -22,8 +22,12 @@ class DummyOM:
 
 
 def test_exit_on_momentum_loss(monkeypatch):
+    dummy_mod = SimpleNamespace(
+        OrderManager=DummyOM,
+        get_pip_size=lambda i: 0.01 if i.endswith("_JPY") else 0.0001,
+    )
+    monkeypatch.setitem(sys.modules, "backend.orders.order_manager", dummy_mod)
     importlib.reload(sm)
-    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
     sm.order_mgr = sm.OrderManager()
     monkeypatch.setattr(
         sm,

--- a/tests/test_scalp_trailing_after_tp.py
+++ b/tests/test_scalp_trailing_after_tp.py
@@ -31,8 +31,12 @@ class FakeSeries:
         return self._val
 
 def test_trailing_attached_on_tp(monkeypatch):
+    dummy_mod = types.SimpleNamespace(
+        OrderManager=DummyOM,
+        get_pip_size=lambda i: 0.01 if i.endswith("_JPY") else 0.0001,
+    )
+    monkeypatch.setitem(sys.modules, "backend.orders.order_manager", dummy_mod)
     importlib.reload(sm)
-    monkeypatch.setattr(sm, "OrderManager", lambda: DummyOM())
     sm.order_mgr = sm.OrderManager()
 
     fetch_mod = types.SimpleNamespace(fetch_candles=lambda *a, **k: [{}] * 30)


### PR DESCRIPTION
## Summary
- simplify ImportError handling for OrderManager
- update scalp manager tests to monkeypatch imports

## Testing
- `./run_tests.sh` *(fails: 146 failed, 140 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6849935755ec8333b242df9ae202303c