### PR TITLE
Fix scalp trade mapping to use string keys

### DIFF
--- a/execution/scalp_manager.py
+++ b/execution/scalp_manager.py
@@ -175,7 +175,7 @@ def enter_scalp_trade(instrument: str, side: str = "long") -> None:
         .get("tradeID")
     )
     if trade_id:
-        _open_scalp_trades[trade_id] = time.time()
+        _open_scalp_trades[str(trade_id)] = time.time()
         # TP が付いているか確認し、無ければ再設定する
         if hasattr(order_mgr, "get_current_tp"):
             time.sleep(1)


### PR DESCRIPTION
## Summary
- ensure `enter_scalp_trade` records trades with string keys in `_open_scalp_trades`

## Testing
- `bash run_tests.sh` *(fails: ImportError, NameError, etc.)*
- `pytest tests/test_scalp_manager.py tests/test_scalp_momentum_exit.py tests/test_scalp_manager_dynamic_tp.py tests/test_scalp_trailing_after_tp.py -q` *(fails: NameError: risk_mgr is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6849935ad7cc833385621f26a24de7c4