### PR TITLE
Add risk manager option to scalp trade

### DIFF
--- a/execution/scalp_manager.py
+++ b/execution/scalp_manager.py
@@ -40,6 +40,7 @@ SCALP_SL_PIPS = float(_CONFIG.get("sl_pips", 1.0))
 order_mgr = OrderManager()
 _open_scalp_trades: dict[str, float] = {}
 TRAIL_AFTER_TP = env_loader.get_env("TRAIL_AFTER_TP", "false").lower() == "true"
+risk_mgr: PortfolioRiskManager | None = None
 
 def get_dynamic_hold_seconds(instrument: str) -> int:
     """Return hold time based on M1 ATR and env constraints."""
@@ -95,9 +96,16 @@ def get_dynamic_hold_seconds(instrument: str) -> int:
     return max(min(hold, max_sec), min_sec)
 
 
-def enter_scalp_trade(instrument: str, side: str = "long") -> None:
+def enter_scalp_trade(
+    instrument: str,
+    side: str = "long",
+    risk_mgr: PortfolioRiskManager | None = None,
+) -> None:
 
     """Place a market order with dynamically calculated TP/SL."""
+
+    if risk_mgr is None:
+        risk_mgr = globals().get("risk_mgr")
 
     tp_pips = None
     sl_pips = None

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -1548,7 +1548,11 @@ class JobRunner:
                                     side = "long" if float(val) >= 0 else "short"
                                 else:
                                     side = "long"
-                                scalp_manager.enter_scalp_trade(DEFAULT_PAIR, side)
+                                scalp_manager.enter_scalp_trade(
+                                    DEFAULT_PAIR,
+                                    side,
+                                    risk_mgr=self.risk_mgr,
+                                )
                                 self.last_run = now
                                 update_oanda_trades()
                                 time.sleep(self.interval_seconds)


### PR DESCRIPTION
## Summary
- add global `risk_mgr` to `execution.scalp_manager`
- allow passing custom risk manager in `enter_scalp_trade`
- wire up runner to use JobRunner's `risk_mgr`

## Testing
- `bash ./run_tests.sh` *(fails: ImportError and missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6849936d777c8333a97a00c1bca9977d