### PR TITLE
Add logging for composite score check

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1503,6 +1503,11 @@ Respond with **one-line valid JSON** exactly as:
         if comp_val is not None and comp_val < COMPOSITE_MIN:
             plan["entry"]["side"] = "no"
             plan.setdefault("reason", "COMPOSITE_TOO_LOW")
+            logger.info(
+                "Composite score %.2f < %.2f → entry blocked",
+                comp_val,
+                COMPOSITE_MIN,
+            )
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- log when composite score fails threshold in `get_trade_plan`

## Testing
- `pytest` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6849a82e24708333804abb1908cf26b4