### PR TITLE
Add fallback doc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,20 @@ reentry:
 `min_atr_sl_multiplier` は ATR を基にした最小ストップ幅の倍率、`min_rr_ratio` は最低リスクリワード比を示します。`avoid_false_break` ではブレイク失敗回避のための期間と閾値を設定し、`reentry` を有効にするとブレイク後に再びエントリーする条件を制御できます。
 これらの値は `params_loader.load_params()` により `MIN_ATR_MULT` などの環境変数に変換されます。
 
+#### fallback ブロック
+
+`config/strategy.yml` ではエントリー判定に失敗した際の予備動作も定義できます。
+
+```yaml
+fallback:
+  force_on_no_side: false
+  default_sl_pips: 12
+  default_tp_pips: 18
+  dynamic_risk: false
+```
+
+`force_on_no_side` は AI が `side: "no"` を返してもトレンド方向のエントリーを強制するかどうかを決めます。`default_sl_pips` と `default_tp_pips` は AI から値が得られない場合の初期値で、`dynamic_risk` を `true` にすると指標から SL/TP を自動計算します。これらは `FALLBACK_FORCE_ON_NO_SIDE`, `FALLBACK_DEFAULT_SL_PIPS`, `FALLBACK_DEFAULT_TP_PIPS`, `FALLBACK_DYNAMIC_RISK` 環境変数として読み込まれます。
+
 ## パラメータ変更履歴の確認
 
 `init_db()` でデータベースを作成または更新した後、`log_param_change()` と `log_trade()` を

--- a/docs/quick_start_ja.md
+++ b/docs/quick_start_ja.md
@@ -43,3 +43,17 @@ INFO:root:Net TP 0.3 < 1.0 → skip entry
 プランには `"reason": "NET_TP_TOO_SMALL"` と記録されます。`MIN_NET_TP_PIPS` を 0.5 程度まで下げる、あるいはスプレッドが狭い時間帯を選ぶとエントリーされやすくなります。
 
 AI が `side: "no"` を返した場合は `why` フィールドに理由が英語で簡潔に記載されます。`side: "yes"` のときは `risk.tp_pips`, `risk.sl_pips` などが必須で、`tp_prob` は 0.70 以上である必要があります。
+
+## fallback パラメータ
+
+`config/strategy.yml` には AI が方向を返さない場合に備えた設定をまとめた `fallback` ブロックがあります。
+
+```yaml
+fallback:
+  force_on_no_side: false
+  default_sl_pips: 12
+  default_tp_pips: 18
+  dynamic_risk: false
+```
+
+`force_on_no_side` を `true` にすると AI が "no" と答えてもトレンド方向へエントリーを強制します。`default_sl_pips` と `default_tp_pips` は AI から数値が得られないときのデフォルト幅です。`dynamic_risk` が `true` の場合、指標を基に自動で SL/TP を計算します。これらは `FALLBACK_FORCE_ON_NO_SIDE` などの環境変数からも設定可能です。


### PR DESCRIPTION
## Summary
- document fallback parameters in README
- add fallback explanation to Japanese quick start guide

## Testing
- `./run_tests.sh` *(fails: 21 failed, 64 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad119a2c8333863d06731ba6ed91