### PR TITLE
Limit AI calls per loop

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover - optional dependency or test stub
 from backend.utils import env_loader, trade_age_seconds
 from backend.utils.restart_guard import can_restart
 from maintenance.disk_guard import maybe_cleanup
+from backend.utils.openai_client import reset_ai_call_counter
 
 try:
     from config import params_loader
@@ -1101,6 +1102,7 @@ class JobRunner:
         while not self._stop:
             try:
                 maybe_cleanup()
+                reset_ai_call_counter()
                 timer = PerfTimer("job_loop")
                 now = datetime.now(timezone.utc)
                 # ---- Market‑hours guard ---------------------------------

--- a/backend/strategy/pattern_ai_detection.py
+++ b/backend/strategy/pattern_ai_detection.py
@@ -39,17 +39,13 @@ def detect_chart_pattern(candles: list, patterns: list[str]) -> dict:
     )
 
     try:
-        response = openai_client.client.chat.completions.create(
+        data = openai_client.ask_openai(
+            user_prompt,
+            system_prompt=system_prompt,
             model=AI_PATTERN_MODEL,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
             max_tokens=AI_PATTERN_MAX_TOKENS,
             temperature=0.0,
         )
-        content = response.choices[0].message.content.strip()
-        data = json.loads(content)
         if isinstance(data, dict) and "pattern" in data:
             return {"pattern": data.get("pattern")}
     except Exception:


### PR DESCRIPTION
## Summary
- limit OpenAI calls to once per loop
- use the limiter for chart pattern detection
- reset the counter on each job loop

## Testing
- `./run_tests.sh` *(fails: ImportError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6849aa51c6648333a860cbb76ef14dd5