### PR TITLE
Update docs for micro scalp

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 - React dashboard and API endpoints for runtime control.
 - Prometheus metrics from both API and job runner.
 - Dockerfiles for containerized deployment.
+- `openai_micro_scalp.py` for tick-level micro structure scalping.
 
 ### Planned
 
@@ -137,6 +138,9 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 - `ADX_TREND_MIN` … ADX がこの値以上でトレンドフォローモード
 - `TREND_PROMPT_BIAS` … `aggressive` にするとトレンドフォローAIがより積極的
 - `AI_RETRY_ON_NO` … true にするとAIが "no" を返した際に再度 "aggressive" バイアスで判定
+- `MICRO_SCALP_ENABLED` … openai_micro_scalp を有効にするフラグ
+- `MICRO_SCALP_LOOKBACK` … マイクロ構造判定に使うティック本数
+- `MICRO_SCALP_MIN_PIPS` … 微小スキャルプの最低TP幅
 - `MODE_ATR_PIPS_MIN` / `MODE_BBWIDTH_PIPS_MIN` … ボラティリティ判定用の閾値
 - `MODE_EMA_SLOPE_MIN` / `MODE_ADX_MIN` … モメンタム判定のしきい値
 - `MODE_VOL_MA_MIN` … 流動性判定に使う出来高平均

--- a/backend/config/secret.env.example
+++ b/backend/config/secret.env.example
@@ -7,3 +7,7 @@ RISK_PER_TRADE=0.005
 
 # Disk guard threshold
 CLEANUP_THRESHOLD=80
+# Micro structure scalp mode
+MICRO_SCALP_ENABLED=false
+MICRO_SCALP_LOOKBACK=5
+MICRO_SCALP_MIN_PIPS=1

--- a/docs/aggressive_scalp.md
+++ b/docs/aggressive_scalp.md
@@ -21,6 +21,19 @@
 - `SCALP_PROMPT_BIAS=aggressive`
 - `AI_RETRY_ON_NO=true`
 
+## マイクロ構造モードの有効化
+
+Tick データから超短期エントリーを判定する `openai_micro_scalp.py` を使う場合は、
+以下を `.env` に追加します。
+
+```bash
+MICRO_SCALP_ENABLED=true
+MICRO_SCALP_LOOKBACK=5
+MICRO_SCALP_MIN_PIPS=1
+```
+
+設定後にジョブランナーを再起動するとマイクロ構造モードが有効になります。
+
 ## 反映手順
 
 1. `backend/config/settings.env` に上記を追記または変更します。


### PR DESCRIPTION
## Summary
- document `openai_micro_scalp.py` in the feature list
- describe micro scalp environment variables in the setup section
- extend secret.env example with micro scalp keys
- add example settings for enabling microstructure mode

## Testing
- `bash run_tests.sh` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684a18c0f2788333a445bae20a802aa2