### PR TITLE
Add volume ratio weight indicator

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1165,6 +1165,23 @@ def get_trade_plan(
     except Exception:
         pullback_done = False
 
+    # --- 最新出来高比率を計算 --------------------------------------
+    vol_ratio = None
+    try:
+        if candles_m5:
+            last = candles_m5[-1]
+            if not last.get('complete'):
+                vol_last = float(last.get('volume', 0))
+                prev_vols = [
+                    float(c.get('volume', 0))
+                    for c in candles_m5[:-1]
+                    if c.get('complete')
+                ][-6:]
+                avg = sum(prev_vols) / len(prev_vols) if prev_vols else 0.0
+                vol_ratio = (vol_last / avg) if avg else 1.0
+    except Exception:
+        vol_ratio = None
+
     prompt, comp_val = build_trade_plan_prompt(
         ind_m5,
         ind_m1,
@@ -1179,6 +1196,8 @@ def get_trade_plan(
         macro_summary,
         macro_sentiment,
         pullback_done=pullback_done,
+        vol_ratio=vol_ratio,
+        weight_last=ind_m5.get("weight_last"),
         allow_delayed_entry=allow_delayed_entry,
         higher_tf_direction=higher_tf_direction,
         trend_prompt_bias=trend_prompt_bias,

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -49,6 +49,8 @@ def build_trade_plan_prompt(
     macro_sentiment: str | None = None,
     pullback_done: bool = False,
     *,
+    vol_ratio: float | None = None,
+    weight_last: float | None = None,
     allow_delayed_entry: bool = False,
     higher_tf_direction: str | None = None,
     trend_prompt_bias: str | None = None,
@@ -287,6 +289,12 @@ Pivot: {ind_m5.get('pivot')}, R1: {ind_m5.get('pivot_r1')}, S1: {ind_m5.get('piv
 
 ### N-Wave Target
 {ind_m5.get('n_wave_target')}
+
+### Volume Ratio
+{f"{vol_ratio:.2f}" if vol_ratio is not None else 'N/A'}
+
+### Weight Last
+{f"{weight_last:.2f}" if weight_last is not None else 'N/A'}
 
 ### Pullback Completed
 {pullback_done}

--- a/backend/tests/test_weight_last.py
+++ b/backend/tests/test_weight_last.py
@@ -1,0 +1,92 @@
+import sys
+import types
+import importlib
+import unittest
+
+
+class FakeSeries:
+    def __init__(self, data=None, *a, **k):
+        self._data = list(data or [])
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+    def diff(self, periods=1):
+        return FakeSeries([0]*len(self._data))
+    def ffill(self):
+        return self
+    def bfill(self):
+        return self
+
+
+def _c(vol, complete=True):
+    return {"mid": {"c": "1", "h": "1", "l": "1"}, "volume": vol, "complete": complete}
+
+
+class TestWeightLast(unittest.TestCase):
+    def setUp(self):
+        pandas_stub = types.ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        sys.modules["pandas"] = pandas_stub
+        sys.modules["numpy"] = types.ModuleType("numpy")
+        mods = {
+            "backend.indicators.rsi": {"calculate_rsi": lambda prices: FakeSeries(prices)},
+            "backend.indicators.ema": {"calculate_ema": lambda prices, period=None: FakeSeries(prices)},
+            "backend.indicators.atr": {"calculate_atr": lambda *a, **k: FakeSeries([0])},
+            "backend.indicators.bollinger": {"calculate_bollinger_bands": lambda x: {"upper_band": FakeSeries(x), "lower_band": FakeSeries(x), "middle_band": FakeSeries(x)}},
+            "backend.indicators.adx": {
+                "calculate_adx": lambda *a, **k: FakeSeries([0]),
+                "calculate_adx_bb_score": lambda *a, **k: 0.0,
+                "calculate_di": lambda *a, **k: (FakeSeries([0]), FakeSeries([0])),
+            },
+            "backend.indicators.pivot": {"calculate_pivots": lambda h,l,c: {"pivot":1,"r1":1,"s1":1,"r2":1,"s2":1}},
+            "backend.indicators.n_wave": {"calculate_n_wave_target": lambda prices: 0.0},
+            "backend.indicators.polarity": {"calculate_polarity": lambda prices: FakeSeries([0])},
+            "backend.indicators.macd": {
+                "calculate_macd": lambda prices, **k: (FakeSeries([0]*len(prices)), FakeSeries([0]*len(prices))),
+                "calculate_macd_histogram": lambda prices, **k: FakeSeries([0]*len(prices)),
+            },
+        }
+        self._added = ["numpy"]
+        for name, attrs in mods.items():
+            mod = types.ModuleType(name)
+            for k, v in attrs.items():
+                setattr(mod, k, v)
+            sys.modules[name] = mod
+            self._added.append(name)
+        cf = types.ModuleType("backend.market_data.candle_fetcher")
+        cf.fetch_candles = lambda *a, **k: []
+        sys.modules["backend.market_data.candle_fetcher"] = cf
+        self._added.append("backend.market_data.candle_fetcher")
+        import backend.indicators.calculate_indicators as ci
+        importlib.reload(ci)
+        self.ci = ci
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+
+    def test_weight_last_zero_avg(self):
+        data = [_c(0, True) for _ in range(6)] + [_c(0, False)]
+        result = self.ci.calculate_indicators(data)
+        self.assertEqual(result.get("weight_last"), 1.0)
+
+    def test_weight_last_zero_volume(self):
+        data = [_c(100, True) for _ in range(6)] + [_c(0, False)]
+        result = self.ci.calculate_indicators(data)
+        self.assertEqual(result.get("weight_last"), 0.5)
+
+    def test_weight_last_clamped(self):
+        data = [_c(100, True) for _ in range(6)] + [_c(400, False)]
+        result = self.ci.calculate_indicators(data)
+        self.assertEqual(result.get("weight_last"), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute volume ratio for last incomplete candle
- store weight_last in indicator dictionary
- expose vol_ratio and weight_last in AI prompt
- add unit tests for weight_last edge cases

## Testing
- `pytest backend/tests/test_weight_last.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a18a692888333bff0ace563391630