### PR TITLE
Fix CI dependency installs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,6 +25,9 @@ jobs:
           pip install --upgrade pip
           # PyTorch の CPU ホイールを取得するために専用インデックスを追加
           pip install --extra-index-url https://download.pytorch.org/whl/cpu -r backend/requirements.txt
+          # テストに必要な追加依存もインストール
+          pip install -r backend/requirements-dev.txt
+          pip install -r requirements-dev.txt
           pytest -q
 
   build-and-push:


### PR DESCRIPTION
## Summary
- ensure CI installs dev requirements by adding steps in `ci-cd.yml`

## Testing
- `./run_tests.sh` *(fails: ImportError/AttributeError in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_684a1b6eb35483338a1f52019bbcf6fd