### PR TITLE
Update micro scalp prompt handling

### DIFF
--- a/backend/strategy/openai_micro_scalp.py
+++ b/backend/strategy/openai_micro_scalp.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from pathlib import Path
 
 from backend.utils.openai_client import ask_openai
 from backend.utils import env_loader, parse_json_answer
@@ -8,17 +9,22 @@ logger = logging.getLogger(__name__)
 
 MICRO_SCALP_MODEL = env_loader.get_env("MICRO_SCALP_MODEL", "gpt-4.1-nano")
 
+PROMPT_PATH = Path(__file__).resolve().parents[2] / "prompts" / "scalp_llm_prompt.txt"
+
+
+def load_prompt() -> str:
+    """Return prompt text for micro-scalp analysis."""
+    try:
+        with open(PROMPT_PATH, "r", encoding="utf-8") as f:
+            return f.read()
+    except Exception as exc:  # pragma: no cover - file issues
+        logger.error("Failed to load micro scalp prompt: %s", exc)
+        return ""
+
 
 def get_plan(features: dict) -> dict:
-    """Return micro-scalp trade plan based on tick features."""
-    prompt = (
-        "You are a forex micro-scalping assistant.\n"
-        "Decide whether to open a very short-term trade.\n"
-        f"OF_imbalance:{features.get('of_imbalance')}\n"
-        f"Vol_burst:{features.get('vol_burst')}\n"
-        f"Avg_spread_pips:{features.get('spd_avg')}\n"
-        "Respond with JSON as {\"enter\":true|false,\"side\":\"long|short\",\"tp_pips\":float,\"sl_pips\":float}"
-    )
+    """Return micro-scalp trade plan based on predefined prompt."""
+    prompt = load_prompt()
     try:
         raw = ask_openai(prompt, model=MICRO_SCALP_MODEL)
     except Exception as exc:  # pragma: no cover - network failure
@@ -30,4 +36,4 @@ def get_plan(features: dict) -> dict:
     return plan
 
 
-__all__ = ["get_plan", "MICRO_SCALP_MODEL"]
+__all__ = ["get_plan", "MICRO_SCALP_MODEL", "load_prompt", "PROMPT_PATH"]

--- a/prompts/scalp_llm_prompt.txt
+++ b/prompts/scalp_llm_prompt.txt
@@ -1,0 +1,3 @@
+You are a forex micro-scalping assistant specialized in breakout continuation trades.
+Decide whether the breakout will continue and if a short-term position should be opened.
+Respond only with JSON as {"enter":true|false,"side":"long|short","tp_pips":float,"sl_pips":float}.

--- a/tests/test_micro_scalp.py
+++ b/tests/test_micro_scalp.py
@@ -16,6 +16,10 @@ class TestMicroScalp(unittest.TestCase):
         val = calc_of_imbalance(ticks)
         self.assertAlmostEqual(val, (2 - 1) / 3)
 
+    def test_load_prompt(self):
+        text = micro.load_prompt()
+        self.assertIn("breakout continuation", text.lower())
+
     def test_get_plan_json(self):
         micro.ask_openai = lambda *a, **k: '{"enter":true,"side":"long","tp_pips":1,"sl_pips":0.5}'
         plan = micro.get_plan({"of_imbalance": 0, "vol_burst": 0, "spd_avg": 0})


### PR DESCRIPTION
## Summary
- add dedicated breakout continuation prompt text
- let micro scalp module load prompt from file
- update micro scalp tests for new prompt loader

## Testing
- `pytest tests/test_micro_scalp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a20d3e5308333ab23e5cb40e98190