### PR TITLE
Add AI call limit setter

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -18,7 +18,7 @@ except Exception:  # pragma: no cover - optional dependency or test stub
 from backend.utils import env_loader, trade_age_seconds
 from backend.utils.restart_guard import can_restart
 from maintenance.disk_guard import maybe_cleanup
-from backend.utils.openai_client import reset_ai_call_counter
+from backend.utils.openai_client import reset_ai_call_counter, set_call_limit
 
 try:
     from config import params_loader
@@ -457,6 +457,9 @@ class JobRunner:
             self.trade_mode = "trend_follow"
             self.current_params_file = "config/trend.yml"
         self.mode_reason = ""
+        # set initial AI call limit based on mode
+        default_limit = int(env_loader.get_env("MAX_AI_CALLS_PER_LOOP", "1"))
+        set_call_limit(4 if self.trade_mode == "scalp_momentum" else default_limit)
 
         # Restore TP adjustment flags based on existing TP order comment
         try:
@@ -578,6 +581,8 @@ class JobRunner:
             params_loader.load_params(path=path)
             # update AI cooldown values after reload
             self.refresh_ai_cooldowns()
+            default_limit = int(env_loader.get_env("MAX_AI_CALLS_PER_LOOP", "1"))
+            set_call_limit(4 if mode == "scalp_momentum" else default_limit)
             self.current_params_file = path
         except Exception as exc:
             log.error("Param reload failed: %s", exc)

--- a/backend/tests/test_ai_cooldown.py
+++ b/backend/tests/test_ai_cooldown.py
@@ -87,6 +87,7 @@ class TestRegimeCooldownReset(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         oa = types.ModuleType("backend.strategy.openai_analysis")

--- a/backend/tests/test_atr_breakout.py
+++ b/backend/tests/test_atr_breakout.py
@@ -88,6 +88,7 @@ class TestMarketConditionAtrBreak(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {"market_condition": "range"}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         import importlib

--- a/backend/tests/test_be_volatility_sl.py
+++ b/backend/tests/test_be_volatility_sl.py
@@ -45,6 +45,7 @@ class TestBeVolatilitySL(unittest.TestCase):
         oc = types.ModuleType('backend.utils.openai_client')
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = 'gpt'
+        oc.set_call_limit = lambda *_a, **_k: None
         add('backend.utils.openai_client', oc)
 
         oa = types.ModuleType('backend.strategy.openai_analysis')

--- a/backend/tests/test_cooldown_refresh.py
+++ b/backend/tests/test_cooldown_refresh.py
@@ -30,6 +30,7 @@ class TestRefreshAICooldowns(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         oa = types.ModuleType("backend.strategy.openai_analysis")

--- a/backend/tests/test_job_runner_env_mode.py
+++ b/backend/tests/test_job_runner_env_mode.py
@@ -30,6 +30,7 @@ class TestJobRunnerEnvMode(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         oa = types.ModuleType("backend.strategy.openai_analysis")

--- a/backend/tests/test_job_runner_restore_mode.py
+++ b/backend/tests/test_job_runner_restore_mode.py
@@ -67,6 +67,7 @@ class TestJobRunnerRestoreMode(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
         sys.modules["backend.strategy.pattern_scanner"].PATTERN_DIRECTION = {}
         sys.modules["backend.strategy.momentum_follow"].follow_breakout = lambda *a, **k: True

--- a/backend/tests/test_job_runner_tp_flags.py
+++ b/backend/tests/test_job_runner_tp_flags.py
@@ -66,6 +66,7 @@ class TestJobRunnerTpFlags(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         sys.modules["backend.market_data.tick_fetcher"].fetch_tick_data = lambda *a, **k: None

--- a/backend/tests/test_market_condition_break.py
+++ b/backend/tests/test_market_condition_break.py
@@ -32,6 +32,7 @@ class TestMarketConditionBreak(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {"market_condition": "range"}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add_module("backend.utils.openai_client", oc)
 
         import backend.strategy.openai_analysis as oa

--- a/backend/tests/test_market_condition_cooldown.py
+++ b/backend/tests/test_market_condition_cooldown.py
@@ -36,6 +36,7 @@ class TestMarketConditionCooldown(unittest.TestCase):
             return {"market_condition": "trend"}
         oc.ask_openai = dummy_ask
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add_module("backend.utils.openai_client", oc)
 
         import backend.strategy.openai_analysis as oa

--- a/backend/tests/test_recent_candle_bias.py
+++ b/backend/tests/test_recent_candle_bias.py
@@ -30,6 +30,7 @@ class TestRecentCandleBias(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         import backend.strategy.openai_analysis as oa

--- a/backend/tests/test_regime_filters.py
+++ b/backend/tests/test_regime_filters.py
@@ -48,6 +48,7 @@ class TestRegimeFilters(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         oa = types.ModuleType("backend.strategy.openai_analysis")

--- a/backend/tests/test_tp_extension.py
+++ b/backend/tests/test_tp_extension.py
@@ -54,6 +54,7 @@ class TestTpExtension(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         stub_names = [

--- a/backend/tests/test_tp_reduction.py
+++ b/backend/tests/test_tp_reduction.py
@@ -54,6 +54,7 @@ class TestTpReduction(unittest.TestCase):
         oc = types.ModuleType("backend.utils.openai_client")
         oc.ask_openai = lambda *a, **k: {}
         oc.AI_MODEL = "gpt"
+        oc.set_call_limit = lambda *_a, **_k: None
         add("backend.utils.openai_client", oc)
 
         stub_names = [

--- a/backend/utils/openai_client.py
+++ b/backend/utils/openai_client.py
@@ -54,11 +54,17 @@ def reset_ai_call_counter() -> None:
 def _register_ai_call() -> bool:
     """Return True if a new AI call is allowed in this loop."""
     global _calls_this_loop
-    if _calls_this_loop >= _CALL_LIMIT_PER_LOOP:
+    if _CALL_LIMIT_PER_LOOP > 0 and _calls_this_loop >= _CALL_LIMIT_PER_LOOP:
         logger.info("AI call skipped due to per-loop limit")
         return False
     _calls_this_loop += 1
     return True
+
+
+def set_call_limit(limit: int) -> None:
+    """Update the per-loop AI call limit."""
+    global _CALL_LIMIT_PER_LOOP
+    _CALL_LIMIT_PER_LOOP = int(limit)
 
 def ask_openai(
     prompt: str,
@@ -157,4 +163,5 @@ __all__ = [
     "ask_openai_async",
     "AI_MODEL",
     "reset_ai_call_counter",
+    "set_call_limit",
 ]

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -16,6 +16,7 @@ except Exception:  # pragma: no cover - optional dependency or test stub
 
 from backend.utils import env_loader, trade_age_seconds
 from backend.utils.restart_guard import can_restart
+from backend.utils.openai_client import set_call_limit
 
 try:
     from config import params_loader
@@ -461,6 +462,8 @@ class JobRunner:
             self.trade_mode = "trend_follow"
             self.current_params_file = "config/trend.yml"
         self.mode_reason = ""
+        default_limit = int(env_loader.get_env("MAX_AI_CALLS_PER_LOOP", "1"))
+        set_call_limit(4 if self.trade_mode == "scalp_momentum" else default_limit)
 
         # Restore TP adjustment flags based on existing TP order comment
         try:
@@ -584,6 +587,8 @@ class JobRunner:
         try:
             logger.info("Reloading params from %s", config_file)
             params_loader.load_params(path=config_file)
+            default_limit = int(env_loader.get_env("MAX_AI_CALLS_PER_LOOP", "1"))
+            set_call_limit(4 if mode == "scalp_momentum" else default_limit)
             self.current_params_file = config_file
         except Exception as exc:
             logger.error("Param reload failed: %s", exc)


### PR DESCRIPTION
## Summary
- introduce `set_call_limit()` in OpenAI client to update per-loop call cap
- call `set_call_limit()` on startup and when reloading params in job runner and core runner
- treat 0 or negative `MAX_AI_CALLS_PER_LOOP` as unlimited
- adjust unit test stubs for new helper

## Testing
- `./run_tests.sh` *(fails: ImportError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a20d57a048333b21bdc4688112f80