### PR TITLE
Update weight_last formula

### DIFF
--- a/backend/indicators/calculate_indicators.py
+++ b/backend/indicators/calculate_indicators.py
@@ -79,8 +79,9 @@ def calculate_indicators(
         complete_vols = [float(c.get('volume', 0)) for c in market_data if c.get('complete')]
     recent_vols = complete_vols[-6:]
     vol_avg = sum(recent_vols) / len(recent_vols) if recent_vols else 0.0
-    vol_ratio = (vol_last / vol_avg) if vol_avg else 1.0
-    weight_last = min(1.0, 0.5 + 0.5 * vol_ratio)
+    # 平均値が得られない場合は 0.5 を用いる
+    vol_ratio = (vol_last / vol_avg) if vol_avg else 0.5
+    weight_last = 0.5 + 0.5 * vol_ratio
 
     import logging
     logger = logging.getLogger(__name__)

--- a/backend/tests/test_weight_last.py
+++ b/backend/tests/test_weight_last.py
@@ -75,7 +75,7 @@ class TestWeightLast(unittest.TestCase):
     def test_weight_last_zero_avg(self):
         data = [_c(0, True) for _ in range(6)] + [_c(0, False)]
         result = self.ci.calculate_indicators(data)
-        self.assertEqual(result.get("weight_last"), 1.0)
+        self.assertEqual(result.get("weight_last"), 0.75)
 
     def test_weight_last_zero_volume(self):
         data = [_c(100, True) for _ in range(6)] + [_c(0, False)]
@@ -85,7 +85,7 @@ class TestWeightLast(unittest.TestCase):
     def test_weight_last_clamped(self):
         data = [_c(100, True) for _ in range(6)] + [_c(400, False)]
         result = self.ci.calculate_indicators(data)
-        self.assertEqual(result.get("weight_last"), 1.0)
+        self.assertEqual(result.get("weight_last"), 2.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- tweak volume ratio fallback to 0.5
- remove weight_last clamp and update formula
- adjust expectations in weight_last tests

## Testing
- `pytest -q backend/tests/test_weight_last.py`
- `bash run_tests.sh backend/tests/test_weight_last.py` *(fails: building hdbscan canceled)*

------
https://chatgpt.com/codex/tasks/task_e_684a339d9f5c83338f0df9ec262f07d2