### PR TITLE
Remove AI call counter

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -19,7 +19,7 @@ from backend.utils import env_loader, trade_age_seconds
 from backend.core.ai_throttle import get_cooldown
 from backend.utils.restart_guard import can_restart
 from maintenance.disk_guard import maybe_cleanup
-from backend.utils.openai_client import reset_ai_call_counter, set_call_limit
+from backend.utils.openai_client import set_call_limit
 
 try:
     from config import params_loader
@@ -1108,7 +1108,6 @@ class JobRunner:
         while not self._stop:
             try:
                 maybe_cleanup()
-                reset_ai_call_counter()
                 timer = PerfTimer("job_loop")
                 now = datetime.now(timezone.utc)
                 # ---- Market‑hours guard ---------------------------------

--- a/backend/utils/openai_client.py
+++ b/backend/utils/openai_client.py
@@ -41,30 +41,11 @@ _CACHE_TTL_SEC = int(env_loader.get_env("OPENAI_CACHE_TTL_SEC", "30"))
 _CACHE_MAX = int(env_loader.get_env("OPENAI_CACHE_MAX", "100"))
 
 # --- AI 呼び出し制御 ----------------------------
-_CALL_LIMIT_PER_LOOP = int(env_loader.get_env("MAX_AI_CALLS_PER_LOOP", "1"))
-_calls_this_loop = 0
 
 
-def reset_ai_call_counter() -> None:
-    """Reset the AI call counter (JobRunner が各ループ開始時に呼び出す)."""
-    global _calls_this_loop
-    _calls_this_loop = 0
-
-
-def _register_ai_call() -> bool:
-    """Return True if a new AI call is allowed in this loop."""
-    global _calls_this_loop
-    if _CALL_LIMIT_PER_LOOP > 0 and _calls_this_loop >= _CALL_LIMIT_PER_LOOP:
-        logger.info("AI call skipped due to per-loop limit")
-        return False
-    _calls_this_loop += 1
-    return True
-
-
-def set_call_limit(limit: int) -> None:
-    """Update the per-loop AI call limit."""
-    global _CALL_LIMIT_PER_LOOP
-    _CALL_LIMIT_PER_LOOP = int(limit)
+def set_call_limit(_limit: int) -> None:
+    """Deprecated stub retained for backward compatibility."""
+    return None
 
 def ask_openai(
     prompt: str,
@@ -89,9 +70,6 @@ def ask_openai(
     Raises:
         Exception: If the API request fails.
     """
-    # ループ開始時に呼び出し許可を確認
-    if not _register_ai_call():
-        return {}
 
     # Use env‑defined default when caller does not specify
     if model is None:
@@ -162,6 +140,5 @@ __all__ = [
     "ask_openai",
     "ask_openai_async",
     "AI_MODEL",
-    "reset_ai_call_counter",
     "set_call_limit",
 ]


### PR DESCRIPTION
## Summary
- remove call counter functionality from OpenAI client
- drop calls to removed reset function

## Testing
- `pytest backend/tests/test_openai_cache_limit.py::TestOpenAICacheLimit::test_cache_evicts_oldest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a33a68c1883338a82415bedaf6678