### PR TITLE
Fix market condition reference

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1431,6 +1431,9 @@ Respond with **one-line valid JSON** exactly as:
         logger.info("Invalid JSON response: %s", raw)
         return {"entry": {"side": "no"}, "raw": raw, "reason": "PARSE_FAIL"}
 
+    # AIが返したレジーム情報を取り出す
+    market_cond = plan.get("regime")
+
     if plan.get("entry", {}).get("side") == "no":
         why = plan.get("why") or plan.get("entry", {}).get("why")
         if isinstance(why, str) and why:


### PR DESCRIPTION
## Summary
- handle market regime info from the plan before computing entry type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684a39607c488333b1e6655dcf222e00