### PR TITLE
Add DB exit sync manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ TRADES_DB_PATH=trades-002.db
 `backend.logs.update_oanda_trades` を走らせると最新履歴が保存されます。
 ローカルの `trades` テーブルと OANDA の取引履歴を突き合わせて
 実現損益を反映させるには `backend.logs.reconcile_trades` を実行します。
+履歴更新から反映までを一度に行う場合は
+`execution.sync_manager.sync_exits()` を呼び出してください。
 分割エントリーに関する解説は `docs/scale_entry.md` にまとめています。
 エントリーフィルタの詳細は `docs/entry_filter.md` を参照してください。
 高位足の使い方に関する補足は `docs/higher_tf_strategy.md` を参照してください。

--- a/execution/sync_manager.py
+++ b/execution/sync_manager.py
@@ -1,0 +1,21 @@
+import logging
+
+from backend.logs.update_oanda_trades import update_oanda_trades
+from backend.logs.reconcile_trades import reconcile_trades
+
+logger = logging.getLogger(__name__)
+
+
+def sync_exits() -> None:
+    """Update trade exits using OANDA history."""
+    logger.info("Updating oanda_trades from API")
+    try:
+        update_oanda_trades()
+    except Exception as exc:  # network or auth error
+        logger.warning("update_oanda_trades failed: %s", exc)
+    logger.info("Reconciling local trades table")
+    reconcile_trades()
+
+
+if __name__ == "__main__":
+    sync_exits()

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -1,0 +1,57 @@
+import os
+import sqlite3
+import importlib
+import tempfile
+
+import pytest
+
+
+def test_sync_exits_updates_db(monkeypatch):
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    os.environ["TRADES_DB_PATH"] = tmp.name
+
+    import backend.logs.log_manager as lm
+    import backend.logs.reconcile_trades as rt
+    import execution.sync_manager as sm
+
+    importlib.reload(lm)
+    importlib.reload(rt)
+    importlib.reload(sm)
+
+    monkeypatch.setattr(sm, "update_oanda_trades", lambda: None)
+
+    lm.init_db()
+    conn = lm.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO trades (instrument, entry_time, entry_price, units) VALUES (?,?,?,?)",
+        ("EUR_USD", "2024-01-01T00:00:00Z", 1.0, 1000),
+    )
+    cur.execute(
+        """
+        INSERT INTO oanda_trades (
+            trade_id, account_id, instrument, open_time, close_time,
+            open_price, close_price, units, realized_pl, state, tp_price, sl_price
+        ) VALUES (1, 'abc', 'EUR_USD', '2024-01-01T00:00:05Z',
+                   '2024-01-01T01:00:00Z', 1.0, 1.1, 1000, 1.5, 'CLOSED', NULL, NULL)
+        """,
+    )
+    conn.commit()
+    conn.close()
+
+    sm.sync_exits()
+
+    conn = lm.get_db_connection()
+    row = conn.execute(
+        "SELECT exit_time, exit_price, profit_loss FROM trades WHERE trade_id = 1"
+    ).fetchone()
+    conn.close()
+
+    os.unlink(tmp.name)
+    os.environ.pop("TRADES_DB_PATH", None)
+
+    assert row[0] == "2024-01-01T01:00:00Z"
+    assert abs(row[1] - 1.1) < 1e-8
+    assert abs(row[2] - 1.5) < 1e-8
+


### PR DESCRIPTION
## Summary
- add `execution.sync_manager.sync_exits` helper
- document usage in README
- add unit test for the sync manager

## Testing
- `./run_tests.sh` *(fails: 31 failed, 65 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684a3b3cfc008333a8d95eb171ca2b19