### PR TITLE
Implement mode selector utilities

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,3 +1,5 @@
+from .llm_mode_selector import select_mode_llm
+from .mode_preclassifier import classify_regime
 from .trade_patterns import calculate_trade_score
 
-__all__ = ["calculate_trade_score"]
+__all__ = ["calculate_trade_score", "classify_regime", "select_mode_llm"]

--- a/analysis/llm_mode_selector.py
+++ b/analysis/llm_mode_selector.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""LLM を用いたモード選択ラッパー."""
+
+import json
+import logging
+from pathlib import Path
+
+import yaml
+
+from backend.utils import ai_parse
+from backend.utils.openai_client import ask_openai
+
+logger = logging.getLogger(__name__)
+
+_cfg: dict | None = None
+
+
+def _load_cfg() -> dict:
+    global _cfg
+    if _cfg is None:
+        path = Path(__file__).resolve().parents[1] / "config" / "strategy.yml"
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                _cfg = yaml.safe_load(f) or {}
+        except Exception:
+            _cfg = {}
+    return _cfg
+
+
+_cfg = _load_cfg()
+_MODEL = _cfg.get("LLM", {}).get("mode_selector", "gpt-3.5-turbo-0125")
+_SYSTEM_PROMPT = (
+    "You are a FX trading mode selector. "
+    "Return one of ['trend_follow','scalp_momentum','no_trade'] "
+    'in JSON: {"mode":"..."}'
+)
+
+
+def select_mode_llm(features: dict) -> str:
+    """LLM を利用してモードを選択する."""
+    try:
+        raw = ask_openai(
+            json.dumps(features),
+            system_prompt=_SYSTEM_PROMPT,
+            model=_MODEL,
+            temperature=0.0,
+        )
+        data, err = ai_parse.parse_json_answer(raw)
+        if err:
+            return "no_trade"
+        mode = str(data.get("mode"))
+        if mode in {"trend_follow", "scalp_momentum", "no_trade"}:
+            return mode
+    except Exception as exc:
+        logger.error("select_mode_llm failed: %s", exc)
+    return "no_trade"
+
+
+__all__ = ["select_mode_llm"]

--- a/analysis/mode_preclassifier.py
+++ b/analysis/mode_preclassifier.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""単純なADX/ATRベースの取引レジーム判定モジュール."""
+
+from pathlib import Path
+
+import yaml
+
+# 設定読み込み
+_cfg: dict | None = None
+
+
+def _load_cfg() -> dict:
+    global _cfg
+    if _cfg is None:
+        path = Path(__file__).resolve().parents[1] / "config" / "strategy.yml"
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                _cfg = yaml.safe_load(f) or {}
+        except Exception:
+            _cfg = {}
+    return _cfg
+
+
+_cfg = _load_cfg()
+_GRAY_BAND = tuple(float(x) for x in _cfg.get("GRAY_ADX_BAND", [25, 30]))
+
+
+def classify_regime(features: dict) -> str:
+    """ADX と ATR 指標から市場状態を分類する."""
+    adx = float(features.get("adx", 0.0))
+    atr_pct = float(features.get("atr_pct", 0.0))  # 未使用だが将来拡張用に保持
+    atr_percentile = float(features.get("atr_percentile", 100.0))
+
+    if atr_percentile < 10:
+        return "no_trade"
+    if adx >= _GRAY_BAND[1]:
+        return "trend"
+    if adx <= _GRAY_BAND[0] - 5:
+        return "range"
+    return "gray"
+
+
+__all__ = ["classify_regime"]

--- a/config/strategy.yml
+++ b/config/strategy.yml
@@ -26,10 +26,8 @@ order:
 
 LLM:
   mode_selector: gpt-3.5-turbo-0125
-  entry_logic: gpt-4.1-nano
-  exit_logic: gpt-4.1-nano
+  entry_logic: gpt-4o-nano
+  exit_logic: gpt-4o-nano
 
-GRAY_ADX_BAND:
-  - 25
-  - 30
+GRAY_ADX_BAND: [25, 30]
 SCALP_THRESHOLD: 0.30

--- a/tests/test_mode_selector.py
+++ b/tests/test_mode_selector.py
@@ -1,0 +1,27 @@
+import importlib
+
+from analysis import llm_mode_selector as lm
+from analysis import mode_preclassifier as mp
+from backend.utils import openai_client
+
+
+def test_classify_regime_boundary():
+    feat = {"adx": 35, "atr_percentile": 50, "atr_pct": 20}
+    assert mp.classify_regime(feat) == "trend"
+    feat["adx"] = 19
+    assert mp.classify_regime(feat) == "range"
+    feat["adx"] = 27
+    assert mp.classify_regime(feat) == "gray"
+    feat["atr_percentile"] = 5
+    assert mp.classify_regime(feat) == "no_trade"
+
+
+def test_llm_fallback(monkeypatch):
+    monkeypatch.setattr(lm, "ask_openai", lambda *a, **k: {"mode": "trend_follow"})
+    assert lm.select_mode_llm({}) == "trend_follow"
+
+    def raise_err(*_a, **_k):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(lm, "ask_openai", raise_err)
+    assert lm.select_mode_llm({}) == "no_trade"


### PR DESCRIPTION
## Summary
- update default models in strategy.yml
- add a regime pre-classifier using ADX & ATR
- add LLM-based mode selector wrapper
- integrate new logic into composite trade mode
- expose helpers via analysis package
- test new classifier and LLM selector

## Testing
- `isort analysis/llm_mode_selector.py analysis/mode_preclassifier.py analysis/__init__.py signals/composite_mode.py tests/test_mode_selector.py`
- `black tests/test_mode_selector.py analysis/llm_mode_selector.py analysis/mode_preclassifier.py analysis/__init__.py signals/composite_mode.py`
- `pytest -q tests/test_mode_selector.py`
- `pytest -q` *(fails: 31 failed, 65 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684a97ea4790833385c95a910e537922