### PR TITLE
Improve AI trade logic

### DIFF
--- a/backend/risk_manager.py
+++ b/backend/risk_manager.py
@@ -91,7 +91,7 @@ def calc_short_sl_price(
     except Exception:
         return None
 
-def cost_guard(tp_pips: float | None, spread_pips: float) -> bool:
+def cost_guard(tp_pips: float | None, spread_pips: float, *, noise_pips: float | None = None) -> bool:
     """Return True if net take-profit after spread meets threshold."""
     from backend.utils import env_loader
 
@@ -100,8 +100,10 @@ def cost_guard(tp_pips: float | None, spread_pips: float) -> bool:
         spread = float(spread_pips)
         if tp is None:
             return True
-        min_net = float(env_loader.get_env("MIN_NET_TP_PIPS", "1"))
-        return (tp - spread) >= min_net
+        base_min = float(env_loader.get_env("MIN_NET_TP_PIPS", "1"))
+        if noise_pips is not None:
+            base_min = max(base_min, float(noise_pips) * 0.6)
+        return (tp - spread) >= base_min
     except Exception:
         return True
 

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -38,6 +38,22 @@ from backend.strategy.exit_ai_decision import AIDecision, evaluate as evaluate_e
 import time
 from datetime import datetime, timezone
 
+
+def _is_schema_valid(plan: dict) -> bool:
+    """Return True if required probability fields sum to one."""
+    try:
+        conf = float(plan.get("entry_confidence", 0))
+        if not 0.0 <= conf <= 1.0:
+            return False
+        probs = plan.get("probs")
+        if not isinstance(probs, dict):
+            return False
+        vals = [float(probs.get(k, 0)) for k in ("long", "short", "no")]
+        total = sum(vals)
+        return abs(total - 1.0) <= 0.01
+    except Exception:
+        return False
+
 macro_analyzer = MacroAnalyzer()
 
 # ----------------------------------------------------------------------
@@ -1430,6 +1446,16 @@ Respond with **one-line valid JSON** exactly as:
             logger.warning("log_ai_decision failed: %s", exc)
         logger.info("Invalid JSON response: %s", raw)
         return {"entry": {"side": "no"}, "raw": raw, "reason": "PARSE_FAIL"}
+    if not _is_schema_valid(plan):
+        try:
+            raw_retry = ask_model(prompt, model=env_loader.get_env("AI_TRADE_MODEL", "gpt-4o-nano"))
+            plan_retry, _ = parse_json_answer(raw_retry)
+            if plan_retry and _is_schema_valid(plan_retry):
+                plan = plan_retry
+            else:
+                logger.warning("Schema validation failed twice")
+        except Exception:
+            logger.warning("Retry after schema validation failed")
 
     # AIが返したレジーム情報を取り出す
     market_cond = plan.get("regime")
@@ -1566,7 +1592,13 @@ Respond with **one-line valid JSON** exactly as:
                 plan["reason"] = "PROB_INVALID"
                 return plan
 
-            if (tp - spread) < MIN_NET_TP_PIPS:
+            min_net = MIN_NET_TP_PIPS
+            if noise_pips is not None:
+                try:
+                    min_net = max(min_net, noise_pips * 0.6)
+                except Exception:
+                    pass
+            if (tp - spread) < min_net:
                 plan["entry"]["side"] = "no"
                 plan.setdefault("reason", "NET_TP_TOO_SMALL")
         except (TypeError, ValueError):

--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -12,7 +12,9 @@ MIN_TP_PROB = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
 TP_PROB_HOURS = int(env_loader.get_env("TP_PROB_HOURS", "24"))
 MIN_RRR = float(env_loader.get_env("MIN_RRR", "0.8"))
 MIN_NET_TP_PIPS = float(env_loader.get_env("MIN_NET_TP_PIPS", "1"))
-TREND_ADX_THRESH = float(env_loader.get_env("TREND_ADX_THRESH", "20"))
+TREND_ADX_THRESH = float(
+    env_loader.get_env("TREND_ADX_THRESH", env_loader.get_env("ADX_TREND_THR", "25"))
+)
 TREND_PROMPT_BIAS = env_loader.get_env("TREND_PROMPT_BIAS", "normal").lower()
 # レンジ相場でのトレード方針を任意に追記できる環境変数
 RANGE_ENTRY_NOTE = env_loader.get_env(

--- a/backend/tests/test_risk_manager.py
+++ b/backend/tests/test_risk_manager.py
@@ -44,8 +44,8 @@ class TestRiskManager(unittest.TestCase):
     def test_cost_guard(self):
         import os
         os.environ["MIN_NET_TP_PIPS"] = "2"
-        self.assertTrue(cost_guard(5, 2))
-        self.assertFalse(cost_guard(3, 2.5))
+        self.assertTrue(cost_guard(5, 2, noise_pips=1.0))
+        self.assertFalse(cost_guard(3, 2.5, noise_pips=1.0))
         os.environ.pop("MIN_NET_TP_PIPS", None)
 
 


### PR DESCRIPTION
## Summary
- sync trend ADX threshold with local config
- scale cost guard by noise and expose `noise_pips` parameter
- derive noise in `entry_logic` and skip trend-follow on reversal
- validate AI JSON schema and retry once
- tighten net TP check using noise
- update risk manager tests

## Testing
- `./run_tests.sh` *(fails: 31 failed, 65 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684ab5800f148333b411644f39e12c86