### PR TITLE
Include scalp_reversion in mode selection

### DIFF
--- a/analysis/llm_mode_selector.py
+++ b/analysis/llm_mode_selector.py
@@ -32,7 +32,7 @@ _cfg = _load_cfg()
 _MODEL = _cfg.get("LLM", {}).get("mode_selector", "gpt-3.5-turbo-0125")
 _SYSTEM_PROMPT = (
     "You are a FX trading mode selector. "
-    "Return one of ['trend_follow','scalp_momentum','no_trade'] "
+    "Return one of ['trend_follow','scalp_momentum','scalp_reversion','no_trade'] "
     'in JSON: {"mode":"..."}'
 )
 
@@ -50,7 +50,7 @@ def select_mode_llm(features: dict) -> str:
         if err:
             return "no_trade"
         mode = str(data.get("mode"))
-        if mode in {"trend_follow", "scalp_momentum", "no_trade"}:
+        if mode in {"trend_follow", "scalp_momentum", "scalp_reversion", "no_trade"}:
             return mode
     except Exception as exc:
         logger.error("select_mode_llm failed: %s", exc)

--- a/signals/composite_mode.py
+++ b/signals/composite_mode.py
@@ -374,7 +374,7 @@ def decide_trade_mode_detail(
 
 def map_llm(llm_mode: str) -> str:
     """LLM からの出力を正規化する."""
-    if llm_mode in {"trend_follow", "scalp_momentum", "no_trade"}:
+    if llm_mode in {"trend_follow", "scalp_momentum", "scalp_reversion", "no_trade"}:
         return llm_mode
     return "no_trade"
 

--- a/tests/test_mode_selector.py
+++ b/tests/test_mode_selector.py
@@ -20,6 +20,9 @@ def test_llm_fallback(monkeypatch):
     monkeypatch.setattr(lm, "ask_openai", lambda *a, **k: {"mode": "trend_follow"})
     assert lm.select_mode_llm({}) == "trend_follow"
 
+    monkeypatch.setattr(lm, "ask_openai", lambda *a, **k: {"mode": "scalp_reversion"})
+    assert lm.select_mode_llm({}) == "scalp_reversion"
+
     def raise_err(*_a, **_k):
         raise RuntimeError("fail")
 


### PR DESCRIPTION
## Summary
- allow LLM to return `scalp_reversion`
- normalize `scalp_reversion` in `map_llm`
- test LLM selector handles `scalp_reversion`

## Testing
- `pytest tests/test_mode_selector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab5a664308333b191263e39766246