### PR TITLE
Update bias note for build_trade_plan

### DIFF
--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -274,8 +274,9 @@ def build_trade_plan_prompt(
     bias_note = ""
     if bias == "aggressive":
         # 条件が曖昧な場合でも積極的にポジションを示すよう指示
+        # "sell" を併記しているのはショートを意味することを明確にするため
         bias_note = (
-            "\nBe strongly proactive: unless risk rules clearly prohibit, choose 'long' or 'short' instead of 'no'. "
+            "\nBe strongly proactive: unless risk rules clearly prohibit, choose 'long' or 'short (sell)' instead of 'no'. "
             "Return 'no' only when absolutely no valid setup exists."
         )
     prompt += bias_note


### PR DESCRIPTION
## Summary
- clarify the aggressive bias note
- explicitly mention `short (sell)` in the prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684ac1c275ac83339f59f539d61ebdbc