### PR TITLE
Check bias before trend retry

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -531,9 +531,11 @@ def process_entry(
     )
 
     # -- "no" の場合は攻めたバイアスで再試行 --------------------
+    # ただし TREND_PROMPT_BIAS が aggressive のときは同じプロンプトを繰り返さない
     if (
         plan.get("entry", {}).get("side", "no").lower() not in ("long", "short")
         and env_loader.get_env("AI_RETRY_ON_NO", "false").lower() == "true"
+        and env_loader.get_env("TREND_PROMPT_BIAS", "normal").lower() != "aggressive"
     ):
         plan = oa.get_trade_plan(
             market_data,


### PR DESCRIPTION
## Summary
- skip aggressive retry if TREND_PROMPT_BIAS is already aggressive
- add Japanese comment about skipping the retry

## Testing
- `pytest -k prompt_bias -q` *(fails: openai package is required)*

------
https://chatgpt.com/codex/tasks/task_e_684ac1c3f0008333a6299ca10c9839f0