### PR TITLE
Implement dynamic TP probability

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -66,6 +66,10 @@ AI_REGIME_COOLDOWN_SEC: int = int(env_loader.get_env("AI_REGIME_COOLDOWN_SEC", A
 
 # --- Threshold for AI‑proposed TP probability ---
 MIN_TP_PROB: float = float(env_loader.get_env("MIN_TP_PROB", "0.75"))
+DYN_TP_PROB_FLOOR: float = float(env_loader.get_env("DYN_TP_PROB_FLOOR", "0.55"))
+DYN_TP_PROB_CEIL: float = float(
+    env_loader.get_env("DYN_TP_PROB_CEIL", str(MIN_TP_PROB))
+)
 TP_PROB_HOURS: int = int(env_loader.get_env("TP_PROB_HOURS", "24"))
 PROB_MARGIN: float = float(env_loader.get_env("PROB_MARGIN", "0.1"))
 MIN_EXPECTED_VALUE: float = float(
@@ -1132,6 +1136,13 @@ def get_trade_plan(
     except Exception:
         noise_pips = None
 
+    # noise_pips を用いて動的な TP 達成確率下限を算出
+    try:
+        dynamic_min_tp_prob = max(DYN_TP_PROB_FLOOR, (noise_pips or 0) * 0.6)
+        dynamic_min_tp_prob = min(dynamic_min_tp_prob, DYN_TP_PROB_CEIL)
+    except Exception:
+        dynamic_min_tp_prob = DYN_TP_PROB_CEIL
+
     noise_val = f"{noise_pips:.1f}" if noise_pips is not None else "N/A"
     tv_score = "N/A"
     comp_val = None
@@ -1608,7 +1619,7 @@ Respond with **one-line valid JSON** exactly as:
             plan["reason"] = "RISK_PARSE_FAIL"
             return plan
 
-        if p < MIN_TP_PROB or (tp * p - sl * q) < MIN_EXPECTED_VALUE:
+        if p < dynamic_min_tp_prob or (tp * p - sl * q) < MIN_EXPECTED_VALUE:
             plan["entry"]["side"] = "no"
             plan.setdefault("reason", "PROB_TOO_LOW")
 

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -178,6 +178,14 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 
   スプレッド控除後に許容される最小TP幅(pips)。デフォルトは1。
 
+### DYN_TP_PROB_FLOOR / DYN_TP_PROB_CEIL
+
+  `noise_pips` を用いて算出される動的な TP 達成確率の下限値・上限値を設定
+  する。計算式は `dynamic_min_tp_prob = max(DYN_TP_PROB_FLOOR, noise_pips * 0.6)`
+  で求めた値を DYN_TP_PROB_CEIL 以下に切り詰める。
+  DYN_TP_PROB_FLOOR のデフォルトは 0.55、DYN_TP_PROB_CEIL のデフォルトは
+  MIN_TP_PROB。
+
 # 以下は README に記載されていた追加の環境変数
 
 - RANGE_CENTER_BLOCK_PCT: ADX が ADX_RANGE_THRESHOLD 以下のとき、BB 中心付近のエントリーをどの程度ブロックするか (0.3 = 30%)


### PR DESCRIPTION
## Summary
- add environment variables `DYN_TP_PROB_FLOOR` and `DYN_TP_PROB_CEIL`
- compute `dynamic_min_tp_prob` based on `noise_pips`
- reject entries when `tp_prob` is below this dynamic minimum
- document the new calculation in `docs/env_vars.md`

## Testing
- `./run_tests.sh` *(fails: 31 failed, 65 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684ac01cdde48333a903488b7eab9ed8