### PR TITLE
Add candle summary option to trade plan prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ TRADES_DB_PATH=trades-002.db
    contracting*.
 `ENABLE_RANGE_ENTRY` を `true` にすると、ADX のノートレード判定を無視してレンジ相場でもエントリーを許可します。価格がボリンジャーバンド中心から `RANGE_ENTRY_OFFSET_PIPS` pips 以内にある場合は、市場注文をバンド端の LIMIT に変換します。この処理は `backend/strategy/entry_logic.py` で行われます。
 `RANGE_ENTRY_NOTE` を指定すると、その内容が AI プロンプトに追記され、レンジ相場での細かな指示を外部から設定できます。
+`USE_CANDLE_SUMMARY` を `true` にすると、ローソク足リストの代わりに平均値まとめを AI へ送信し、トークン消費を抑えられます。
 `AI_PROFIT_TRIGGER_RATIO` defines what portion of the take-profit target must
 be reached before an AI exit check occurs. The default value is `0.5` (50%).
 `SCALE_LOT_SIZE` sets how many lots are added when the AI exit decision is `SCALE`.

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -39,6 +39,7 @@ SL_COOLDOWN_SEC=300              # SL後の再エントリー待機秒
 # === ローソク足設定 ===
 CANDLE_GRANULARITY=M5            # 主軸となる足種
 TRADE_TIMEFRAMES=S10:60,M1:20,M5:50,M15:50,H1:120,H4:90,D:90  # 取得する時間足
+USE_CANDLE_SUMMARY=false        # ローソク足を平均値で要約してプロンプトに渡す
 
 # === Exitフィルタ ===
 RSI_EXIT_LOWER=30                # RSIがこの値以下で利確検討

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -28,6 +28,8 @@ from backend.risk_manager import (
 )
 
 from backend.strategy.openai_prompt import build_trade_plan_prompt, TREND_ADX_THRESH
+
+USE_CANDLE_SUMMARY = env_loader.get_env("USE_CANDLE_SUMMARY", "false").lower() == "true"
 from backend.strategy.validators import normalize_probs, risk_autofix
 from backend.config.defaults import MIN_ABS_SL_PIPS
 
@@ -1271,6 +1273,7 @@ def get_trade_plan(
         higher_tf_direction=higher_tf_direction,
         trend_prompt_bias=trend_prompt_bias,
         trade_mode=trade_mode,
+        summarize_candles=USE_CANDLE_SUMMARY,
     )
     pattern_text = f"\n### Detected Chart Pattern\n{pattern_line}\n" if pattern_line else "\n### Detected Chart Pattern\nNone\n"
     # ADX が高い場合はプルバック不要メッセージを追加する

--- a/backend/tests/test_candle_summary.py
+++ b/backend/tests/test_candle_summary.py
@@ -1,0 +1,65 @@
+import os
+import importlib
+import unittest
+
+class FakeSeries:
+    def __init__(self, data=None):
+        self._data = list(data or [])
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+        self.iloc = _ILoc(self)
+    def __getitem__(self, idx):
+        return self._data[idx]
+    def __len__(self):
+        return len(self._data)
+
+def _ind():
+    return {
+        "rsi": FakeSeries([50]*20),
+        "atr": FakeSeries([0]*20),
+        "adx": FakeSeries([20]*20),
+        "bb_upper": FakeSeries([1]*20),
+        "bb_lower": FakeSeries([0]*20),
+        "ema_fast": FakeSeries([1]*20),
+        "ema_slow": FakeSeries([1]*20),
+    }
+
+class TestCandleSummary(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault("OPENAI_API_KEY", "dummy")
+        pandas_stub = importlib.import_module("types").ModuleType("pandas")
+        pandas_stub.Series = FakeSeries
+        import sys
+        sys.modules["pandas"] = pandas_stub
+        import backend.strategy.openai_prompt as op
+        importlib.reload(op)
+        self.op = op
+
+    def test_summary_included(self):
+        ind = _ind()
+        candles = [{"mid": {"o": 1, "h": 1, "l": 0, "c": 1}}]*20
+        prompt, _ = self.op.build_trade_plan_prompt(
+            ind, ind, ind, ind,
+            candles, candles, candles, candles,
+            {}, None,
+            False,
+            summarize_candles=True,
+        )
+        self.assertIn('"open_avg":1.0', prompt)
+
+    def test_summary_disabled_by_default(self):
+        ind = _ind()
+        candles = [{"mid": {"o": 1, "h": 1, "l": 0, "c": 1}}]*20
+        prompt, _ = self.op.build_trade_plan_prompt(
+            ind, ind, ind, ind,
+            candles, candles, candles, candles,
+            {}, None,
+            False,
+        )
+        self.assertNotIn('"open_avg":1.0', prompt)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -301,6 +301,7 @@ SCALE_TRIGGER_ATR=0.5
 - USE_LOCAL_MODEL: OpenAI APIの代わりにローカルモデルを使用するか (true/false)
 - LOCAL_MODEL_NAME: 使用するローカルモデル名 (例: distilgpt2)
 - USE_LOCAL_PATTERN: チャートパターン検出をローカルで行うか (true/false)
+- USE_CANDLE_SUMMARY: ローソク足情報を平均値で要約して AI へ渡すか (true/false)
 - FRED_API_KEY: 米国経済指標取得に使用するFRED APIキー
 - KAFKA_SERVERS: Kafkaブローカーの接続先リスト (例: localhost:9092)
   - KAFKA_BROKERS や KAFKA_BROKER_URL、KAFKA_BOOTSTRAP_SERVERS でも同じ値を指定可能

--- a/prompts/trade_plan_instruction.txt
+++ b/prompts/trade_plan_instruction.txt
@@ -87,6 +87,10 @@ EMA_s: {d1_ema_s}
 ### D1 Candles
 {candles_d1_tail}
 
+### Candle Summary
+{candle_summary}
+# Example: {{"m5": {{"open_avg": 1.2345, "close_last": 1.2360}}}}
+
 {adx_snapshot}{pattern_text}{direction_line}
 ### How to use the provided candles:
 - Use the medium-term view (50 candles) to understand the general market trend, key support/resistance levels, and to avoid noisy, short-lived moves.


### PR DESCRIPTION
## Summary
- support summarizing candle data in `build_trade_plan_prompt`
- toggle with `USE_CANDLE_SUMMARY` environment variable
- document the new option and update sample settings
- include example in `trade_plan_instruction.txt`
- add regression tests for the summary feature

## Testing
- `pytest -q backend/tests/test_candle_summary.py`

------
https://chatgpt.com/codex/tasks/task_e_684ac318315c8333a127b67f15d9ae08