### PR TITLE
Implement majority-vote trading flow

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -294,3 +294,15 @@ ACCOUNT_BALANCE=130000
 ENTRY_RISK_PCT=0.5
 MAX_CVAR=0
 FORCE_CLOSE_ON_RISK=false
+
+# === Strategy ensembles ===
+STRAT_TEMP=0.15
+STRAT_N=3
+STRAT_VOTE_MIN=2
+
+# === Entry vertical ensemble ===
+ENTRY_BUFFER_K=3
+
+# === Regime detection ===
+REGIME_ADX_TREND=30
+REGIME_BB_NARROW=0.05

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -347,3 +347,12 @@ SCALE_TRIGGER_ATR=0.5
 - **ENTRY_RISK_PCT**: 1トレードあたりのリスク許容比率 (デフォルト: 0.01)
 - **PIP_VALUE_JPY**: 1pipあたりの円換算値 (デフォルト: 100)
 - **MARGIN_WARNING_THRESHOLD**: 証拠金アラートを出す残高比率 (デフォルト: 0)
+
+## 多数決フロー関連
+
+- **STRAT_TEMP**: Strategy Select で使う temperature。
+- **STRAT_N**: Strategy Select の生成本数。
+- **STRAT_VOTE_MIN**: 採用に必要な一致数。
+- **ENTRY_BUFFER_K**: Entry Plan を平均化するバッファ長。
+- **REGIME_ADX_TREND**: Regime 判定でトレンドとみなすADX値。
+- **REGIME_BB_NARROW**: Range 判定で用いるBB幅の閾値。

--- a/piphawk_ai/vote_arch/__init__.py
+++ b/piphawk_ai/vote_arch/__init__.py
@@ -1,0 +1,21 @@
+"""Majority-vote trading pipeline components."""
+from .regime_detector import MarketMetrics, rule_based_regime
+from .ai_strategy_selector import select_strategy
+from .trade_mode_selector import choose_mode
+from .ai_entry_plan import generate_plan, EntryPlan
+from .entry_buffer import PlanBuffer
+from .post_filters import final_filter
+from .market_air_sensor import MarketSnapshot, air_index
+
+__all__ = [
+    "MarketMetrics",
+    "rule_based_regime",
+    "select_strategy",
+    "choose_mode",
+    "generate_plan",
+    "EntryPlan",
+    "PlanBuffer",
+    "final_filter",
+    "MarketSnapshot",
+    "air_index",
+]

--- a/piphawk_ai/vote_arch/ai_entry_plan.py
+++ b/piphawk_ai/vote_arch/ai_entry_plan.py
@@ -1,0 +1,38 @@
+"""Deterministic entry plan generation via OpenAI."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.utils import env_loader
+from backend.utils.openai_client import ask_openai
+
+AI_ENTRY_MODEL = env_loader.get_env("AI_ENTRY_MODEL", "gpt-4.1-nano")
+
+@dataclass
+class EntryPlan:
+    side: str
+    tp: float
+    sl: float
+    lot: float
+
+
+def generate_plan(prompt: str) -> EntryPlan | None:
+    """Return EntryPlan from AI."""
+    resp = ask_openai(
+        prompt,
+        system_prompt="You are a trading entry planner.",
+        model=AI_ENTRY_MODEL,
+        temperature=0.0,
+        response_format={"type": "json_object"},
+    )
+    try:
+        return EntryPlan(
+            side=str(resp["side"]),
+            tp=float(resp["tp"]),
+            sl=float(resp["sl"]),
+            lot=float(resp.get("lot", 1.0)),
+        )
+    except Exception:
+        return None
+
+__all__ = ["EntryPlan", "generate_plan"]

--- a/piphawk_ai/vote_arch/ai_strategy_selector.py
+++ b/piphawk_ai/vote_arch/ai_strategy_selector.py
@@ -1,0 +1,36 @@
+"""Select trade strategy via OpenAI and majority vote."""
+from __future__ import annotations
+
+from collections import Counter
+
+from backend.utils.openai_client import ask_openai
+from backend.utils import env_loader
+
+AI_STRATEGY_MODEL = env_loader.get_env("AI_STRATEGY_MODEL", "gpt-4.1-nano")
+STRAT_TEMP = float(env_loader.get_env("STRAT_TEMP", "0.15"))
+STRAT_N = int(env_loader.get_env("STRAT_N", "3"))
+STRAT_VOTE_MIN = int(env_loader.get_env("STRAT_VOTE_MIN", "2"))
+
+
+def select_strategy(prompt: str, n: int | None = None) -> tuple[str, bool]:
+    """Return voted trade mode and bool indicating majority."""
+    if n is None:
+        n = STRAT_N
+    modes = []
+    for _ in range(n):
+        try:
+            resp = ask_openai(
+                prompt,
+                system_prompt="You are a trading strategy selector.",
+                model=AI_STRATEGY_MODEL,
+                temperature=STRAT_TEMP,
+                response_format={"type": "json_object"},
+            )
+            if isinstance(resp, dict):
+                modes.append(str(resp.get("trade_mode", "")))
+        except Exception:
+            continue
+    vote, cnt = Counter(modes).most_common(1)[0]
+    return vote, cnt >= STRAT_VOTE_MIN
+
+__all__ = ["select_strategy"]

--- a/piphawk_ai/vote_arch/entry_buffer.py
+++ b/piphawk_ai/vote_arch/entry_buffer.py
@@ -1,0 +1,34 @@
+"""Simple vertical ensemble buffer for entry plans."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections import deque
+
+from .ai_entry_plan import EntryPlan
+from backend.utils import env_loader
+
+ENTRY_BUFFER_K = int(env_loader.get_env("ENTRY_BUFFER_K", "3"))
+
+
+@dataclass
+class PlanBuffer:
+    _buf: deque[EntryPlan]
+
+    def __init__(self) -> None:
+        self._buf = deque(maxlen=ENTRY_BUFFER_K)
+
+    def append(self, plan: EntryPlan) -> None:
+        self._buf.append(plan)
+
+    def average(self) -> EntryPlan | None:
+        if len(self._buf) < ENTRY_BUFFER_K:
+            return None
+        tp = sum(p.tp for p in self._buf) / ENTRY_BUFFER_K
+        sl = sum(p.sl for p in self._buf) / ENTRY_BUFFER_K
+        side = (
+            self._buf[0].side if all(p.side == self._buf[0].side for p in self._buf) else "none"
+        )
+        lot = sum(p.lot for p in self._buf) / ENTRY_BUFFER_K
+        return EntryPlan(side=side, tp=tp, sl=sl, lot=lot)
+
+__all__ = ["PlanBuffer"]

--- a/piphawk_ai/vote_arch/market_air_sensor.py
+++ b/piphawk_ai/vote_arch/market_air_sensor.py
@@ -1,0 +1,20 @@
+"""Calculate market air index used in prompts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MarketSnapshot:
+    atr: float
+    news_score: float
+    oi_bias: float
+
+
+def air_index(m: MarketSnapshot) -> float:
+    vol_heat = min(m.atr / 0.1, 1)
+    news_heat = min(abs(m.news_score) / 5, 1)
+    flow_heat = abs(m.oi_bias)
+    return 0.5 * vol_heat + 0.3 * news_heat + 0.2 * flow_heat
+
+__all__ = ["MarketSnapshot", "air_index"]

--- a/piphawk_ai/vote_arch/post_filters.py
+++ b/piphawk_ai/vote_arch/post_filters.py
@@ -1,0 +1,38 @@
+"""Final safety checks for entry plans."""
+from __future__ import annotations
+
+from backend.utils import env_loader
+from .ai_entry_plan import EntryPlan
+
+EMA_DIFF_THRESHOLD = float(env_loader.get_env("EMA_DIFF_THRESHOLD", "0.0"))
+MIN_RRR = float(env_loader.get_env("MIN_RRR", "0.8"))
+MIN_NET_TP_PIPS = float(env_loader.get_env("MIN_NET_TP_PIPS", "1"))
+
+
+def ema_divergence_ok(diff: float) -> bool:
+    return diff >= EMA_DIFF_THRESHOLD
+
+
+def rrr_ok(tp: float, sl: float) -> bool:
+    if sl == 0:
+        return False
+    return (tp / sl) >= MIN_RRR
+
+
+def net_tp_ok(tp: float, spread: float) -> bool:
+    return (tp - spread) >= MIN_NET_TP_PIPS
+
+
+def final_filter(plan: EntryPlan, indicators: dict) -> bool:
+    """Return True if plan passes all filters."""
+    diff = float(indicators.get("ema_diff", 0))
+    spread = float(indicators.get("spread", 0))
+    return all(
+        [
+            ema_divergence_ok(diff),
+            rrr_ok(plan.tp, plan.sl),
+            net_tp_ok(plan.tp, spread),
+        ]
+    )
+
+__all__ = ["final_filter"]

--- a/piphawk_ai/vote_arch/regime_detector.py
+++ b/piphawk_ai/vote_arch/regime_detector.py
@@ -1,0 +1,28 @@
+"""Simple rule-based regime detection."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.utils import env_loader
+
+@dataclass
+class MarketMetrics:
+    """Container for indicator values used in regime detection."""
+    adx_m5: float
+    ema_fast: float
+    ema_slow: float
+    bb_width_m5: float
+
+REGIME_ADX_TREND = float(env_loader.get_env("REGIME_ADX_TREND", "30"))
+REGIME_BB_NARROW = float(env_loader.get_env("REGIME_BB_NARROW", "0.05"))
+
+
+def rule_based_regime(m: MarketMetrics) -> str:
+    """Return market regime based on ADX and Bollinger width."""
+    if m.adx_m5 >= REGIME_ADX_TREND and m.ema_fast > m.ema_slow:
+        return "trend"
+    if m.bb_width_m5 <= REGIME_BB_NARROW and m.adx_m5 < 20:
+        return "range"
+    return "vol_spike"
+
+__all__ = ["MarketMetrics", "rule_based_regime"]

--- a/piphawk_ai/vote_arch/trade_mode_selector.py
+++ b/piphawk_ai/vote_arch/trade_mode_selector.py
@@ -1,0 +1,21 @@
+"""Select final trade mode with rule fallback."""
+from __future__ import annotations
+
+from backend.utils import env_loader
+
+FALLBACK_MAP = {
+    "trend": "trend_follow",
+    "range": "scalp_reversal",
+    "vol_spike": "scalp_momentum",
+}
+
+STRAT_VOTE_MIN = int(env_loader.get_env("STRAT_VOTE_MIN", "2"))
+
+
+def choose_mode(conf_ok: bool, voted_mode: str, regime: str, indicators: dict) -> str:
+    """Return final trade mode."""
+    if conf_ok:
+        return voted_mode
+    return FALLBACK_MAP.get(regime, "scalp_momentum")
+
+__all__ = ["choose_mode"]


### PR DESCRIPTION
## Summary
- add simple rule-based regime detector
- implement OpenAI strategy selector with majority vote
- choose final trade mode with rule fallback
- generate deterministic entry plans via OpenAI
- provide vertical ensemble buffer and post-filters
- include market air index helper
- expose new components via `vote_arch`
- document related environment variables

## Testing
- `./run_tests.sh` *(fails: pip install heavy; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684ae0861508833382d8bad815f7d7ba