### PR TITLE
Remove aggressive retry behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 - `ADX_SCALP_MIN` … ADX がこの値以上でスキャルプモード
 - `ADX_TREND_MIN` … ADX がこの値以上でトレンドフォローモード
 - `TREND_PROMPT_BIAS` … `aggressive` にするとトレンドフォローAIがより積極的に判断します。モデルは追加のリトライなしで `long` か `sell` を選択するよう指示されます
-- `AI_RETRY_ON_NO` … true にするとAIが "no" を返した際に再度 "aggressive" バイアスで判定
+- `AI_RETRY_ON_NO` … (廃止) このオプションは無効化され、AIを再試行しません
 - `PROMPT_TAIL_LEN` … プロンプトへ含める指標履歴の本数
 - `PROMPT_CANDLE_LEN` … プロンプトへ含めるローソク足の本数
 - `MICRO_SCALP_ENABLED` … openai_micro_scalp を有効にするフラグ

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -268,7 +268,7 @@ SCALP_SL_PIPS=8                  # スキャルプ時のSL幅
 SCALP_COND_TF=S10                 # 市場判定に使う時間足(M1/M5等)
 SCALP_PROMPT_BIAS=aggressive     # AIプロンプトの攻め姿勢
 TREND_PROMPT_BIAS=aggressive     # トレンド判断を積極的にする
-AI_RETRY_ON_NO=false             # "no" の際は再試行しない
+AI_RETRY_ON_NO=false             # (廃止) AI再試行機能は無効
 # --- プロンプト履歴件数設定 ---
 PROMPT_TAIL_LEN=20               # 指標履歴をプロンプトへ入れる本数
 PROMPT_CANDLE_LEN=20             # 各TFのローソク足を含める本数

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -530,25 +530,7 @@ def process_entry(
         filter_ctx=strategy_params.get("filter_ctx") if isinstance(strategy_params, dict) else None,
     )
 
-    # -- "no" の場合は攻めたバイアスで再試行 --------------------
-    # ただし TREND_PROMPT_BIAS が aggressive のときは同じプロンプトを繰り返さない
-    if (
-        plan.get("entry", {}).get("side", "no").lower() not in ("long", "short")
-        and env_loader.get_env("AI_RETRY_ON_NO", "false").lower() == "true"
-        and env_loader.get_env("TREND_PROMPT_BIAS", "normal").lower() != "aggressive"
-    ):
-        plan = oa.get_trade_plan(
-            market_data,
-            indicators_multi,
-            candles_dict,
-            patterns=patterns,
-            detected_patterns=detected,
-            allow_delayed_entry=allow_delayed_entry,
-            trend_prompt_bias="aggressive",
-            filter_ctx=strategy_params.get("filter_ctx") if isinstance(strategy_params, dict) else None,
-        )
-        ai_raw = json.dumps(plan, ensure_ascii=False)
-        logging.info(f"AI trade plan aggressive retry: {ai_raw}")
+    # AI_RETRY_ON_NO 機能は廃止されたため、ここでの再試行は行わない
 
     # Raw JSON for audit log
     ai_raw = json.dumps(plan, ensure_ascii=False)

--- a/docs/aggressive_scalp.md
+++ b/docs/aggressive_scalp.md
@@ -19,7 +19,7 @@
 - `SCALP_TP_PIPS=8`
 - `SCALP_SL_PIPS=8`
 - `SCALP_PROMPT_BIAS=aggressive`
-- `AI_RETRY_ON_NO=true`
+- `AI_RETRY_ON_NO=false`  # このオプションは廃止されました
 
 ## マイクロ構造モードの有効化
 


### PR DESCRIPTION
## Summary
- remove AI aggressive retry call
- mark `AI_RETRY_ON_NO` as deprecated in docs and configs

## Testing
- `./run_tests.sh` *(fails: pip install step blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684af15e6a948333afb620b176162453