### PR TITLE
Implement majority-vote pipeline

### DIFF
--- a/piphawk_ai/vote_arch/__init__.py
+++ b/piphawk_ai/vote_arch/__init__.py
@@ -6,6 +6,7 @@ from .ai_entry_plan import generate_plan, EntryPlan
 from .entry_buffer import PlanBuffer
 from .post_filters import final_filter
 from .market_air_sensor import MarketSnapshot, air_index
+from .pipeline import run_cycle, PipelineResult
 
 __all__ = [
     "MarketMetrics",
@@ -18,4 +19,6 @@ __all__ = [
     "final_filter",
     "MarketSnapshot",
     "air_index",
+    "run_cycle",
+    "PipelineResult",
 ]

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Orchestration pipeline for the majority-vote trading architecture."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from backend.strategy.signal_filter import pass_entry_filter
+
+from .regime_detector import MarketMetrics, rule_based_regime
+from .ai_strategy_selector import select_strategy
+from .trade_mode_selector import choose_mode
+from .ai_entry_plan import generate_plan, EntryPlan
+from .entry_buffer import PlanBuffer
+from .post_filters import final_filter
+from .market_air_sensor import MarketSnapshot, air_index
+
+
+@dataclass
+class PipelineResult:
+    """Simple result object for one trading cycle."""
+
+    plan: Optional[EntryPlan]
+    mode: str
+    regime: str
+    passed: bool
+
+
+def run_cycle(
+    indicators: dict,
+    metrics: MarketMetrics,
+    snapshot: MarketSnapshot,
+    buffer: PlanBuffer | None = None,
+    *,
+    price: float | None = None,
+) -> PipelineResult:
+    """Run the full majority-vote pipeline and return result."""
+
+    if not pass_entry_filter(indicators, price):
+        return PipelineResult(None, mode="", regime="", passed=False)
+
+    regime = rule_based_regime(metrics)
+    air = air_index(snapshot)
+
+    prompt = f"Regime: {regime}\nAir: {air:.2f}"
+    mode_raw, conf_ok = select_strategy(prompt)
+
+    mode = choose_mode(conf_ok, mode_raw, regime, indicators)
+
+    plan = generate_plan(f"trade_mode: {mode}")
+    if not plan:
+        return PipelineResult(None, mode=mode, regime=regime, passed=False)
+
+    if buffer is not None:
+        buffer.append(plan)
+        avg_plan = buffer.average()
+        if avg_plan:
+            plan = avg_plan
+
+    passed = final_filter(plan, indicators)
+    return PipelineResult(plan if passed else None, mode=mode, regime=regime, passed=passed)
+
+
+__all__ = ["PipelineResult", "run_cycle"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,84 @@
+import sys
+import types
+import pytest
+
+# Stub requests module for isolated testing
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+openai_stub = types.ModuleType("openai")
+openai_stub.OpenAI = object
+openai_stub.APIError = Exception
+sys.modules.setdefault("openai", openai_stub)
+pandas_stub = types.ModuleType("pandas")
+pandas_stub.Series = object
+pandas_stub.DataFrame = object
+sys.modules.setdefault("pandas", pandas_stub)
+
+from piphawk_ai.vote_arch.pipeline import run_cycle, PipelineResult
+from piphawk_ai.vote_arch.regime_detector import MarketMetrics
+from piphawk_ai.vote_arch.market_air_sensor import MarketSnapshot
+from piphawk_ai.vote_arch.entry_buffer import PlanBuffer
+from piphawk_ai.vote_arch.ai_entry_plan import EntryPlan
+
+
+def test_run_cycle(monkeypatch):
+    def fake_filter(indicators, price=None, **_):
+        return True
+
+    monkeypatch.setattr(
+        "backend.strategy.signal_filter.pass_entry_filter", fake_filter
+    )
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.pipeline.pass_entry_filter", fake_filter
+    )
+
+    def fake_select(prompt: str, n=None):
+        return "scalp_momentum", True
+
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.ai_strategy_selector.select_strategy", fake_select
+    )
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.pipeline.select_strategy", fake_select
+    )
+
+    def fake_plan(prompt: str):
+        return EntryPlan(side="long", tp=10, sl=5, lot=1)
+
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.ai_entry_plan.generate_plan", fake_plan
+    )
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.pipeline.generate_plan", fake_plan
+    )
+
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.post_filters.final_filter", lambda p, i: True
+    )
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.pipeline.final_filter", lambda p, i: True
+    )
+
+    metrics = MarketMetrics(adx_m5=30, ema_fast=1.1, ema_slow=1.0, bb_width_m5=0.1)
+    snapshot = MarketSnapshot(atr=0.05, news_score=0.0, oi_bias=0.0)
+    result = run_cycle({}, metrics, snapshot, PlanBuffer())
+
+    assert isinstance(result, PipelineResult)
+    assert result.passed is True
+    assert result.plan is not None
+    assert result.mode == "scalp_momentum"
+    assert result.regime == "trend"
+
+
+def test_run_cycle_filter_block(monkeypatch):
+    monkeypatch.setattr(
+        "backend.strategy.signal_filter.pass_entry_filter", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.pipeline.pass_entry_filter", lambda *a, **k: False
+    )
+    metrics = MarketMetrics(0, 0, 0, 0)
+    snapshot = MarketSnapshot(0, 0, 0)
+    result = run_cycle({}, metrics, snapshot)
+    assert result.passed is False
+    assert result.plan is None
+


### PR DESCRIPTION
## Summary
- add new `run_cycle` orchestration pipeline
- expose new pipeline in package init
- add unit tests for pipeline module

## Testing
- `pytest -q tests/test_pipeline.py`
- `./run_tests.sh tests/test_pipeline.py` *(failed: pip build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684af1c1268083338eeedef6a7ac9882