### PR TITLE
Add minimal test requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,7 @@ quickly using the helper script:
 ```
 
 
-This script installs dependencies from `requirements-dev.txt` and then launches
+This script installs dependencies from `requirements-test.txt` and then launches
 `pytest` automatically. Recent additions include tests for the monitoring
 utilities such as ``SafetyTrigger`` and ``metrics_publisher``.
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+pytest
+numpy
+pandas
+scikit-learn
+requests

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-pip install -r requirements-dev.txt
+pip install --only-binary=:all: -r requirements-test.txt
 pytest "$@"


### PR DESCRIPTION
## Summary
- split minimal test dependencies into `requirements-test.txt`
- update `run_tests.sh` to install minimal requirements using binary wheels
- adjust README to mention the new requirements file

## Testing
- `./run_tests.sh tests/test_prompt_log.py::test_log_prompt_response -q`

------
https://chatgpt.com/codex/tasks/task_e_684af91f29a88333a7acdc80af16c10c