### PR TITLE
Add majority vote pipeline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Piphawk AI consists of the following components:
 The backend resides in the `backend/` directory and is designed to run either
 directly with Python or inside Docker containers. Configuration values are
 loaded from environment variables and optional YAML files under `config/`.
+Trading decisions are determined through a majority vote pipeline that filters
+indicators, selects a strategy via OpenAI, and averages entry plans. For a
+detailed diagram see [docs/majority_vote_flow.md](docs/majority_vote_flow.md).
 
 ## QuickStart
 

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -360,3 +360,4 @@ SCALE_TRIGGER_ATR=0.5
 - **ENTRY_BUFFER_K**: Entry Plan を平均化するバッファ長。
 - **REGIME_ADX_TREND**: Regime 判定でトレンドとみなすADX値。
 - **REGIME_BB_NARROW**: Range 判定で用いるBB幅の閾値。
+フロー全体の解説は [majority_vote_flow.md](majority_vote_flow.md) を参照してください。

--- a/docs/majority_vote_flow.md
+++ b/docs/majority_vote_flow.md
@@ -1,0 +1,24 @@
+# 多数決パイプラインの流れ
+
+AI モデルのノイズを抑えるため、複数ステップを組み合わせた多数決フローを用います。以下は `piphawk_ai.vote_arch` モジュールで実装されている処理の概要です。
+
+```text
+[Indicators] --pass_entry_filter--> [Regime Detection]
+                 \-- NG --> stop
+Regime Detection --prompt--> Strategy Select (n times)
+Strategy Select --vote--> Trade Mode
+Trade Mode --prompt--> Entry Plan
+Entry Plan --> Plan Buffer --> Final Filter --> PipelineResult
+```
+
+## 各ステップの役割
+
+1. **pass_entry_filter** – RSI やATRなどの指標から事前条件を判定し、不適切な状況では早期に終了します。
+2. **Regime Detection** – ADXとボリンジャーバンド幅から `trend` / `range` / `vol_spike` を推定します。
+3. **Strategy Select** – OpenAI API を複数回呼び出し、`STRAT_N` 本の候補から多数決でモードを決定します。温度は `STRAT_TEMP` で調整します。
+4. **Trade Mode** – 多数決が十分でない場合はレジームに応じたフォールバックを行います (`STRAT_VOTE_MIN` が閾値)。
+5. **Entry Plan** – 選択されたモードをプロンプトに与え、TP/SL などの具体的なプランを生成します。
+6. **Plan Buffer** – 直近 `ENTRY_BUFFER_K` 個のプランを平均化して外れ値を緩和します。
+7. **Final Filter** – EMA 乖離やリスクリワード比を再確認し、条件を満たした場合のみ採用します。
+
+詳細な実装は `piphawk_ai/vote_arch/` ディレクトリを参照してください。


### PR DESCRIPTION
## Summary
- document majority vote flow in `docs/majority_vote_flow.md`
- link the new diagram from environment variables list
- mention majority vote pipeline in System Overview

## Testing
- `./run_tests.sh` *(fails: openai package is required)*

------
https://chatgpt.com/codex/tasks/task_e_684b675910b48333880d48c863548012