### PR TITLE
Add missing environment variables

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -306,3 +306,30 @@ ENTRY_BUFFER_K=3
 # === Regime detection ===
 REGIME_ADX_TREND=30
 REGIME_BB_NARROW=0.05
+
+# === External API keys ===
+OPENAI_API_KEY=                 # OpenAI APIキー
+OANDA_API_KEY=                  # OANDAアクセスキー
+OANDA_ACCOUNT_ID=               # OANDAアカウントID
+
+# === Optional configurations ===
+RISK_PER_TRADE=0.005            # 1トレードあたりのリスク比率
+CLEANUP_THRESHOLD=80            # ディスク使用率警告閾値
+MICRO_SCALP_LOOKBACK=5          # マイクロスキャルプ参照本数
+MICRO_SCALP_MIN_PIPS=1          # マイクロスキャルプ判定幅
+OANDA_API_URL=https://api-fxtrade.oanda.com/v3          # OANDA REST APIベースURL
+OANDA_STREAM_URL=https://stream-fxtrade.oanda.com/v3    # OANDA Stream API URL
+HTTP_MAX_RETRIES=3              # HTTPリトライ回数
+HTTP_BACKOFF_CAP_SEC=8          # HTTPバックオフ上限秒
+HTTP_TIMEOUT_SEC=10             # HTTPタイムアウト秒
+API_PORT=8080                   # APIサーバーポート
+METRICS_PORT=8001               # メトリクス用ポート
+LOG_LEVEL=INFO                  # ログ出力レベル
+PAPER_MODE=false                # 実取引を行わない
+FRED_API_KEY=                   # FRED APIキー
+KAFKA_SERVERS=                  # Kafkaブローカー
+METRICS_TOPIC=                  # メトリクストピック
+LOSS_LIMIT=                     # 累積損失上限
+ERROR_LIMIT=                    # 許容エラー回数
+USE_OFFLINE_POLICY=false        # オフライン学習ポリシー利用
+RESTART_STATE_PATH=/tmp/piphawk_last_restart  # 再起動状態ファイルパス


### PR DESCRIPTION
## Summary
- add API key and runtime variables to settings.env

## Testing
- `bash run_tests.sh` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684b6b221d1c833390ff4794414c17a5