### PR TITLE
Set vote arch default true

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -464,7 +464,7 @@ class JobRunner:
         self.last_candles_m5: list[dict] | None = None
 
         # Majority-vote architecture toggle
-        self.use_vote_arch = env_loader.get_env("USE_VOTE_ARCH", "false").lower() == "true"
+        self.use_vote_arch = env_loader.get_env("USE_VOTE_ARCH", "true").lower() == "true"
         self.plan_buffer = PlanBuffer() if self.use_vote_arch else None
 
         # SCALP_MODE 時に市場判断へ使う時間足


### PR DESCRIPTION
## Summary
- default USE_VOTE_ARCH to `true`

## Testing
- `pytest tests/test_job_runner_vote_arch.py::test_job_runner_vote_arch_entry -q`
- `pytest -q` *(fails: ImportError and other configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a8eaaf483338b7a237d01a7dc91