### PR TITLE
Optimize strategy selector API usage

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -355,7 +355,7 @@ SCALE_TRIGGER_ATR=0.5
 ## 多数決フロー関連
 
 - **STRAT_TEMP**: Strategy Select で使う temperature。
-- **STRAT_N**: Strategy Select の生成本数。
+- **STRAT_N**: Strategy Select が一度の API 呼び出しで生成する候補本数。
 - **STRAT_VOTE_MIN**: 採用に必要な一致数。
 - **ENTRY_BUFFER_K**: Entry Plan を平均化するバッファ長。
 - **REGIME_ADX_TREND**: Regime 判定でトレンドとみなすADX値。

--- a/docs/majority_vote_flow.md
+++ b/docs/majority_vote_flow.md
@@ -15,7 +15,7 @@ Entry Plan --> Plan Buffer --> Final Filter --> PipelineResult
 
 1. **pass_entry_filter** – RSI やATRなどの指標から事前条件を判定し、不適切な状況では早期に終了します。
 2. **Regime Detection** – ADXとボリンジャーバンド幅から `trend` / `range` / `vol_spike` を推定します。
-3. **Strategy Select** – OpenAI API を複数回呼び出し、`STRAT_N` 本の候補から多数決でモードを決定します。温度は `STRAT_TEMP` で調整します。
+3. **Strategy Select** – OpenAI API を1回呼び出して `STRAT_N` 本の候補を生成し、多数決でモードを決定します。温度は `STRAT_TEMP` で調整します。
 4. **Trade Mode** – 多数決が十分でない場合はレジームに応じたフォールバックを行います (`STRAT_VOTE_MIN` が閾値)。
 5. **Entry Plan** – 選択されたモードをプロンプトに与え、TP/SL などの具体的なプランを生成します。
 6. **Plan Buffer** – 直近 `ENTRY_BUFFER_K` 個のプランを平均化して外れ値を緩和します。

--- a/piphawk_ai/vote_arch/ai_strategy_selector.py
+++ b/piphawk_ai/vote_arch/ai_strategy_selector.py
@@ -16,20 +16,21 @@ def select_strategy(prompt: str, n: int | None = None) -> tuple[str, bool]:
     """Return voted trade mode and bool indicating majority."""
     if n is None:
         n = STRAT_N
-    modes = []
-    for _ in range(n):
-        try:
-            resp = ask_openai(
-                prompt,
-                system_prompt="You are a trading strategy selector.",
-                model=AI_STRATEGY_MODEL,
-                temperature=STRAT_TEMP,
-                response_format={"type": "json_object"},
-            )
-            if isinstance(resp, dict):
-                modes.append(str(resp.get("trade_mode", "")))
-        except Exception:
-            continue
+    try:
+        resp_list = ask_openai(
+            prompt,
+            system_prompt="You are a trading strategy selector.",
+            model=AI_STRATEGY_MODEL,
+            temperature=STRAT_TEMP,
+            response_format={"type": "json_object"},
+            n=n,
+        )
+    except Exception:
+        resp_list = []
+    if isinstance(resp_list, dict):
+        modes = [str(resp_list.get("trade_mode", ""))]
+    else:
+        modes = [str(r.get("trade_mode", "")) for r in resp_list]
     vote, cnt = Counter(modes).most_common(1)[0]
     return vote, cnt >= STRAT_VOTE_MIN
 

--- a/tests/test_vote_arch.py
+++ b/tests/test_vote_arch.py
@@ -7,8 +7,8 @@ from piphawk_ai.vote_arch.regime_detector import MarketMetrics, rule_based_regim
 
 def test_select_strategy_majority(monkeypatch):
     calls = ["scalp_momentum", "trend_follow", "trend_follow"]
-    def fake_ask(prompt: str, system_prompt: str, model: str, temperature: float, response_format: dict):
-        return {"trade_mode": calls.pop(0)}
+    def fake_ask(prompt: str, system_prompt: str, model: str, temperature: float, response_format: dict, n: int):
+        return [{"trade_mode": calls.pop(0)} for _ in range(n)]
     monkeypatch.setattr("piphawk_ai.vote_arch.ai_strategy_selector.ask_openai", fake_ask)
     mode, ok = select_strategy("foo")
     assert mode == "trend_follow"


### PR DESCRIPTION
## Summary
- update `ask_openai` to support multiple completions in one call
- switch strategy selector to single OpenAI call with `n` completions
- document new behaviour in majority vote docs and env vars
- adjust unit tests for new interface

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684b6ad320608333bb0240603a2d27ee