### PR TITLE
Fix env comment parsing

### DIFF
--- a/backend/utils/env_loader.py
+++ b/backend/utils/env_loader.py
@@ -35,4 +35,8 @@ def load_env(paths: Iterable[str | Path], *, override: bool = True) -> None:
 
 def get_env(key: str, default: Optional[str] = None) -> Optional[str]:
     """Return the value of an environment variable."""
-    return os.getenv(key, default)
+    val = os.getenv(key, default)
+    if isinstance(val, str):
+        # 行末のコメントや余分な空白を除去する
+        val = val.split("#", 1)[0].strip()
+    return val


### PR DESCRIPTION
## Summary
- ignore trailing comments when reading environment variables

## Testing
- `bash run_tests.sh` *(fails: openai package missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b6e6c37708333a20888b85a5d4c8e