### PR TITLE
Fix enum logging and strategy selector

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -1,9 +1,9 @@
 import requests
 from backend.utils import env_loader
 from backend.utils.http_client import request_with_retries
-from backend.logs.log_manager import log_trade, log_error
+from backend.logs.log_manager import log_error
 from backend.logs.info_logger import info
-from backend.logs.trade_logger import ExitReason
+from backend.logs.trade_logger import ExitReason, log_trade
 from backend.logs.update_oanda_trades import fetch_trade_details
 from backend.utils.price import format_price
 from backend.risk_manager import (

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -1,6 +1,6 @@
 from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
 from backend.orders.order_manager import OrderManager
-from backend.logs.log_manager import log_trade
+from backend.logs.trade_logger import log_trade
 from backend.strategy.risk_manager import calc_lot_size
 from risk.tp_sl_manager import adjust_sl_for_rr
 import importlib

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -3,8 +3,7 @@ import importlib
 openai_analysis = importlib.import_module("backend.strategy.openai_analysis")
 EXIT_BIAS_FACTOR = getattr(openai_analysis, "EXIT_BIAS_FACTOR", 1.0)
 from backend.orders.order_manager import OrderManager
-from backend.logs.log_manager import log_trade
-from backend.logs.trade_logger import ExitReason
+from backend.logs.trade_logger import ExitReason, log_trade
 from backend.logs.exit_logger import append_exit_log
 from datetime import datetime, timezone
 import logging

--- a/piphawk_ai/vote_arch/ai_strategy_selector.py
+++ b/piphawk_ai/vote_arch/ai_strategy_selector.py
@@ -28,9 +28,12 @@ def select_strategy(prompt: str, n: int | None = None) -> tuple[str, bool]:
     except Exception:
         resp_list = []
     if isinstance(resp_list, dict):
-        modes = [str(resp_list.get("trade_mode", ""))]
+        modes = [str(resp_list.get("trade_mode", "")).strip()]
     else:
-        modes = [str(r.get("trade_mode", "")) for r in resp_list]
+        modes = [str(r.get("trade_mode", "")).strip() for r in resp_list]
+    modes = [m for m in modes if m]
+    if not modes:
+        return "", False
     vote, cnt = Counter(modes).most_common(1)[0]
     return vote, cnt >= STRAT_VOTE_MIN
 


### PR DESCRIPTION
## Summary
- use `log_trade` wrapper so `ExitReason` enums are handled correctly
- validate strategy votes to avoid IndexError

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'openai', fastapi, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684b70fe125883339e7d128778e36f5e