### PR TITLE
Fix log_trade issues

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -1,5 +1,6 @@
 import sqlite3
 import logging
+from enum import Enum
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -249,6 +250,8 @@ def log_trade(
     is_manual: bool | None = None,
     score_version: int | None = None,
 ):
+    if isinstance(exit_reason, Enum):
+        exit_reason = exit_reason.name
     with get_db_connection() as conn:
         cursor = conn.cursor()
         cursor.execute('''

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -1254,7 +1254,7 @@ def process_entry(
         except Exception:
             rrr = None
         log_trade(
-            instrument,
+            instrument=instrument,
             entry_time=entry_time,
             entry_price=entry_price,
             units=units,

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -213,7 +213,7 @@ def process_exit(
             else -int(position["short"]["units"])
         )
         log_trade(
-            position["instrument"],
+            instrument=position["instrument"],
             exit_time=exit_time,
             entry_time=position.get("entry_time", exit_time),
             entry_price=float(position[position_side]["averagePrice"]),
@@ -367,7 +367,7 @@ def process_exit(
                     else -int(position["short"]["units"])
                 )
                 log_trade(
-                    position["instrument"],
+                    instrument=position["instrument"],
                     exit_time=exit_time,
                     entry_time=position.get(
                         "entry_time", position.get("openTime", exit_time)
@@ -428,7 +428,7 @@ def process_exit(
         exit_time = datetime.now(timezone.utc).isoformat()
 
         log_trade(
-            instrument,
+            instrument=instrument,
             exit_time=exit_time,
             entry_time=entry_time,
             entry_price=entry_price,
@@ -473,7 +473,7 @@ def process_exit(
                         close_units = close_units if units > 0 else -close_units
                         order_manager.close_partial(trade_ids[0], close_units)
                         log_trade(
-                            position["instrument"],
+                            instrument=position["instrument"],
                             entry_time=position.get("entry_time", position.get("openTime", datetime.now(timezone.utc).isoformat())),
                             entry_price=entry_price,
                             units=close_units,


### PR DESCRIPTION
## Summary
- convert `exit_reason` enums to strings when logging
- call `log_trade` with keyword arguments

## Testing
- `pytest -k exit_reason_logging -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684b776151cc8333ab333461fa817211