### PR TITLE
Improve trend entry logic

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1353,6 +1353,18 @@ def get_trade_plan(
     plan["entry_confidence"] = entry_conf
     plan["entry_type"] = entry_type
 
+    # LLMが反守方向を出した場合の後処理
+    try:
+        regime = market_cond.get("market_condition") if market_cond else None
+        if regime == "trend" and plan.get("entry_type") == "reversal":
+            plan["entry_type"] = "trend"
+            probs = plan.get("probs", {})
+            if "long" in probs and "short" in probs:
+                probs["long"], probs["short"] = probs["short"], probs["long"]
+            plan["probs"] = probs
+    except Exception:
+        pass
+
     # ---- local guards -------------------------------------------------
     risk = risk_autofix(plan.get("risk"))
     plan["risk"] = risk

--- a/prompts/trade_plan_instruction.txt
+++ b/prompts/trade_plan_instruction.txt
@@ -126,3 +126,5 @@ Pivot: {pivot}, R1: {pivot_r1}, S1: {pivot_s1}
 {macro_summary_formatted}
 ### Macro Sentiment
 {macro_sentiment_formatted}
+
+- If ADX \u2265 25 and price above 50EMA, prefer entry_type "trend" (not "reversal").


### PR DESCRIPTION
## Summary
- tweak prompt to encourage trend entries when ADX is high and price above 50EMA
- swap probabilities to trend when LLM suggests a reversal during trend regime

## Testing
- `./run_tests.sh` *(fails: openai package required)*

------
https://chatgpt.com/codex/tasks/task_e_684b8609ee94833385bad0c912abdda6