### PR TITLE
Fix prompts for OpenAI JSON mode

### DIFF
--- a/piphawk_ai/vote_arch/ai_entry_plan.py
+++ b/piphawk_ai/vote_arch/ai_entry_plan.py
@@ -20,7 +20,9 @@ def generate_plan(prompt: str) -> EntryPlan | None:
     """Return EntryPlan from AI."""
     resp = ask_openai(
         prompt,
-        system_prompt="You are a trading entry planner.",
+        system_prompt=(
+            "You are a trading entry planner. Respond in JSON format."
+        ),
         model=AI_ENTRY_MODEL,
         temperature=0.0,
         response_format={"type": "json_object"},

--- a/piphawk_ai/vote_arch/ai_strategy_selector.py
+++ b/piphawk_ai/vote_arch/ai_strategy_selector.py
@@ -19,7 +19,9 @@ def select_strategy(prompt: str, n: int | None = None) -> tuple[str, bool]:
     try:
         resp_list = ask_openai(
             prompt,
-            system_prompt="You are a trading strategy selector.",
+            system_prompt=(
+                "You are a trading strategy selector. Respond in JSON format."
+            ),
             model=AI_STRATEGY_MODEL,
             temperature=STRAT_TEMP,
             response_format={"type": "json_object"},


### PR DESCRIPTION
## Summary
- ensure prompts mention JSON when requesting `json_object` format

## Testing
- `./run_tests.sh` *(fails: openai package is required)*

------
https://chatgpt.com/codex/tasks/task_e_684b86b0c5fc83339c3de0ddb61e8dfd