### PR TITLE
Add Bollinger and ATR utilities

### DIFF
--- a/backend/indicators/__init__.py
+++ b/backend/indicators/__init__.py
@@ -2,6 +2,8 @@ from .candle_features import get_candle_features, compute_volume_sma
 from .keltner import calculate_keltner_bands
 from .rolling import RollingATR, RollingADX, RollingBBWidth, RollingKeltner
 from .vwap_band import get_vwap_delta, get_vwap_bias
+from .bollinger import close_breaks_bbands, high_hits_bbands
+from .atr import atr_tick_ratio
 
 __all__ = [
     "get_candle_features",
@@ -13,4 +15,7 @@ __all__ = [
     "RollingKeltner",
     "get_vwap_delta",
     "get_vwap_bias",
+    "close_breaks_bbands",
+    "high_hits_bbands",
+    "atr_tick_ratio",
 ]

--- a/backend/indicators/atr.py
+++ b/backend/indicators/atr.py
@@ -31,3 +31,26 @@ def calculate_atr(high, low, close, period=None):
     tr = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
     atr = tr.rolling(window=period, min_periods=1).mean()
     return atr
+
+
+def atr_tick_ratio(ticks, short_window=10):
+    """Return ATR ratio of recent ticks versus overall average."""
+    df = pd.DataFrame(ticks)
+    if df.empty or not {"high", "low", "close"}.issubset(df.columns):
+        return 0.0
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    close = df["close"].astype(float)
+    prev_close = close.shift(1)
+    tr1 = high - low
+    tr2 = (high - prev_close).abs()
+    tr3 = (low - prev_close).abs()
+    tr = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+    if tr.empty:
+        return 0.0
+    recent_mean = tr.tail(short_window).mean()
+    overall_mean = tr.mean()
+    return float(recent_mean / overall_mean) if overall_mean else 0.0
+
+
+__all__ = ["calculate_atr", "atr_tick_ratio"]

--- a/backend/indicators/bollinger.py
+++ b/backend/indicators/bollinger.py
@@ -46,3 +46,47 @@ def calculate_bb_width(prices, window=None, num_std=None):
     """Return Bollinger Band width as a Series."""
     df = calculate_bollinger_bands(prices, window=window, num_std=num_std)
     return df['upper_band'] - df['lower_band']
+
+
+def close_breaks_bbands(price_series, level, window=20):
+    """Return ``True`` if close price breaks the Bollinger band."""
+    series = pd.Series(price_series)
+    if len(series) < 2:
+        return False
+    ma = series.rolling(window=window).mean()
+    std = series.rolling(window=window).std()
+    if ma.isna().iloc[-1] or ma.isna().iloc[-2]:
+        return False
+    prev_close, last_close = series.iloc[-2], series.iloc[-1]
+    prev_upper = ma.iloc[-2] + level * std.iloc[-2]
+    prev_lower = ma.iloc[-2] - level * std.iloc[-2]
+    last_upper = ma.iloc[-1] + level * std.iloc[-1]
+    last_lower = ma.iloc[-1] - level * std.iloc[-1]
+    prev_out = prev_close > prev_upper or prev_close < prev_lower
+    last_out = last_close > last_upper or last_close < last_lower
+    return last_out and not prev_out
+
+
+def high_hits_bbands(price_series, level, window=20):
+    """Return ``True`` if high or low touches the Bollinger band."""
+    df = pd.DataFrame(price_series)
+    if df.empty or not {"high", "low", "close"}.issubset(df.columns):
+        return False
+    close = df["close"]
+    ma = close.rolling(window=window).mean()
+    std = close.rolling(window=window).std()
+    if ma.isna().iloc[-1]:
+        return False
+    upper = ma.iloc[-1] + level * std.iloc[-1]
+    lower = ma.iloc[-1] - level * std.iloc[-1]
+    high_val = float(df["high"].iloc[-1])
+    low_val = float(df["low"].iloc[-1])
+    return high_val >= upper or low_val <= lower
+
+
+__all__ = [
+    "calculate_bollinger_bands",
+    "calculate_bb_width",
+    "close_breaks_bbands",
+    "high_hits_bbands",
+]

--- a/tests/test_indicators_extra.py
+++ b/tests/test_indicators_extra.py
@@ -1,0 +1,25 @@
+import pytest
+import pandas as pd
+
+from backend.indicators.bollinger import close_breaks_bbands, high_hits_bbands
+from backend.indicators.atr import atr_tick_ratio
+
+
+def test_close_breaks_bbands():
+    prices = [1.0] * 21 + [1.5]
+    assert close_breaks_bbands(prices, 1)
+
+
+def test_high_hits_bbands():
+    data = [{"high": 1.0, "low": 1.0, "close": 1.0}] * 20
+    data.append({"high": 1.5, "low": 0.8, "close": 1.0})
+    assert high_hits_bbands(data, 1)
+
+
+def test_atr_tick_ratio():
+    ticks = [{"high": 1.01, "low": 0.99, "close": 1.0}] * 15
+    ratio1 = atr_tick_ratio(ticks)
+    assert ratio1 == pytest.approx(1.0)
+    ticks.extend([{"high": 1.05, "low": 0.95, "close": 1.0}] * 5)
+    ratio2 = atr_tick_ratio(ticks)
+    assert ratio2 > 1.0


### PR DESCRIPTION
## Summary
- expand bollinger indicator utilities
- implement ATR tick ratio helper
- expose new helpers from indicators package
- test bollinger breakout/hit and ATR tick ratio

## Testing
- `bash run_tests.sh tests/test_indicators_extra.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9e9de5508333b0841147165c7d32