### PR TITLE
Fix mode_detector duplicate definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 
 - Automated entry and exit decisions using OpenAI models with technical indicator context.
 - Composite trade mode logic switching between **scalp** and **trend_follow**.
-- Local mode detection via `analysis.detect_mode()` without LLM.
+- Local mode detection via `analysis.detect_mode_simple()` without LLM.
 - Multi-timeframe indicators and regime detection.
 - Parameterized `mode_detector` allows tuning without any LLM calls.
 - Optional chart pattern detection via OpenAI or a local scanner.
@@ -247,7 +247,7 @@ ema_slope_min: 0.1
 ### LLM model settings
 
 `strategy.yml` では利用する OpenAI モデルを個別に指定できます。現在はトレードモー
-ド判定がローカルの `analysis.detect_mode()` へ置き換わったため、`mode_selector`
+ド判定がローカルの `analysis.detect_mode_simple()` へ置き換わったため、`mode_selector`
 キーは無視されます。以下の例ではエントリーとエグジットのみ AI モデルを指定してい
 ます。
 
@@ -789,7 +789,7 @@ plan = get_trade_plan({}, {}, candles_dict,
 ```
 
 ## レジーム衝突処理
-以前は `LOCAL_WEIGHT_THRESHOLD` を用いてローカル判定と LLM 判定の整合度を比較していましたが、現在は `analysis.detect_mode()` のみを利用するためこの設定は不要になりました。`LOCAL_WEIGHT_THRESHOLD` はチャートパターン検出の重み付けにのみ使用されます。
+以前は `LOCAL_WEIGHT_THRESHOLD` を用いてローカル判定と LLM 判定の整合度を比較していましたが、現在は `analysis.detect_mode_simple()` のみを利用するためこの設定は不要になりました。`LOCAL_WEIGHT_THRESHOLD` はチャートパターン検出の重み付けにのみ使用されます。
 
 ## ブレイクアウト追随エントリー
 

--- a/analysis/mode_detector.py
+++ b/analysis/mode_detector.py
@@ -11,12 +11,12 @@ _REGIME_TO_MODE = {
 }
 
 
-def detect_mode(features: dict) -> str:
+def detect_mode_simple(features: dict) -> str:
     """Return trade mode based on preclassifier only."""
     regime = classify_regime(features)
     return _REGIME_TO_MODE.get(regime, "no_trade")
 
-__all__ = ["detect_mode"]
+__all__ = ["detect_mode_simple"]
 
 """Rule-based trade mode detection."""
 
@@ -115,4 +115,4 @@ def load_config(path: str | Path | None = None) -> dict:
     return merged
 
 
-__all__ = ["MarketContext", "detect_mode", "load_config"]
+__all__ = ["MarketContext", "detect_mode", "detect_mode_simple", "load_config"]

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -92,7 +92,8 @@ def test_decide_trade_mode_matrix(monkeypatch):
         "adx": [30],
         "volume": [60, 70, 80, 90, 100],
     }
-    assert md.detect_mode(inds) == "scalp_momentum"
+    ctx = md.MarketContext(price=0.0, indicators=inds)
+    assert md.detect_mode(ctx) == "scalp_momentum"
 
 
 def test_decide_trade_mode_scalp(monkeypatch):
@@ -101,6 +102,7 @@ def test_decide_trade_mode_scalp(monkeypatch):
     monkeypatch.setenv("MODE_EMA_SLOPE_MIN", "0.5")
     monkeypatch.setenv("MODE_ADX_MIN", "50")
     monkeypatch.setenv("MODE_VOL_MA_MIN", "100")
+    monkeypatch.setenv("ADX_TREND_MIN", "50")
     cm = _reload_composite()
     md = _reload_detector()
     inds = {
@@ -112,7 +114,8 @@ def test_decide_trade_mode_scalp(monkeypatch):
         "adx": [20],
         "volume": [20, 30, 40, 50, 60],
     }
-    assert md.detect_mode(inds) == "flat"
+    ctx = md.MarketContext(price=0.0, indicators=inds)
+    assert md.detect_mode(ctx) == "flat"
 
 
 def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
@@ -129,7 +132,8 @@ def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
         "adx": [10],
         "volume": [50, 50, 50, 50, 50],
     }
-    assert md.detect_mode(inds) == "scalp_momentum"
+    ctx = md.MarketContext(price=0.0, indicators=inds)
+    assert md.detect_mode(ctx) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(1.5, 1.0, 10) == "scalp_range"
     assert cm.decide_trade_mode_matrix(1.5, 1.0, 30) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(0.7, 1.0, 30) == "trend_follow"

--- a/tests/test_mode_selector.py
+++ b/tests/test_mode_selector.py
@@ -15,8 +15,8 @@ def test_classify_regime_boundary():
 
 def test_detect_mode():
     features = {"adx": 35, "atr_percentile": 50, "atr_pct": 20}
-    assert md.detect_mode(features) == "trend_follow"
+    assert md.detect_mode_simple(features) == "trend_follow"
     features["adx"] = 19
-    assert md.detect_mode(features) == "scalp_momentum"
+    assert md.detect_mode_simple(features) == "scalp_momentum"
     features["atr_percentile"] = 5
-    assert md.detect_mode(features) == "no_trade"
+    assert md.detect_mode_simple(features) == "no_trade"


### PR DESCRIPTION
## Summary
- rename duplicate `detect_mode` to `detect_mode_simple`
- export the new name via `__all__`
- adjust mode detector tests for new function
- update README examples

## Testing
- `pytest tests/test_mode_selector.py tests/test_adx_mode.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba4712a188333bd570a7c61f59a76