### PR TITLE
Implement M5 flow with risk filters and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ indicators, selects a strategy via OpenAI, and averages entry plans. For a
 detailed diagram see [docs/majority_vote_flow.md](docs/majority_vote_flow.md).
 An alternative fully technical pipeline is available under
 `piphawk_ai.tech_arch`; see [docs/technical_pipeline.md](docs/technical_pipeline.md).
+The module exposes `run_cycle()` which implements a simplified M5 entry flow.
 
 ## QuickStart
 

--- a/piphawk_ai/tech_arch/ai_decision.py
+++ b/piphawk_ai/tech_arch/ai_decision.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""OpenAI decision helper for the M5 pipeline."""
+
+import logging
+
+from backend.utils.openai_client import ask_openai
+
+logger = logging.getLogger(__name__)
+
+
+def call_llm(mode: str, signal: dict, indicators: dict) -> dict:
+    """Ask OpenAI for final entry decision and TP/SL multipliers."""
+    prompt = (
+        f"mode: {mode}\n"
+        f"signal: {signal.get('side')}\n"
+        f"atr: {indicators.get('atr')[-1] if indicators.get('atr') else 'na'}\n"
+        "Respond with JSON {\"go\":true/false, \"tp_mult\":float, \"sl_mult\":float}"
+    )
+    try:
+        resp = ask_openai(
+            prompt,
+            system_prompt="You are a trading assistant. Respond in JSON only.",
+        )
+        if isinstance(resp, dict):
+            return resp
+    except Exception as exc:
+        logger.warning("call_llm failed: %s", exc)
+    return {"go": False}
+
+
+__all__ = ["call_llm"]

--- a/piphawk_ai/tech_arch/m5_entry.py
+++ b/piphawk_ai/tech_arch/m5_entry.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""M5 signal detection helpers."""
+
+from backend.utils import env_loader
+
+
+def _last(series):
+    if series is None:
+        return None
+    try:
+        if hasattr(series, "iloc"):
+            return float(series.iloc[-1]) if len(series) else None
+        if isinstance(series, (list, tuple)):
+            return float(series[-1]) if series else None
+        return float(series)
+    except Exception:
+        return None
+
+
+def detect_entry(mode: str, candles: list[dict], indicators: dict) -> dict | None:
+    """Return signal dict ``{"side": "long"|"short"}`` or ``None``."""
+    if len(candles) < 2:
+        return None
+    last = candles[-1].get("mid", candles[-1])
+    prev = candles[-2].get("mid", candles[-2])
+    close = float(last.get("c"))
+    prev_high = float(prev.get("h"))
+    prev_low = float(prev.get("l"))
+
+    if mode == "trend":
+        if close > prev_high:
+            return {"side": "long"}
+        if close < prev_low:
+            return {"side": "short"}
+        return None
+
+    bb_upper = _last(indicators.get("bb_upper"))
+    bb_lower = _last(indicators.get("bb_lower"))
+    prev_close = float(prev.get("c"))
+    open_p = float(last.get("o", prev_close))
+
+    if bb_lower is not None and prev_close < bb_lower and close > open_p > prev_close:
+        return {"side": "long"}
+    if bb_upper is not None and prev_close > bb_upper and close < open_p < prev_close:
+        return {"side": "short"}
+
+    return None
+
+
+__all__ = ["detect_entry"]

--- a/piphawk_ai/tech_arch/market_classifier.py
+++ b/piphawk_ai/tech_arch/market_classifier.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Simple market classification utilities."""
+
+import logging
+from backend.utils import env_loader
+
+logger = logging.getLogger(__name__)
+
+
+def _last(series):
+    if series is None:
+        return None
+    try:
+        if hasattr(series, "iloc"):
+            return float(series.iloc[-1]) if len(series) else None
+        if isinstance(series, (list, tuple)):
+            return float(series[-1]) if series else None
+        return float(series)
+    except Exception:
+        return None
+
+
+def classify_market(indicators: dict) -> str:
+    """Return 'trend' or 'range' based on ADX and EMA divergence."""
+    adx = _last(indicators.get("adx"))
+    ema_fast = _last(indicators.get("ema_fast"))
+    ema_slow = _last(indicators.get("ema_slow"))
+
+    if None in (adx, ema_fast, ema_slow):
+        logger.debug("Insufficient indicators for classification")
+        return "range"
+
+    adx_min = float(env_loader.get_env("ADX_TREND_MIN", "25"))
+    ema_diff_min = float(env_loader.get_env("EMA_DIFF_MIN", "0.001"))
+
+    if adx >= adx_min and abs(ema_fast - ema_slow) >= ema_diff_min:
+        return "trend"
+    return "range"
+
+
+__all__ = ["classify_market"]

--- a/piphawk_ai/tech_arch/pipeline.py
+++ b/piphawk_ai/tech_arch/pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Technical entry pipeline orchestration."""
+"""M5 technical entry pipeline orchestrator."""
 
 from backend.orders import get_order_manager
 from backend.utils import env_loader
@@ -8,45 +8,47 @@ from monitoring import metrics_publisher
 
 from .market_context import build as build_context
 from .indicator_engine import compute
-from .mode_detector import detect_mode
-from .prefilters import generic_prefilters, trend_filters
-from .entry_gate import ask_entry
-from .rule_validator import validate_plan
-from .post_filters import apply_post_filters
+from .market_classifier import classify_market
+from .risk_filters import check_risk
+from .m5_entry import detect_entry
+from .ai_decision import call_llm
 
 
 def run_cycle() -> dict | None:
-    """Run one iteration of the technical entry pipeline."""
+    """Run one iteration of the simplified M5 pipeline."""
     ctx = build_context()
     indicators = compute(ctx.candles)
-    mode = detect_mode(indicators, ctx.candles)
+    mode = classify_market(indicators)
 
-    if not generic_prefilters(indicators, ctx.spread):
-        return None
-    if mode.startswith("trend") and not trend_filters(indicators):
+    if not check_risk(ctx, indicators):
         return None
 
-    plan = ask_entry(mode, indicators)
-    if not plan:
+    signal = detect_entry(mode, ctx.candles, indicators)
+    if not signal:
         return None
-    if not validate_plan(plan):
+
+    decision = call_llm(mode, signal, indicators)
+    if not decision.get("go"):
         return None
-    if not apply_post_filters(ctx.candles, indicators):
-        return None
+
+    atr = indicators.get("atr")
+    pip_size = 0.01 if env_loader.get_env("DEFAULT_PAIR", "USD_JPY").endswith("_JPY") else 0.0001
+    atr_val = float(atr[-1]) if atr else 0.0
+    tp_pips = atr_val / pip_size * float(decision.get("tp_mult", 2.0))
+    sl_pips = atr_val / pip_size * float(decision.get("sl_mult", 1.0))
 
     manager = get_order_manager()
     instrument = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
-    side = plan.get("side", "long")
-    tp = float(plan.get("tp", 0))
-    sl = float(plan.get("sl", 0))
-    lot = int(plan.get("lot", 1))
-    manager.place_market_with_tp_sl(instrument, lot, side, tp, sl)
+    side = signal.get("side", "long")
+    lot = int(decision.get("lot", 1))
+    manager.place_market_with_tp_sl(instrument, lot, side, tp_pips, sl_pips)
 
     try:
         metrics_publisher.incr_metric("tech_entry_total", 1, {"mode": mode})
     except Exception:
         pass
-    return plan
+
+    return {"side": side, "tp": tp_pips, "sl": sl_pips, "mode": mode}
 
 
 __all__ = ["run_cycle"]

--- a/piphawk_ai/tech_arch/risk_filters.py
+++ b/piphawk_ai/tech_arch/risk_filters.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Basic risk filters for the technical pipeline."""
+
+import logging
+import time
+
+from backend.utils import env_loader
+
+logger = logging.getLogger(__name__)
+
+_last_entry_ts: float = 0.0
+
+
+def _last(series):
+    if series is None:
+        return None
+    try:
+        if hasattr(series, "iloc"):
+            return float(series.iloc[-1]) if len(series) else None
+        if isinstance(series, (list, tuple)):
+            return float(series[-1]) if series else None
+        return float(series)
+    except Exception:
+        return None
+
+
+def _pip_size() -> float:
+    return 0.01 if env_loader.get_env("DEFAULT_PAIR", "USD_JPY").endswith("_JPY") else 0.0001
+
+
+def spread_filter(indicators: dict, spread: float) -> bool:
+    atr = _last(indicators.get("atr"))
+    if atr is None:
+        return True
+    limit = float(env_loader.get_env("MAX_SPREAD_ATR_RATIO", "0.15"))
+    return spread <= atr * limit
+
+
+def margin_filter(account: dict | None) -> bool:
+    if not account:
+        return True
+    try:
+        nav = float(account.get("NAV") or account.get("balance") or 0.0)
+        avail = float(account.get("marginAvailable", 0.0))
+        if nav <= 0:
+            return True
+        return (avail / nav) > 0.05
+    except Exception:
+        return True
+
+
+def duplicate_guard() -> bool:
+    global _last_entry_ts
+    interval = float(env_loader.get_env("DUPLICATE_INTERVAL_SEC", "60"))
+    now = time.time()
+    if now - _last_entry_ts < interval:
+        logger.debug("duplicate_guard blocked entry")
+        return False
+    _last_entry_ts = now
+    return True
+
+
+def vol_spike_guard(indicators: dict) -> bool:
+    atr_series = indicators.get("atr")
+    if atr_series is None:
+        return True
+    try:
+        if hasattr(atr_series, "iloc") and len(atr_series) >= 2:
+            prev = float(atr_series.iloc[-2])
+            last = float(atr_series.iloc[-1])
+        elif isinstance(atr_series, (list, tuple)) and len(atr_series) >= 2:
+            prev = float(atr_series[-2])
+            last = float(atr_series[-1])
+        else:
+            return True
+        if prev <= 0:
+            return True
+        ratio = last / prev
+        threshold = float(env_loader.get_env("VOL_SPIKE_RATIO", "2.0"))
+        return ratio < threshold
+    except Exception:
+        return True
+
+
+def check_risk(ctx, indicators: dict) -> bool:
+    return all(
+        [
+            spread_filter(indicators, ctx.spread),
+            margin_filter(ctx.account),
+            duplicate_guard(),
+            vol_spike_guard(indicators),
+        ]
+    )
+
+
+__all__ = ["check_risk", "spread_filter", "margin_filter", "duplicate_guard", "vol_spike_guard"]

--- a/tests/test_tech_arch_flow.py
+++ b/tests/test_tech_arch_flow.py
@@ -1,0 +1,66 @@
+import types
+import sys
+
+sys.modules.setdefault(
+    "monitoring.metrics_publisher",
+    types.SimpleNamespace(incr_metric=lambda *a, **k: None),
+)
+
+from piphawk_ai.tech_arch.pipeline import run_cycle
+from piphawk_ai.tech_arch.market_context import MarketContext
+
+
+def test_run_cycle(monkeypatch):
+    monkeypatch.setenv("DEFAULT_PAIR", "USD_JPY")
+    monkeypatch.setenv("OANDA_API_KEY", "x")
+    monkeypatch.setenv("OANDA_ACCOUNT_ID", "x")
+
+    ctx = MarketContext(
+        candles=[
+            {"mid": {"c": "1.0", "h": "1.0", "l": "1.0"}, "complete": True},
+            {"mid": {"c": "1.02", "h": "1.03", "l": "1.01"}, "complete": True},
+        ],
+        tick={"prices": [{"bids": [{"price": "1.02"}], "asks": [{"price": "1.03"}]}]},
+        spread=0.00005,
+        account={"NAV": "1000", "marginAvailable": "100"},
+    )
+
+    monkeypatch.setattr("piphawk_ai.tech_arch.market_context.build", lambda: ctx)
+    monkeypatch.setattr("piphawk_ai.tech_arch.pipeline.build_context", lambda: ctx)
+
+    indicators = {
+        "atr": [0.0005, 0.0005],
+        "adx": [30],
+        "ema_fast": [1.02],
+        "ema_slow": [1.00],
+        "bb_upper": [1.05],
+        "bb_lower": [0.95],
+    }
+    monkeypatch.setattr(
+        "piphawk_ai.tech_arch.indicator_engine.compute", lambda _c: indicators
+    )
+    monkeypatch.setattr(
+        "piphawk_ai.tech_arch.pipeline.compute", lambda _c: indicators
+    )
+
+    monkeypatch.setattr(
+        "piphawk_ai.tech_arch.ai_decision.call_llm",
+        lambda mode, signal, ind: {"go": True, "tp_mult": 2.0, "sl_mult": 1.0},
+    )
+    monkeypatch.setattr(
+        "piphawk_ai.tech_arch.pipeline.call_llm",
+        lambda mode, signal, ind: {"go": True, "tp_mult": 2.0, "sl_mult": 1.0},
+    )
+
+    calls = []
+    fake_mgr = types.SimpleNamespace(
+        place_market_with_tp_sl=lambda inst, lot, side, tp, sl: calls.append((inst, side, tp, sl))
+    )
+    monkeypatch.setattr("backend.orders.get_order_manager", lambda: fake_mgr)
+    monkeypatch.setattr("piphawk_ai.tech_arch.pipeline.get_order_manager", lambda: fake_mgr)
+
+    plan = run_cycle()
+    assert plan is not None
+    assert calls
+    assert plan["tp"] > plan["sl"]
+


### PR DESCRIPTION
## Summary
- document tech pipeline entry point in README
- implement market classification based on ADX and EMA gap
- add risk filters checking spread and margin conditions
- detect M5 entry signals
- wrap OpenAI call for decision making
- build new simplified pipeline using these pieces
- test the new pipeline behaviour

## Testing
- `./run_tests.sh tests/test_tech_arch_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_684be4f034b883338a9500454d618bfe