### PR TITLE
Add ENTRY_USE_AI toggle

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -144,6 +144,7 @@ from backend.strategy.higher_tf_analysis import analyze_higher_tf
 from backend.strategy import pattern_scanner
 from backend.strategy.momentum_follow import follow_breakout
 from piphawk_ai.analysis.regime_detector import RegimeDetector
+from piphawk_ai.tech_arch.pipeline import run_cycle as tech_run_cycle
 try:
     from piphawk_ai.vote_arch.pipeline import run_cycle, PipelineResult
     from piphawk_ai.vote_arch.entry_buffer import PlanBuffer
@@ -298,6 +299,7 @@ RUNNER_INSTANCE = None
 
 
 DEFAULT_PAIR = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
+ENTRY_USE_AI = env_loader.get_env("ENTRY_USE_AI", "true").lower() == "true"
 
 # Comma-separated chart pattern names used for AI analysis
 PATTERN_NAMES = [
@@ -2268,6 +2270,28 @@ class JobRunner:
                                 )
 
                             entry_params = {"tp_ratio": tp_ratio} if tp_ratio else None
+
+                            if not ENTRY_USE_AI:
+                                res = tech_run_cycle()
+                                if res:
+                                    price = float(tick_data["prices"][0]["bids"][0]["price"])
+                                    send_line_message(
+                                        f"【ENTRY】{DEFAULT_PAIR} {price} でエントリーしました。"
+                                    )
+                                    info(
+                                        "entry",
+                                        pair=DEFAULT_PAIR,
+                                        side=res.get("side"),
+                                        price=price,
+                                        lot=1.0,
+                                        regime=res.get("mode"),
+                                    )
+                                self.last_run = now
+                                update_oanda_trades()
+                                time.sleep(self.interval_seconds)
+                                timer.stop()
+                                continue
+
                             if self.use_vote_arch:
                                 pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
                                 bb_width = None

--- a/docs/technical_pipeline.md
+++ b/docs/technical_pipeline.md
@@ -73,3 +73,7 @@ flowchart TD
 EXIT ロジック（トレイリング SL, 時間切れ, AI exit 等）は既存のままで TP/SL に追随します。
 
 これが最新の最小フィルタ × M5 即エントリー × AI TP チューナー フローです。
+
+### ENTRY_USE_AI
+
+環境変数 `ENTRY_USE_AI` を `false` にすると、LLM への問い合わせを行わずに既定の TP/SL 倍率を用いてエントリーします。`backend/scheduler/job_runner.py` もこの変数を参照し、無効時は本パイプラインを用いて発注を行います。

--- a/piphawk_ai/tech_arch/pipeline.py
+++ b/piphawk_ai/tech_arch/pipeline.py
@@ -13,6 +13,8 @@ from .risk_filters import check_risk
 from .m5_entry import detect_entry
 from .ai_decision import call_llm
 
+ENTRY_USE_AI = env_loader.get_env("ENTRY_USE_AI", "true").lower() == "true"
+
 
 def run_cycle() -> dict | None:
     """Run one iteration of the simplified M5 pipeline."""
@@ -27,9 +29,12 @@ def run_cycle() -> dict | None:
     if not signal:
         return None
 
-    decision = call_llm(mode, signal, indicators)
-    if not decision.get("go"):
-        return None
+    if ENTRY_USE_AI:
+        decision = call_llm(mode, signal, indicators)
+        if not decision.get("go"):
+            return None
+    else:
+        decision = {"go": True, "tp_mult": 2.0, "sl_mult": 1.0}
 
     atr = indicators.get("atr")
     pip_size = 0.01 if env_loader.get_env("DEFAULT_PAIR", "USD_JPY").endswith("_JPY") else 0.0001


### PR DESCRIPTION
## Summary
- add ENTRY_USE_AI flag to tech entry pipeline
- respect the flag in JobRunner and tech pipeline
- document ENTRY_USE_AI usage

## Testing
- `./run_tests.sh` *(fails: 31 failed, 67 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b7879a8833395b8b64afc25ace1