### PR TITLE
Update AGENTS guidelines and tidy README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,25 @@
 - OpenAI API（AI戦略分析・決定）
 - Docker（コンテナ運用）
 - GitHub Actions（CI/CD、任意）
+
+## 2. 開発ガイドライン
+
+- 推奨 Python バージョンは **3.11** です。
+- コードは PEP8 に準拠させ、`isort` で import を整列してください。
+- Docstring は `pydocstyle` の基準に合わせます。
+- 静的解析は `ruff`、型チェックは `mypy` を利用します。
+
+### テスト・静的解析手順
+
+```bash
+pip install -r requirements-test.txt
+ruff check .
+isort .
+mypy .
+pytest
+```
+
+### PR 作成ルール
+
+- ブランチ名は `feature/<内容>`、`fix/<内容>`、`docs/<内容>` の形式とします。
+- PR には `## Summary` と `## Testing` セクションを含めてください。

--- a/README.md
+++ b/README.md
@@ -35,20 +35,13 @@ The module exposes `run_cycle()` which implements a simplified M5 entry flow.
    cd piphawk-ai
    ```
 
-2. Create .env from template
+2. Create `.env` from the template
 
    ```bash
    cp .env.template .env
    ```
-
-   Edit `.env` and set OPENAI_API_KEY, OANDA_API_KEY and OANDA_ACCOUNT_ID.
-   To disable AI entry or the vote pipeline add:
-
-   ```bash
-   ENTRY_USE_AI=false
-   USE_VOTE_PIPELINE=false
-   MAX_AI_EXIT_CALLS=5
-   ```
+   Edit the file and set your API keys. Detailed options are covered in the
+   [Setup](#setup) section.
 3. Build and run the backend container
 
    ```bash
@@ -66,6 +59,7 @@ The module exposes `run_cycle()` which implements a simplified M5 entry flow.
    ```
 
 See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
+For detailed instructions, refer to [Setup](#setup).
 
 ## Features
 
@@ -92,6 +86,8 @@ See [docs/quick_start_ja.md](docs/quick_start_ja.md) for the Japanese guide.
 - See [docs/training_guide.md](docs/training_guide.md) for training scripts.
 
 ## Setup
+
+See [AGENTS.md](AGENTS.md) for coding guidelines and test commands.
 
 1. **Clone the repository**
 
@@ -867,25 +863,14 @@ TP/SL の組み合わせは複数候補から期待値を計算し、最も利�
 
 ## Running Tests
 
-The repository includes a set of unit tests under `tests/`. You can run them
-quickly using the helper script:
+Use the helper script to run unit tests:
 
 ```bash
 ./run_tests.sh
 ```
 
-
-This script installs dependencies from `requirements-test.txt` and then launches
-`pytest` automatically. Recent additions include tests for the monitoring
-utilities such as ``SafetyTrigger`` and ``metrics_publisher``.
-
-Pass any extra arguments to forward them directly to `pytest`.
-
-For example, run only the technical pipeline tests with:
-
-```bash
-./run_tests.sh -k test_tech_arch_no_ai.py
-```
+For lint and type checks, refer to the commands listed in
+[AGENTS.md](AGENTS.md).
 
 ## プロンプト変更手順
 


### PR DESCRIPTION
## Summary
- add development guidelines for Python 3.11, isort, pydocstyle, ruff and mypy
- outline test commands and PR rules in AGENTS
- trim duplicate instructions in README
- reference AGENTS for coding rules

## Testing
- `ruff check .` *(fails: unused imports and E402 errors)*
- `mypy .` *(fails: missing stubs such as `fastapi`)*
- `pytest -q` *(fails: ModuleNotFoundError for `fastapi`)*

------
https://chatgpt.com/codex/tasks/task_e_684c25c612a083338c25dc76ff880289