### PR TITLE
Unify Bollinger implementation and add regression test

### DIFF
--- a/indicators/bollinger.py
+++ b/indicators/bollinger.py
@@ -2,27 +2,22 @@ from __future__ import annotations
 
 """Bollinger Band utilities for multiple timeframes."""
 
-from typing import Sequence, Mapping, Dict
+from typing import Dict, Mapping, Sequence
 
-try:
-    import pandas as pd
-except ImportError as e:  # pragma: no cover - dependency guard
-    raise ImportError(
-        "Pandas is required for indicator calculations."
-        " Install it with 'pip install pandas'."
-    ) from e
+from backend.indicators.bollinger import calculate_bollinger_bands
 
 
 def _calc_single(prices: Sequence[float], window: int = 20, num_std: float = 2.0) -> Dict[str, float]:
     """Return latest Bollinger values as a dict."""
-    series = pd.Series(prices)
-    ma = series.rolling(window=window).mean()
-    std = series.rolling(window=window).std()
-    if ma.empty:
+    df = calculate_bollinger_bands(prices, window=window, num_std=num_std)
+    if df.empty:
         return {"middle": 0.0, "upper": 0.0, "lower": 0.0}
-    middle = ma.iloc[-1]
-    sd = std.iloc[-1]
-    return {"middle": middle, "upper": middle + num_std * sd, "lower": middle - num_std * sd}
+    latest = df.iloc[-1]
+    return {
+        "middle": float(latest["middle_band"]),
+        "upper": float(latest["upper_band"]),
+        "lower": float(latest["lower_band"]),
+    }
 
 
 def multi_bollinger(

--- a/tests/test_bollinger_regression.py
+++ b/tests/test_bollinger_regression.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pandas as pd
+
+from indicators.bollinger import multi_bollinger
+
+
+def old_calc_single(prices, window=20, num_std=2.0):
+    series = pd.Series(prices)
+    ma = series.rolling(window=window).mean()
+    std = series.rolling(window=window).std()
+    if ma.empty:
+        return {"middle": 0.0, "upper": 0.0, "lower": 0.0}
+    middle = ma.iloc[-1]
+    sd = std.iloc[-1]
+    return {"middle": middle, "upper": middle + num_std * sd, "lower": middle - num_std * sd}
+
+
+def test_multi_bollinger_regression():
+    data = {
+        "A": np.linspace(1, 10, 10),
+        "B": np.linspace(2, 11, 10),
+    }
+    expected = {tf: old_calc_single(p, window=3, num_std=1) for tf, p in data.items()}
+    result = multi_bollinger(data, window=3, num_std=1)
+    for tf in data:
+        for key in ["middle", "upper", "lower"]:
+            assert abs(expected[tf][key] - result[tf][key]) <= 1e-8

--- a/tests/test_scalp_manager.py
+++ b/tests/test_scalp_manager.py
@@ -1,12 +1,13 @@
 import importlib
-import time
+import os
 import sys
+import time
 from types import SimpleNamespace
 
-import os
 os.environ.setdefault("OANDA_API_KEY", "x")
 os.environ.setdefault("OANDA_ACCOUNT_ID", "x")
 import execution.scalp_manager as sm
+
 
 class DummyOM:
     def __init__(self):
@@ -65,18 +66,24 @@ def test_hold_seconds_varies_with_atr(monkeypatch):
     sm.order_mgr = sm.OrderManager()
 
     candle = {"mid": {"h": "1.0", "l": "0.9", "c": "0.95"}, "complete": True}
-    fetch_mod = SimpleNamespace(fetch_candles=lambda *a, **k: [candle] * 20)
-    sys.modules["backend.market_data.candle_fetcher"] = fetch_mod
-
-    atr_mod_small = SimpleNamespace(calculate_atr=lambda *a, **k: FakeSeries(0.001))
-    sys.modules["backend.indicators.atr"] = atr_mod_small
+    fetch_func = lambda *a, **k: [candle] * 20
+    atr_small = lambda *a, **k: FakeSeries(0.001)
 
     monkeypatch.setenv("HOLD_TIME_MIN", "1")
     monkeypatch.setenv("HOLD_TIME_MAX", "5000")
-    hold_small = sm.get_dynamic_hold_seconds("EUR_USD")
+    hold_small = sm.get_dynamic_hold_seconds(
+        "EUR_USD",
+        fetch_candles_func=fetch_func,
+        calculate_atr_func=atr_small,
+        pip_size_fn=lambda i: 0.0001,
+    )
 
-    atr_mod_big = SimpleNamespace(calculate_atr=lambda *a, **k: FakeSeries(0.01))
-    sys.modules["backend.indicators.atr"] = atr_mod_big
-    hold_big = sm.get_dynamic_hold_seconds("EUR_USD")
+    atr_big = lambda *a, **k: FakeSeries(0.01)
+    hold_big = sm.get_dynamic_hold_seconds(
+        "EUR_USD",
+        fetch_candles_func=fetch_func,
+        calculate_atr_func=atr_big,
+        pip_size_fn=lambda i: 0.0001,
+    )
 
     assert hold_big > hold_small


### PR DESCRIPTION
## Summary
- remove duplicate Bollinger calculation logic
- refactor `get_dynamic_hold_seconds` to accept DI parameters
- adjust scalp manager tests for new function signature
- add regression test to ensure Bollinger results match previous logic

## Testing
- `ruff check .`
- `isort execution/scalp_manager.py indicators/bollinger.py tests/test_scalp_manager.py tests/test_scalp_manager_hold.py tests/test_bollinger_regression.py`
- `mypy .`
- `pytest -q` *(fails: 31 failed, 67 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684c27a44ab48333939f7072d9d7d969