### PR TITLE
fix integration tests dependencies

### DIFF
--- a/monitoring/metrics_publisher.py
+++ b/monitoring/metrics_publisher.py
@@ -5,10 +5,14 @@
 import json
 import logging
 from datetime import datetime
-from backend.utils import env_loader
 
-from kafka import KafkaProducer
+try:
+    from kafka import KafkaProducer
+except Exception:  # pragma: no cover - Kafka optional
+    KafkaProducer = None
 from prometheus_client import Gauge
+
+from backend.utils import env_loader
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- expose `ask_openai` alias for testing hooks
- call `ask_openai` so unit tests can stub OpenAI requests
- make kafka dependency optional for metrics publisher

## Testing
- `pytest backend/tests/test_exit_cooldown.py::TestExitDecisionCooldown::test_exit_decision_skipped_during_cooldown backend/tests/test_higher_tf_tp.py::TestHigherTfTp::test_tp_uses_nearest_higher_tf_pivot tests/test_entry_rules.py tests/test_force_close.py tests/test_rule_selector.py -q`
- `ruff check backend/strategy/openai_analysis.py monitoring/metrics_publisher.py`
- `mypy backend/strategy/openai_analysis.py monitoring/metrics_publisher.py`


------
https://chatgpt.com/codex/tasks/task_e_684c350c59548333be289e5564e5e71e