### PR TITLE
fix env loader default

### DIFF
--- a/backend/tests/test_env_loader.py
+++ b/backend/tests/test_env_loader.py
@@ -1,0 +1,42 @@
+import importlib
+import os
+import sys
+import types
+import unittest
+
+
+class TestEnvLoader(unittest.TestCase):
+    def setUp(self):
+        self._mods: list[str] = []
+
+        def add(name: str, mod: types.ModuleType) -> None:
+            sys.modules[name] = mod
+            self._mods.append(name)
+
+        requests_stub = types.ModuleType("requests")
+        add("requests", requests_stub)
+
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *a, **k: None
+        add("dotenv", dotenv_stub)
+
+        self.env_loader = importlib.import_module("backend.utils.env_loader")
+
+    def tearDown(self):
+        for name in self._mods:
+            sys.modules.pop(name, None)
+        os.environ.pop("EMPTY_VAR", None)
+        os.environ.pop("MISSING_VAR", None)
+
+    def test_empty_env_returns_default(self):
+        os.environ["EMPTY_VAR"] = ""
+        self.assertEqual(
+            self.env_loader.get_env("EMPTY_VAR", "default"),
+            "default",
+        )
+
+    def test_missing_env_returns_default(self):
+        self.assertEqual(
+            self.env_loader.get_env("MISSING_VAR", "fallback"),
+            "fallback",
+        )

--- a/backend/utils/env_loader.py
+++ b/backend/utils/env_loader.py
@@ -35,8 +35,12 @@ def load_env(paths: Iterable[str | Path], *, override: bool = True) -> None:
 
 def get_env(key: str, default: Optional[str] = None) -> Optional[str]:
     """Return the value of an environment variable."""
-    val = os.getenv(key, default)
+    val = os.getenv(key)
     if isinstance(val, str):
         # 行末のコメントや余分な空白を除去する
         val = val.split("#", 1)[0].strip()
+        if not val:
+            return default
+    if val is None:
+        return default
     return val


### PR DESCRIPTION
## Summary
- handle empty env vars when loading environment values
- add test covering env_loader behaviour

## Testing
- `ruff check .`
- `isort --check --diff .` *(fails: imports not sorted)*
- `mypy .`
- `pytest -q` *(fails: 47 errors during collection)*
- `pytest backend/tests/test_env_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3835b99883338b4473964dabe8ef