### PR TITLE
Update env precedence handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ See [AGENTS.md](AGENTS.md) for coding guidelines and test commands.
    # Edit `.env` and set OPENAI_API_KEY, OANDA_API_KEY and OANDA_ACCOUNT_ID
    ```
 
-   アプリケーションは `.env`, `backend/config/settings.env`, `backend/config/secret.env` の順で環境変数を読み込みます。
-   必要に応じて `settings.env` の値も調整してください。
+   アプリケーションが参照する環境変数の優先順位は
+   **外部で設定された値 → `.env` → `backend/config/settings.env` → `backend/config/secret.env`**
+   です。必要に応じて `settings.env` の値も調整してください。
 詳細な変数解説は [docs/env_reference.md](docs/env_reference.md) を参照してください。
 
 ### Directory Structure

--- a/backend/utils/env_loader.py
+++ b/backend/utils/env_loader.py
@@ -22,7 +22,7 @@ _DEFAULT_FILES = [
 # Automatically load default env files if they exist
 for _file in _DEFAULT_FILES:
     if _file.exists():
-        load_dotenv(_file, override=True)
+        load_dotenv(_file, override=False)
 
 
 def load_env(paths: Iterable[str | Path], *, override: bool = True) -> None:

--- a/docs/env_reference.md
+++ b/docs/env_reference.md
@@ -1,6 +1,8 @@
 # 主要環境変数リファレンス
 
-アプリケーションは `.env`、`backend/config/settings.env`、`backend/config/secret.env` の順に値を読み込みます。よく使う変数を以下にまとめます。
+アプリケーションが参照する環境変数の優先順位は
+**外部で設定された値 → `.env` → `backend/config/settings.env` → `backend/config/secret.env`**
+の順になります。よく使う変数を以下にまとめます。
 
 | 変数 | デフォルト値 | 用途 | 設定例 |
 |---|---|---|---|


### PR DESCRIPTION
## Summary
- adjust default env loading to keep existing variables
- document env variable precedence in README and env reference

## Testing
- `ruff check .`
- `isort .` *(ran but reverted changes)*
- `mypy .`
- `pytest -q` *(failed: 25 failed, 75 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684c3e0129dc8333978b7f7f0a684bfe