### PR TITLE
docs: add fallback env vars

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -380,3 +380,30 @@ SCALE_TRIGGER_ATR=0.5
 ### USE_VOTE_ARCH
 
 vote_arch 全体を無効化したい場合に `false` を指定します。
+
+### FALLBACK_FORCE_ON_NO_SIDE
+
+AI が `side:"no"` を返しても、現在のトレンド方向へエントリーを強制するかを決め
+ます。デフォルトは `false` です。
+
+### FALLBACK_DEFAULT_SL_PIPS
+
+AI が SL 値を返さない場合に利用する予備の幅(pips)。デフォルトは `8` です。
+
+### FALLBACK_DEFAULT_TP_PIPS
+
+AI が TP 値を返さない場合に利用する予備の幅(pips)。デフォルトは `12` です。
+
+### FALLBACK_DYNAMIC_RISK
+
+`true` を指定すると、指標から自動算出した TP/SL を使用します。デフォルトは
+`false` です。
+
+設定例:
+
+```
+FALLBACK_FORCE_ON_NO_SIDE=true
+FALLBACK_DEFAULT_SL_PIPS=10
+FALLBACK_DEFAULT_TP_PIPS=15
+FALLBACK_DYNAMIC_RISK=true
+```


### PR DESCRIPTION
## Summary
- add documentation for fallback env variables

## Testing
- `ruff check .`
- `isort .` *(reverted changes)*
- `mypy .`
- `pytest -q` *(fails: AttributeError: module 'pandas' has no attribute 'DataFrame')*

------
https://chatgpt.com/codex/tasks/task_e_684c44e383c08333870cda9e37daf0f7