### PR TITLE
fix entry_logic return and add test

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -1,11 +1,12 @@
-from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
-from backend.orders.order_manager import OrderManager
-from backend.logs.trade_logger import log_trade
-from backend.strategy.risk_manager import calc_lot_size
-from risk.tp_sl_manager import adjust_sl_for_rr
 import importlib
 
 from backend.filters.false_break_filter import should_skip as false_break_skip
+from backend.logs.trade_logger import log_trade
+from backend.orders.order_manager import OrderManager
+from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
+from backend.strategy.risk_manager import calc_lot_size
+from risk.tp_sl_manager import adjust_sl_for_rr
+
 # trend_pullback filter removed – AI handles pullback assessment
 
 try:
@@ -36,12 +37,11 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from backend.filters.extension_block import is_extension
 
-
 try:
 
     from backend.filters.h1_level_block import (
-        is_near_h1_support,
         is_near_h1_resistance,
+        is_near_h1_support,
     )
 except ModuleNotFoundError:  # pragma: no cover
 
@@ -54,16 +54,21 @@ except ModuleNotFoundError:  # pragma: no cover
         return False
 
 
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+
 from backend.risk_manager import (
-    validate_rrr,
-    validate_rrr_after_cost,
-    validate_sl,
+    calc_fallback_tp_sl,
     calc_min_sl,
     get_recent_swing_diff,
     is_high_vol_session,
-    calc_fallback_tp_sl,
+    validate_rrr,
+    validate_rrr_after_cost,
+    validate_sl,
 )
-from datetime import datetime, timezone
 from backend.utils import env_loader
 
 # signals パッケージはプロジェクト直下にあるため、
@@ -72,10 +77,6 @@ from piphawk_ai.signals.composite_mode import (
     decide_trade_mode,
     decide_trade_mode_detail,
 )
-import os
-import logging
-import json
-import uuid
 
 logger = logging.getLogger(__name__)
 log_level = env_loader.get_env("LOG_LEVEL", "INFO").upper()
@@ -1267,4 +1268,4 @@ def process_entry(
             is_manual=False,
         )
 
-    return True
+    return bool(trade_result)

--- a/tests/test_process_entry_return.py
+++ b/tests/test_process_entry_return.py
@@ -1,0 +1,61 @@
+import os
+import types
+
+os.environ.setdefault("OANDA_API_KEY", "x")
+os.environ.setdefault("OANDA_ACCOUNT_ID", "x")
+
+from backend.strategy import entry_logic
+
+
+class FakeSeries:
+    def __init__(self, data):
+        self._data = list(data)
+
+        class _ILoc:
+            def __init__(self, outer):
+                self._outer = outer
+
+            def __getitem__(self, idx):
+                return self._outer._data[idx]
+
+        self.iloc = _ILoc(self)
+
+    def __getitem__(self, idx):
+        return self._data[idx]
+
+    def __len__(self):
+        return len(self._data)
+
+
+def test_process_entry_returns_false(monkeypatch):
+    monkeypatch.setattr(entry_logic.order_manager, "enter_trade", lambda *a, **k: None)
+    monkeypatch.setattr(entry_logic, "decide_trade_mode", lambda *_a, **_k: "trend")
+    monkeypatch.setattr(entry_logic, "decide_trade_mode_detail", lambda *_a, **_k: ("trend", 0.0, {}))
+    monkeypatch.setattr(
+        "backend.strategy.openai_analysis.get_trade_plan",
+        lambda *a, **k: {"entry": {"side": "long", "mode": "market"}, "risk": {"tp_pips": 2, "sl_pips": 1}},
+    )
+    monkeypatch.setattr(
+        "backend.strategy.openai_analysis.should_convert_limit_to_market", lambda ctx: True
+    )
+    monkeypatch.setattr(
+        "backend.strategy.openai_analysis.evaluate_exit",
+        lambda *a, **k: types.SimpleNamespace(action="HOLD", confidence=0.0, reason=""),
+    )
+    monkeypatch.setattr("backend.logs.trade_logger.log_trade", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "backend.strategy.dynamic_pullback.calculate_dynamic_pullback", lambda *a, **k: 0
+    )
+    monkeypatch.setenv("PIP_SIZE", "0.01")
+
+    indicators = {"atr": FakeSeries([0.1])}
+    candles = []
+    market_data = {
+        "prices": [
+            {"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}
+        ]
+    }
+    result = entry_logic.process_entry(
+        indicators, candles, market_data, candles_dict={"M5": candles}, tf_align=None
+    )
+    assert result is False


### PR DESCRIPTION
## Summary
- fix market order return value in entry logic
- add unit test for process_entry() return value when order manager fails

## Testing
- `ruff check .`
- `isort backend/strategy/entry_logic.py tests/test_process_entry_return.py`
- `mypy .`
- `pytest tests/test_process_entry_return.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684c44cf1a68833398066fbddfdca8d5