### PR TITLE
fix: skip TF align when forced entry

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -236,6 +236,7 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 - VOL_SPIKE_ADX_MULT / VOL_SPIKE_ATR_MULT: BB幅がしきい値を下回っていても、ADXまたはATRがこの倍率で急拡大した場合は成行エントリーに切り替える
 - STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
 - ALIGN_STRICT: 上記と同義のエイリアス
+- FALLBACK_FORCE_ON_NO_SIDE: AI が "no" と答えたときトレンド方向へエントリーを強制するオプション。使用時は STRICT_TF_ALIGN の影響を受けない。
 - TF_EMA_WEIGHTS: 上位足EMA整合の重み付け (例 `M5:0.4,M15:0.2,H1:0.3,H4:0.1`)
 - AI_ALIGN_WEIGHT: AIの方向性をEMA整合に加味する重み
 - ALIGN_BYPASS_ADX: M5 ADXがこの値以上でAI方向が設定されている場合、整合チェックをスキップ (デフォルト30)

--- a/tests/test_forced_entry_bypass.py
+++ b/tests/test_forced_entry_bypass.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+import types
+
+import backend.strategy.entry_logic as el
+
+
+def setup_stub(monkeypatch, force=False):
+    # stub openai_analysis module
+    oa = types.ModuleType("backend.strategy.openai_analysis")
+    oa.get_trade_plan = lambda *a, **k: {"entry": {"side": "no"}, "risk": {}}
+    oa.is_entry_blocked_by_recent_candles = lambda *a, **k: False
+    monkeypatch.setitem(sys.modules, "backend.strategy.openai_analysis", oa)
+
+    # stub dependencies
+    monkeypatch.setattr(el.order_manager, "enter_trade", lambda *a, **k: True)
+    monkeypatch.setattr(el, "log_trade", lambda *a, **k: None)
+    monkeypatch.setattr(el, "is_extension", lambda *a, **k: False)
+    monkeypatch.setattr(el, "false_break_skip", lambda *a, **k: False)
+    monkeypatch.setattr("backend.risk_manager.cost_guard", lambda *a, **k: True)
+    monkeypatch.setattr("piphawk_ai.analysis.signal_filter.is_multi_tf_aligned", lambda *a, **k: None)
+
+    monkeypatch.setenv("STRICT_TF_ALIGN", "true")
+    monkeypatch.setenv("FALLBACK_FORCE_ON_NO_SIDE", "true" if force else "false")
+
+    importlib.reload(el)
+
+    kwargs = dict(
+        indicators={},
+        candles=[],
+        market_data={"prices": [{"bids": [{"price": "1"}], "asks": [{"price": "1.01"}]}]},
+        market_cond={"market_condition": "trend", "trend_direction": "long"},
+        candles_dict={"M5": []},
+        tf_align="M5",
+        indicators_multi={"M5": {}},
+    )
+    return kwargs
+
+
+def test_forced_entry_bypass(monkeypatch):
+    kwargs = setup_stub(monkeypatch, force=False)
+    assert el.process_entry(**kwargs) is False
+
+    kwargs = setup_stub(monkeypatch, force=True)
+    assert el.process_entry(**kwargs) is True
+


### PR DESCRIPTION
## Summary
- skip multi-TF alignment when FALLBACK_FORCE_ON_NO_SIDE triggers forced entry
- note behaviour in env vars docs
- add regression test for forced entry bypass

## Testing
- `ruff check backend/strategy/entry_logic.py tests/test_forced_entry_bypass.py`
- `isort backend/strategy/entry_logic.py tests/test_forced_entry_bypass.py`
- `mypy .`
- `pytest -q` *(fails: 25 failed, 75 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684c44dd80bc8333bb048a59be356137