### PR TITLE
fix: fallback to micro scalp plan

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -1,11 +1,12 @@
-from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
-from backend.orders.order_manager import OrderManager
-from backend.logs.trade_logger import log_trade
-from backend.strategy.risk_manager import calc_lot_size
-from risk.tp_sl_manager import adjust_sl_for_rr
 import importlib
 
 from backend.filters.false_break_filter import should_skip as false_break_skip
+from backend.logs.trade_logger import log_trade
+from backend.orders.order_manager import OrderManager
+from backend.strategy.dynamic_pullback import calculate_dynamic_pullback
+from backend.strategy.risk_manager import calc_lot_size
+from risk.tp_sl_manager import adjust_sl_for_rr
+
 # trend_pullback filter removed – AI handles pullback assessment
 
 try:
@@ -36,12 +37,11 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from backend.filters.extension_block import is_extension
 
-
 try:
 
     from backend.filters.h1_level_block import (
-        is_near_h1_support,
         is_near_h1_resistance,
+        is_near_h1_support,
     )
 except ModuleNotFoundError:  # pragma: no cover
 
@@ -54,16 +54,21 @@ except ModuleNotFoundError:  # pragma: no cover
         return False
 
 
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+
 from backend.risk_manager import (
-    validate_rrr,
-    validate_rrr_after_cost,
-    validate_sl,
+    calc_fallback_tp_sl,
     calc_min_sl,
     get_recent_swing_diff,
     is_high_vol_session,
-    calc_fallback_tp_sl,
+    validate_rrr,
+    validate_rrr_after_cost,
+    validate_sl,
 )
-from datetime import datetime, timezone
 from backend.utils import env_loader
 
 # signals パッケージはプロジェクト直下にあるため、
@@ -72,10 +77,6 @@ from piphawk_ai.signals.composite_mode import (
     decide_trade_mode,
     decide_trade_mode_detail,
 )
-import os
-import logging
-import json
-import uuid
 
 logger = logging.getLogger(__name__)
 log_level = env_loader.get_env("LOG_LEVEL", "INFO").upper()
@@ -322,31 +323,37 @@ def process_entry(
         try:
             import importlib
 
-            micro_enabled = env_loader.get_env("MICRO_SCALP_ENABLED", "false").lower() == "true"
-            micro_plan = None
-            if micro_enabled:
-                from backend.market_data import calc_tick_features
-
-                ticks = []
-                if isinstance(strategy_params, dict):
-                    ticks = strategy_params.get("ticks") or []
-                mscalp = importlib.import_module("backend.strategy.openai_micro_scalp")
-                feats = calc_tick_features(ticks)
-                micro_plan = mscalp.get_plan(feats)
-
-            if micro_plan and micro_plan.get("enter"):
-                plan = micro_plan
-            else:
-                scalp_ai = importlib.import_module(
-                    "backend.strategy.openai_scalp_analysis"
-                )
-                plan = scalp_ai.get_scalp_plan(
-                    indicators,
-                    candles,
-                    higher_tf_direction=(market_cond or {}).get("trend_direction"),
-                )
+            scalp_ai = importlib.import_module(
+                "backend.strategy.openai_scalp_analysis"
+            )
+            plan = scalp_ai.get_scalp_plan(
+                indicators,
+                candles,
+                higher_tf_direction=(market_cond or {}).get("trend_direction"),
+            )
 
             ai_side = plan.get("side")
+            if ai_side not in ("long", "short"):
+                micro_plan = None
+                if env_loader.get_env("MICRO_SCALP_ENABLED", "false").lower() == "true":
+                    from backend.market_data import calc_tick_features
+
+                    ticks = []
+                    if isinstance(strategy_params, dict):
+                        ticks = strategy_params.get("ticks") or []
+                    mscalp = importlib.import_module(
+                        "backend.strategy.openai_micro_scalp"
+                    )
+                    feats = calc_tick_features(ticks)
+                    micro_plan = mscalp.get_plan(feats)
+
+                if micro_plan and micro_plan.get("enter"):
+                    plan = micro_plan
+                    ai_side = plan.get("side")
+                else:
+                    logging.info("Scalp AI returned no tradable side → skip entry")
+                    return False
+
             if ai_side in ("long", "short"):
                 tp_pips = float(
                     plan.get("tp_pips", env_loader.get_env("SCALP_TP_PIPS", "2"))

--- a/tests/test_entry_logic.py
+++ b/tests/test_entry_logic.py
@@ -1,0 +1,79 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+
+def test_micro_scalp_on_ai_no(monkeypatch):
+    # 環境変数設定
+    monkeypatch.setenv("MICRO_SCALP_ENABLED", "true")
+    monkeypatch.setenv("SCALP_SUPPRESS_ADX_MAX", "0")
+    monkeypatch.setenv("SCALP_TP_PIPS", "2")
+    monkeypatch.setenv("SCALP_SL_PIPS", "1")
+    monkeypatch.setenv("OANDA_API_KEY", "x")
+    monkeypatch.setenv("OANDA_ACCOUNT_ID", "x")
+
+    import backend.strategy.entry_logic as el
+
+    # モジュールパッチ
+    scalp_mod = SimpleNamespace(get_scalp_plan=lambda *a, **k: {"side": "no"})
+    micro_mod = SimpleNamespace(
+        get_plan=lambda *a, **k: {
+            "enter": True,
+            "side": "short",
+            "tp_pips": 3,
+            "sl_pips": 1,
+        }
+    )
+    md_mod = SimpleNamespace(calc_tick_features=lambda _t: {})
+
+    monkeypatch.setitem(sys.modules, "backend.strategy.openai_scalp_analysis", scalp_mod)
+    monkeypatch.setitem(sys.modules, "backend.strategy.openai_micro_scalp", micro_mod)
+    monkeypatch.setitem(sys.modules, "backend.market_data", md_mod)
+
+    # OrderManager ダミー
+    calls = {}
+
+    class DummyOM:
+        def enter_trade(self, side, lot_size, market_data, strategy_params, force_limit_only=False):
+            calls["side"] = side
+            calls["tp_pips"] = strategy_params.get("tp_pips")
+            calls["sl_pips"] = strategy_params.get("sl_pips")
+            return {"ok": True}
+
+    monkeypatch.setattr(el, "order_manager", DummyOM())
+
+    # 依存関数のスタブ
+    monkeypatch.setattr(el, "calc_lot_size", lambda *a, **k: 1.0)
+    monkeypatch.setattr(el, "_calc_scalp_tp_sl", lambda *a, **k: (None, None))
+    monkeypatch.setattr(el, "_calc_reversion_tp_sl", lambda *a, **k: (None, None))
+    monkeypatch.setattr(el, "false_break_skip", lambda *_a, **_k: False)
+
+    indicators = {
+        "adx": [25],
+        "bb_upper": [1.2],
+        "bb_lower": [1.0],
+        "atr": [0.1],
+        "rsi": [50],
+    }
+    candle = {"mid": {"c": "1", "h": "1", "l": "1"}, "complete": True}
+    candles = [candle] * 20
+    market_data = {
+        "prices": [{
+            "instrument": "USD_JPY",
+            "bids": [{"price": "1.0"}],
+            "asks": [{"price": "1.01"}],
+        }]
+    }
+
+    res = el.process_entry(
+        indicators,
+        candles,
+        market_data,
+        market_cond={"trend_direction": "long"},
+        strategy_params={"ticks": []},
+    )
+
+    assert res is True
+    assert calls["side"] == "short"
+    assert calls["tp_pips"] == 3
+    assert calls["sl_pips"] == 1


### PR DESCRIPTION
## Summary
- detect when scalp AI returns `no` side
- fallback to micro scalp decision when enabled
- add regression test for micro scalp fallback

## Testing
- `pip install -r requirements-test.txt`
- `ruff check tests/test_entry_logic.py backend/strategy/entry_logic.py`
- `isort tests/test_entry_logic.py backend/strategy/entry_logic.py`
- `mypy tests/test_entry_logic.py backend/strategy/entry_logic.py`
- `pytest -q tests/test_entry_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_684c46e88d7083338dc684da482a5c8d