### PR TITLE
fix/test-httpx-dependency

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,3 +10,4 @@ fastapi
 apscheduler
 line-bot-sdk
 prometheus-client
+httpx==0.28.1


### PR DESCRIPTION
## Summary
- add `httpx` into test requirements

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .` *(changes reverted)*
- `mypy .`
- `pytest -q` *(fails: ImportError for other modules, but no `httpx` import errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c48ac38d083339c819f051194f1a9