### PR TITLE
fix json parse and cleanup settings

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -39,8 +39,8 @@ AI_COOLDOWN_SEC_OPEN=20          # パッチ: 30s → 20s に短縮
 MAX_AI_CALLS_PER_LOOP=4          # 1ループあたりのAI呼び出し上限
 MIN_TRADE_LOT=30.0               # 最小ロット数
 MAX_TRADE_LOT=40.0               # 最大ロット数
-SCALE_LOT_SIZE=0.5               # 追加エントリー時のロット
-SCALE_MAX_POS=1                  # 追加エントリー最大回数
+SCALE_LOT_SIZE=1.0               # 同ロットで追撃
+SCALE_MAX_POS=3                  # 追加エントリー 3 件まで
 SCALE_TRIGGER_ATR=0.0            # 追加エントリーATR倍率
 SL_COOLDOWN_SEC=300              # SL後の再エントリー待機秒
 
@@ -318,7 +318,7 @@ REGIME_BB_NARROW=0.05
 
 # === Optional configurations ===
 RISK_PER_TRADE=0.005            # 1トレードあたりのリスク比率
-CLEANUP_THRESHOLD=80            # ディスク使用率警告閾値
+CLEANUP_THRESHOLD=90            # ディスク使用率警告閾値
 HTTP_MAX_RETRIES=3              # HTTPリトライ回数
 HTTP_BACKOFF_CAP_SEC=8          # HTTPバックオフ上限秒
 HTTP_TIMEOUT_SEC=10             # HTTPタイムアウト秒


### PR DESCRIPTION
## Summary
- handle OpenAI JSON string in `get_trade_plan`
- relax disk cleanup threshold
- allow up to three scale positions with same lot size

## Testing
- `ruff check .`
- `isort --check .` *(fails: many files unsorted)*
- `mypy .`
- `pytest -q` *(fails: 25 failed, 75 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c478321f483338bf34292bb4ec83a