### PR TITLE
fix: relax entry filters

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -34,8 +34,8 @@ SHORT_TP_ATR_RATIO=0.6           # ATR短期倍率によるTP調整
 TP_BB_RATIO=1.0                  # BB幅からTP算出する倍率
 
 # === AIクールダウンとロット制限 ===
-AI_COOLDOWN_SEC_FLAT=10          # ノーポジ時のAI呼び出し間隔
-AI_COOLDOWN_SEC_OPEN=20          # パッチ: 30s → 20s に短縮
+AI_COOLDOWN_SEC_FLAT=5           # ノーポジ時のAI呼び出し間隔を短縮
+AI_COOLDOWN_SEC_OPEN=15          # ポジション保有時のAI呼び出し間隔も短縮
 MAX_AI_CALLS_PER_LOOP=4          # 1ループあたりのAI呼び出し上限
 MIN_TRADE_LOT=30.0               # 最小ロット数
 MAX_TRADE_LOT=40.0               # 最大ロット数
@@ -179,7 +179,7 @@ MM_DRAW_MAX_ATR_RATIO=2.0        # ATR倍率によるドローダウン許容幅
 # === TP/SL確率フィルター ===
 MIN_TP_PROB=0.6                  # TP達成確率しきい値
 TP_PROB_HOURS=1                  # 確率計算に使う時間
-MIN_NET_TP_PIPS=1                # スプレッド控除後の最小TP
+MIN_NET_TP_PIPS=0.5              # スプレッド控除後の最小TPを緩和
 MIN_EXPECTED_VALUE=0.0           # TPとSLの期待値下限
 
 # === 指値エントリー設定 ===
@@ -194,7 +194,7 @@ PULLBACK_ATR_RATIO=0.3           # ATR比によるプルバック閾値
 EXT_BLOCK_ATR=1.5                # EMA乖離ATR倍率でエントリーブロック
 REENTRY_TRIGGER_PIPS=1           # 再エントリー用乖離幅
 BREAK_PIPS_MIN=1                 # ブレイクとみなす最小pips
-BYPASS_PULLBACK_ADX_MIN=20       # ADXがこの値以上ならプルバック待ちをスキップ
+BYPASS_PULLBACK_ADX_MIN=15       # ADXがこの値以上ならプルバック待ちをスキップ
 ALLOW_NO_PULLBACK_WHEN_ADX=20    # ADXがこの値以上ならプルバック不要と明記
 
 # === クールダウン・ADXレンジ ===


### PR DESCRIPTION
## Summary
- lower minimum TP requirement
- shorten AI cooldowns
- allow earlier pullback bypass

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: 23 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4e22256c8333acc13dddabb28785