### PR TITLE
docs: add file roles overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ The root also includes `Dockerfile` definitions for containerized deployment and
 `trades.db` as the default SQLite database path.
 When running inside Docker this file is located at `/app/backend/logs/trades.db` by default.
 
+For details on the role of each top-level file and directory, see
+[docs/file_roles.md](docs/file_roles.md).
+
 ### Logging
 
 Set the `LOG_LEVEL` environment variable to control verbosity. When `DEBUG` is

--- a/docs/file_roles.md
+++ b/docs/file_roles.md
@@ -1,0 +1,44 @@
+# File Roles
+
+このドキュメントでは、リポジトリ直下にある主なファイルやディレクトリの役割を簡単に説明します。
+
+| パス | 役割 |
+| --- | --- |
+| `AGENTS.md` | 開発ルールやテスト手順の説明 |
+| `CHANGELOG.md` | 変更履歴 |
+| `Dockerfile` | バックエンド用 Docker イメージ定義 |
+| `LICENSE` | ライセンス情報 |
+| `README.md` | プロジェクト概要とセットアップ手順 |
+| `ai/` | AI 関連モジュール群 |
+| `analysis/` | 市場分析スクリプトとユーティリティ |
+| `backend/` | FastAPI サーバーとジョブランナー |
+| `benchmarks/` | ベンチマーク用コード |
+| `config/` | YAML 設定ファイル |
+| `core/` | エントリー・エグジットの基盤ロジック |
+| `deploy.sh` | デプロイ補助スクリプト |
+| `diagnostics/` | 動作診断やログ解析ツール |
+| `docker-compose.yml` | Docker Compose 定義 |
+| `docs/` | ドキュメント群 |
+| `execution/` | 約定処理を含む実行モジュール |
+| `fast_metrics.py` | Prometheus 用メトリクス取得スクリプト |
+| `indicators/` | テクニカル指標モジュール |
+| `maintenance/` | メンテナンススクリプト |
+| `models/` | 機械学習モデル関連ファイル |
+| `monitoring/` | モニタリングと通知処理 |
+| `pipelines/` | 分析・取引パイプライン定義 |
+| `piphawk-ui/` | React 製フロントエンド |
+| `piphawk_ai/` | Job Runner 本体と戦略実装 |
+| `prompts/` | OpenAI へのプロンプトテンプレート |
+| `pyproject.toml` | Python プロジェクト設定 |
+| `pytest.ini` | Pytest 設定ファイル |
+| `regime/` | 市場レジーム分析モジュール |
+| `requirements-dev.txt` | 開発用依存ライブラリ一覧 |
+| `requirements-test.txt` | テスト用依存ライブラリ一覧 |
+| `risk/` | ポートフォリオリスク管理 |
+| `run_tests.sh` | テスト実行スクリプト |
+| `selector_fast.py` | 高速モード判定ツール |
+| `signals/` | 取引シグナル生成処理 |
+| `sql/` | SQL スクリプトやDB関連ファイル |
+| `strategies/` | 取引戦略モジュール |
+| `tests/` | 単体テストコード |
+| `training/` | 学習・検証用スクリプト |


### PR DESCRIPTION
## Summary
- ファイルごとの役割をまとめた `docs/file_roles.md` を追加
- README の Directory Structure セクションから新ドキュメントへリンク

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(一部テストが失敗)*


------
https://chatgpt.com/codex/tasks/task_e_684c5098c1b08333a24862b6b292058a