### PR TITLE
docs: note optional deps for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,14 @@ Use the helper script to run unit tests:
 For lint and type checks, refer to the commands listed in
 [AGENTS.md](AGENTS.md).
 
+Some tests require optional dependencies such as `httpx` and `apscheduler`.
+These tests call `pytest.importorskip()` to skip when the packages are missing.
+Install all test requirements to ensure they run:
+
+```bash
+pip install -r requirements-test.txt
+```
+
 ## プロンプト変更手順
 
 各 AI 機能の指示文は `prompts/` ディレクトリにテンプレートとして保存されています。

--- a/backend/api/test_control_endpoints.py
+++ b/backend/api/test_control_endpoints.py
@@ -1,5 +1,9 @@
 import importlib
 
+import pytest
+
+pytest.importorskip("apscheduler")
+
 from apscheduler.schedulers.base import STATE_RUNNING
 from fastapi.testclient import TestClient
 

--- a/backend/api/test_panic_stop.py
+++ b/backend/api/test_panic_stop.py
@@ -1,5 +1,9 @@
 import importlib
 
+import pytest
+
+pytest.importorskip("apscheduler")
+
 from apscheduler.schedulers.base import STATE_RUNNING
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- skip tests that need optional packages
- document optional dependencies in README

## Testing
- `ruff check .`
- `isort backend/api/test_control_endpoints.py backend/api/test_panic_stop.py`
- `mypy .`
- `pytest` *(fails: dynamic SL, early exit, entry decline, regime logging, exit reason, exit trade, fallback dynamic risk, false break filter, follow breakout call, h1 level block, higher timeframe override/pivot/prompt/tp)*

------
https://chatgpt.com/codex/tasks/task_e_684ce90ef46c833390cd040ab261951e