### PR TITLE
feature/archive ticks weekly

### DIFF
--- a/maintenance/archive_ticks.py
+++ b/maintenance/archive_ticks.py
@@ -1,0 +1,49 @@
+"""Archive old tick data once per week."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from backend.utils import env_loader
+
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "data/trades.db"))
+
+
+def archive_old_ticks(days: int = 30) -> int:
+    """Move tick records older than ``days`` to ``ticks_archive`` table."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        # テーブルが存在しない場合は何もしない
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='ticks'"
+        )
+        if cur.fetchone() is None:
+            return 0
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS ticks_archive AS SELECT * FROM ticks WHERE 0"
+        )
+        cur.execute(
+            "SELECT COUNT(*) FROM ticks WHERE timestamp < ?",
+            (cutoff.isoformat(),),
+        )
+        count = cur.fetchone()[0]
+        if count:
+            cur.execute(
+                "INSERT INTO ticks_archive SELECT * FROM ticks WHERE timestamp < ?",
+                (cutoff.isoformat(),),
+            )
+            cur.execute(
+                "DELETE FROM ticks WHERE timestamp < ?",
+                (cutoff.isoformat(),),
+            )
+            conn.commit()
+            conn.execute("VACUUM")
+    return count
+
+
+if __name__ == "__main__":
+    num = archive_old_ticks()
+    print(f"archived {num} ticks")

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -85,3 +85,28 @@ CREATE TABLE IF NOT EXISTS trade_labels (
     label TEXT NOT NULL,
     timestamp TEXT NOT NULL
 );
+
+-- Tick data and archive tables
+CREATE TABLE IF NOT EXISTS ticks (
+    timestamp TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    bid REAL,
+    ask REAL
+);
+CREATE TABLE IF NOT EXISTS ticks_archive (
+    timestamp TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    bid REAL,
+    ask REAL
+);
+
+-- Weekly summary view of archived ticks
+CREATE VIEW IF NOT EXISTS weekly_tick_summary AS
+SELECT
+    strftime('%Y-%W', timestamp) AS week,
+    instrument,
+    COUNT(*) AS tick_count
+FROM ticks_archive
+WHERE timestamp >= date('now', '-4 weeks')
+GROUP BY week, instrument
+ORDER BY week DESC;


### PR DESCRIPTION
## Summary
- add maintenance script to archive old tick data weekly
- create tables and view for tick archives
- schedule archive job via BackgroundScheduler

## Testing
- `ruff check .`
- `isort maintenance/archive_ticks.py backend/api/main.py`
- `mypy .`
- `pytest -q` *(fails: ImportError and OANDA config issues)*

------
https://chatgpt.com/codex/tasks/task_e_684ce90f48a48333befbb804ff708582