### PR TITLE
feat(logs): add trade labels

### DIFF
--- a/backend/logs/update_oanda_trades.py
+++ b/backend/logs/update_oanda_trades.py
@@ -8,6 +8,7 @@ from backend.utils import env_loader
 
 try:
     from backend.logs.log_manager import (
+        add_trade_label,
         get_db_connection,
         init_db,
         log_error,
@@ -24,6 +25,9 @@ except Exception:  # テスト環境では簡易版を提供
         pass
 
     def log_error(*_a, **_k):
+        pass
+
+    def add_trade_label(*_a, **_k):
         pass
 
 # env_loader automatically loads default env files at import time
@@ -194,6 +198,7 @@ def update_oanda_trades():
                     realized_pl,
                     conn=conn,
                 )
+                add_trade_label(trade_id, "FILL")
                 logger.debug("Debug AFTER INSERT rowcount: 1")
                 rowcount = 1
                 updated_count += rowcount
@@ -216,6 +221,7 @@ def update_oanda_trades():
                         (close_time, price, price, realized_pl, trade_id),
                     )
                     rowcount = conn.total_changes - before
+                    add_trade_label(trade_id, "TP")
 
                 elif transaction_type == 'STOP_LOSS_ORDER':
                     before = conn.total_changes
@@ -229,6 +235,7 @@ def update_oanda_trades():
                         (close_time, price, price, realized_pl, trade_id),
                     )
                     rowcount = conn.total_changes - before
+                    add_trade_label(trade_id, "SL")
 
                 logger.info(f"{transaction_type} updated for trade_id {trade_id}, rowcount={rowcount}")
 

--- a/tests/test_trade_logger_labels.py
+++ b/tests/test_trade_logger_labels.py
@@ -1,0 +1,31 @@
+import importlib
+from types import SimpleNamespace
+
+import backend.logs.trade_logger as tl
+
+
+def test_entry_and_exit_labels(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(tl, "_log_trade", lambda **kw: 1)
+    monkeypatch.setattr(tl, "add_trade_label", lambda tid, label: recorded.append((tid, label)))
+
+    tl.log_trade(
+        instrument="EUR_USD",
+        entry_time="2024-01-01T00:00:00",
+        entry_price=1.0,
+        units=1,
+        ai_reason="test",
+    )
+    tl.log_trade(
+        instrument="EUR_USD",
+        entry_time="2024-01-01T00:00:00",
+        entry_price=1.0,
+        units=1,
+        ai_reason="test",
+        exit_time="2024-01-01T01:00:00",
+        exit_price=1.1,
+        exit_reason=tl.ExitReason.AI,
+    )
+
+    assert recorded[0] == (1, "ENTRY")
+    assert recorded[1] == (1, "EXIT")


### PR DESCRIPTION
## Summary
- attach labels when syncing and logging trades
- test trade labels for OANDA trade updates
- test entry/exit labeling

## Testing
- `ruff check backend/logs/update_oanda_trades.py backend/logs/trade_logger.py tests/test_update_oanda_trades_logs.py tests/test_trade_logger_labels.py`
- `isort backend/logs/update_oanda_trades.py backend/logs/trade_logger.py tests/test_update_oanda_trades_logs.py tests/test_trade_logger_labels.py`
- `mypy backend/logs/update_oanda_trades.py backend/logs/trade_logger.py tests/test_update_oanda_trades_logs.py tests/test_trade_logger_labels.py`
- `pytest` *(fails: 37 failed, 63 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684ce90dfd348333a9f47af8497c74a9