### PR TITLE
Add offline training pipeline

### DIFF
--- a/config/thresholds.yml
+++ b/config/thresholds.yml
@@ -1,0 +1,3 @@
+accuracy: 0.6
+sharpe: 1.0
+win_rate: 0.55

--- a/offline_training/backtest.py
+++ b/offline_training/backtest.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Simple walk-forward backtest."""
+
+import argparse
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+
+from pipelines.walk_forward.utils import calc_sharpe, simulate_trades
+
+
+def run(model_path: str, dataset_path: str) -> dict:
+    model = joblib.load(model_path)
+    df = pd.read_feather(dataset_path)
+    returns = simulate_trades(model, df)
+    sharpe = calc_sharpe(returns)
+    win_rate = float(np.mean(returns > 0)) if len(returns) else 0.0
+    max_dd = float(np.min(np.cumsum(returns)))
+    metrics = {"sharpe": sharpe, "win_rate": win_rate, "max_dd": max_dd}
+    return metrics
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", required=True)
+    p.add_argument("--data", required=True)
+    p.add_argument("--out", type=Path, default=Path("metrics.json"))
+    args = p.parse_args()
+    metrics = run(args.model, args.data)
+    args.out.write_text(pd.Series(metrics).to_json())
+    print(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/offline_training/build_features.py
+++ b/offline_training/build_features.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""candles parquetから特徴量テーブルを生成する."""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from indicators.ema import add_ema
+from indicators.macd import calc_macd
+from indicators.rsi import calc_rsi
+
+
+def build_feature_table(candle_path: str) -> pd.DataFrame:
+    df = pd.read_parquet(candle_path).sort_values("time")
+    df = add_ema(df, [21, 55, 200])
+    df["RSI"] = calc_rsi(df["close"], period=14)
+    macd, signal = calc_macd(df["close"])
+    df["MACD"], df["MACD_signal"] = macd, signal
+    df = df.dropna().reset_index(drop=True)
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    feats = build_feature_table(args.input)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    feats.to_feather(out_path)
+    print(f"\u2705 Features saved: {out_path} ({len(feats):,} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/offline_training/build_labels.py
+++ b/offline_training/build_labels.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""trades.dbから助言を生成し、特徴量データに追加する."""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from backend.utils.db_helper import connect
+
+
+def attach_labels(feature_path: str, db_path: str) -> pd.DataFrame:
+    df = pd.read_feather(feature_path)
+    with connect(db_path) as conn:
+        trades = pd.read_sql_query(
+            "SELECT entry_time, profit_loss FROM trades WHERE profit_loss IS NOT NULL",
+            conn,
+        )
+    trades["timestamp"] = pd.to_datetime(trades["entry_time"])
+    trades["label"] = (trades["profit_loss"] > 0).astype(int)
+    merged = pd.merge_asof(
+        df.sort_values("time"),
+        trades.sort_values("timestamp"),
+        left_on="time",
+        right_on="timestamp",
+        direction="backward",
+    )
+    merged = merged.drop(columns=["entry_time", "timestamp", "profit_loss"])
+    return merged.dropna(subset=["label"]).reset_index(drop=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--features", required=True)
+    parser.add_argument("--db", type=str, default="trades.db")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    labeled = attach_labels(args.features, args.db)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    labeled.to_feather(out_path)
+    print(f"\u2705 Dataset saved: {out_path} ({len(labeled):,} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/offline_training/fetch_history.py
+++ b/offline_training/fetch_history.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""OANDAの古いローソク買いデータを下げるスクリプト."""
+
+import argparse
+import datetime as dt
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import requests
+
+OANDA_API_URL = os.environ.get("OANDA_API_URL", "https://api-fxtrade.oanda.com")
+OANDA_API_KEY = os.environ.get("OANDA_API_KEY")
+OANDA_ACCOUNT_ID = os.environ.get("OANDA_ACCOUNT_ID")
+INSTRUMENT = os.environ.get("OANDA_INSTRUMENT", "EUR_USD")
+GRANULARITY = os.environ.get("OANDA_GRANULARITY", "M5")
+
+
+def fetch_candles(start: dt.datetime, end: dt.datetime) -> pd.DataFrame:
+    """指定区間のローソク買いデータを取得する."""
+    headers = {"Authorization": f"Bearer {OANDA_API_KEY}"}
+    params: dict[str, Any] = {
+        "from": start.isoformat(),
+        "to": end.isoformat(),
+        "granularity": GRANULARITY,
+        "price": "M",
+    }
+    url = f"{OANDA_API_URL}/v3/instruments/{INSTRUMENT}/candles"
+    resp = requests.get(url, headers=headers, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json().get("candles", [])
+    if not data:
+        return pd.DataFrame()
+    rows = [
+        {
+            "time": c["time"],
+            "open": float(c["mid"]["o"]),
+            "high": float(c["mid"]["h"]),
+            "low": float(c["mid"]["l"]),
+            "close": float(c["mid"]["c"]),
+            "volume": int(c["volume"]),
+        }
+        for c in data
+    ]
+    return pd.DataFrame(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--output", type=Path, default=Path("parquet"))
+    args = parser.parse_args()
+
+    end = dt.datetime.utcnow()
+    start = end - dt.timedelta(days=args.days)
+    df = fetch_candles(start, end)
+    if df.empty:
+        print("No data fetched")
+        return
+    args.output.mkdir(parents=True, exist_ok=True)
+    fname = args.output / f"candles_{start.date()}_{end.date()}.parquet"
+    df.to_parquet(fname)
+    print(f"Saved {len(df)} rows to {fname}")
+
+
+if __name__ == "__main__":
+    main()

--- a/offline_training/release.py
+++ b/offline_training/release.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""metrics.jsonとthresholdsをチェックしてモデル更新."""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+import yaml
+
+THRESH_PATH = Path("config/thresholds.yml")
+MODEL_REPO = Path("models/latest")
+
+
+def should_release(metrics: dict, thresholds: dict) -> bool:
+    return all(metrics.get(k, 0) >= v for k, v in thresholds.items())
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--metrics", required=True)
+    p.add_argument("--model", required=True)
+    args = p.parse_args()
+
+    thresholds = yaml.safe_load(THRESH_PATH.read_text())
+    metrics = json.loads(Path(args.metrics).read_text())
+    if should_release(metrics, thresholds):
+        MODEL_REPO.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(args.model, MODEL_REPO / "model.pkl")
+        print("\u2705 Model released")
+    else:
+        print("\u274c Metrics below threshold")
+
+
+if __name__ == "__main__":
+    main()

--- a/offline_training/train_model.py
+++ b/offline_training/train_model.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""LogisticRegressionを用いて説明算のトレーニング."""
+
+import argparse
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+
+
+def train(dataset_path: str, model_dir: str) -> dict:
+    df = pd.read_feather(dataset_path)
+    X = df.drop(columns=["label", "time"])
+    y = df["label"]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    model = LogisticRegression(max_iter=200)
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    acc = float(accuracy_score(y_test, preds))
+
+    Path(model_dir).mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, Path(model_dir) / "model.pkl")
+    metrics = {"accuracy": acc}
+    Path(model_dir).joinpath("metrics.json").write_text(pd.Series(metrics).to_json())
+    return metrics
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--data", required=True)
+    p.add_argument("--outdir", required=True)
+    args = p.parse_args()
+    metrics = train(args.data, args.outdir)
+    print(metrics)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement offline_training with fetch, feature build, labeling, training, backtesting and release scripts
- add thresholds config for model release

## Testing
- `isort offline_training config/thresholds.yml`
- `ruff check offline_training`
- `mypy offline_training`
- `pytest -k 'nothing'`

------
https://chatgpt.com/codex/tasks/task_e_684cec3311e88333802fdd319dc67d68