### PR TITLE
feat(mode): add ModeSelector with trend & overshoot logic

### DIFF
--- a/signals/mode_selector.py
+++ b/signals/mode_selector.py
@@ -1,0 +1,33 @@
+"""
+モード選択ロジック.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+
+def _norm(value: float, scale: float) -> float:
+    """値を 0-1 に正規化."""
+    if scale <= 0:
+        return 0.0
+    v = abs(value) / scale
+    return min(max(v, 0.0), 1.0)
+
+
+def select_mode(context: Dict[str, float]) -> str:
+    """コンテキストからトレードモードを決定."""
+    slope = context.get("ema_slope_15m", 0.0)
+    adx = context.get("adx_15m", 0.0)
+    overshoot = context.get("overshoot_flag", 0)
+
+    slope_norm = _norm(slope, 0.3)
+    adx_norm = _norm(adx, 50.0)
+    trend_strength = slope_norm * adx_norm
+
+    if trend_strength > 0.6:
+        return "TREND"
+    if overshoot:
+        return "REBOUND_SCALP"
+    return "BASE_SCALP"
+
+__all__ = ["select_mode"]

--- a/tests/test_mode_selector_v2.py
+++ b/tests/test_mode_selector_v2.py
@@ -1,0 +1,19 @@
+import importlib
+
+from signals import mode_selector
+
+
+def test_select_mode_trend():
+    ctx = {"ema_slope_15m": 0.3, "adx_15m": 40, "overshoot_flag": 0}
+    importlib.reload(mode_selector)
+    assert mode_selector.select_mode(ctx) == "TREND"
+
+
+def test_select_mode_rebound():
+    ctx = {"ema_slope_15m": 0.1, "adx_15m": 10, "overshoot_flag": 1}
+    assert mode_selector.select_mode(ctx) == "REBOUND_SCALP"
+
+
+def test_select_mode_base():
+    ctx = {"ema_slope_15m": 0.05, "adx_15m": 10, "overshoot_flag": 0}
+    assert mode_selector.select_mode(ctx) == "BASE_SCALP"


### PR DESCRIPTION
## Summary
- add ModeSelector module with trend strength and overshoot logic
- add unit tests for mode selection cases

## Testing
- `ruff check signals/mode_selector.py tests/test_mode_selector_v2.py`
- `mypy signals/mode_selector.py tests/test_mode_selector_v2.py`
- `pytest tests/test_mode_selector_v2.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d50a836c88333822c458c20b4b359