### PR TITLE
feature/prom-exporter

### DIFF
--- a/docs/file_roles.md
+++ b/docs/file_roles.md
@@ -340,6 +340,8 @@
 | `monitoring/__init__.py` | 監視機能を提供するサブモジュール. |
 | `monitoring/metrics_publisher.py` | Kafka と Prometheus へメトリクスを送信するユーティリティ. |
 | `monitoring/safety_trigger.py` | 損失やエラー発生数を監視して安全停止を行うためのモジュール. |
+| `monitoring/prom_exporter.py` | Prometheus メトリクスを `/metrics` で公開するエクスポーター. |
+| `monitoring/grafana_import.py` | Grafana ダッシュボードを自動インポートするスクリプト. |
 | `pipelines/walk_forward/eval_kpi.py` | kpiを評価し、再lainフラグを決定します。 |
 | `pipelines/walk_forward/run_walk_forward.py` | ウォークフォワード最適化メインスクリプト。 |
 | `pipelines/walk_forward/utils.py` | 単純なウォークフォワード取引のためのユーティリティ機能。 |

--- a/monitoring/grafana_import.py
+++ b/monitoring/grafana_import.py
@@ -1,0 +1,33 @@
+"""Grafana ダッシュボードをインポートするスクリプト."""
+
+from __future__ import annotations
+
+import os
+
+import requests
+
+GRAFANA_URL = os.getenv("GRAFANA_URL", "http://localhost:3000")
+GRAFANA_TOKEN = os.getenv("GRAFANA_TOKEN", "")
+DASHBOARD_ID = 12011
+
+
+def import_dashboard(dashboard_id: int = DASHBOARD_ID) -> dict:
+    """指定 ID のダッシュボードをダウンロードしてインポートする."""
+    download_url = f"https://grafana.com/api/dashboards/{dashboard_id}/revisions/latest/download"
+    response = requests.get(download_url, timeout=10)
+    response.raise_for_status()
+    dashboard_json = response.json()
+
+    import_url = f"{GRAFANA_URL}/api/dashboards/db"
+    headers = {
+        "Authorization": f"Bearer {GRAFANA_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    payload = {"dashboard": dashboard_json["dashboard"], "overwrite": True}
+    r = requests.post(import_url, json=payload, headers=headers, timeout=10)
+    r.raise_for_status()
+    return r.json()
+
+
+if __name__ == "__main__":
+    import_dashboard()

--- a/monitoring/prom_exporter.py
+++ b/monitoring/prom_exporter.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Prometheus メトリクスエクスポーター."""
+
+from fastapi import FastAPI, Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+
+registry = CollectorRegistry()
+
+trade_mode_count_total = Counter(
+    "trade_mode_count_total",
+    "Total trade mode counts",
+    ["mode"],
+    registry=registry,
+)
+
+ai_confidence_bucket = Histogram(
+    "ai_confidence_bucket",
+    "Distribution of AI confidence scores",
+    buckets=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+    registry=registry,
+)
+
+rl_override_total = Counter(
+    "rl_override_total",
+    "Number of RL overrides",
+    registry=registry,
+)
+
+app = FastAPI()
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    """Prometheus メトリクスを出力するエンドポイント."""
+    data = generate_latest(registry)
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
+
+
+def increment_trade_mode(mode: str) -> None:
+    """trade_mode_count_total をインクリメントする."""
+    trade_mode_count_total.labels(mode=mode).inc()
+
+
+def record_ai_confidence(value: float) -> None:
+    """ai_confidence_bucket に値を記録する."""
+    ai_confidence_bucket.observe(value)
+
+
+def increment_rl_override() -> None:
+    """rl_override_total をインクリメントする."""
+    rl_override_total.inc()
+
+
+def start(port: int = 8001) -> None:
+    """UVicorn でサーバーを起動する."""
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    start()

--- a/tests/test_prom_exporter.py
+++ b/tests/test_prom_exporter.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from monitoring import prom_exporter as pe
+
+
+def test_metrics_endpoint():
+    client = TestClient(pe.app)
+    pe.increment_trade_mode("scalp")
+    pe.record_ai_confidence(0.5)
+    pe.increment_rl_override()
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "trade_mode_count_total" in body
+    assert "ai_confidence_bucket" in body
+    assert "rl_override_total" in body


### PR DESCRIPTION
## Summary
- expose Prometheus metrics via new `prom_exporter` module
- add script to import Grafana dashboard 12011
- document monitoring utilities
- test Prometheus exporter

## Testing
- `isort .`
- `ruff check .`
- `mypy .` *(fails: Source file found twice under different module names)*
- `pytest tests/test_prom_exporter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9735362c8333bfd743a1a3fe6513