### PR TITLE
Implement LLM mode scoring blend

### DIFF
--- a/analysis/llm_client.py
+++ b/analysis/llm_client.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Helper for LLM mode scoring."""
+
+import json
+import logging
+from typing import Any, Dict
+
+from backend.utils.openai_client import ask_openai
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "You are a forex trading mode scorer."
+    " Evaluate how appropriate each trading mode is given the market snapshot."
+    " Respond strictly with JSON as {\"TREND\":0-1,\"BASE_SCALP\":0-1,\"REBOUND_SCALP\":0-1}."
+)
+
+
+def get_mode_scores(snapshot: Any) -> Dict[str, float]:
+    """Return LLM mode scores for the given snapshot."""
+    prompt = json.dumps(
+        {
+            "atr": getattr(snapshot, "atr", None),
+            "news_score": getattr(snapshot, "news_score", None),
+            "oi_bias": getattr(snapshot, "oi_bias", None),
+        },
+        ensure_ascii=False,
+    )
+    try:
+        raw = ask_openai(
+            prompt,
+            system_prompt=_SYSTEM_PROMPT,
+            model="gpt-4o",
+            temperature=0.0,
+            response_format={"type": "json_object"},
+        )
+        data = raw if isinstance(raw, dict) else json.loads(str(raw))
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.error("get_mode_scores failed: %s", exc)
+        return {"TREND": 0.0, "BASE_SCALP": 0.0, "REBOUND_SCALP": 0.0}
+    result = {}
+    for key in ("TREND", "BASE_SCALP", "REBOUND_SCALP"):
+        try:
+            result[key] = float(data.get(key, 0.0))
+        except Exception:
+            result[key] = 0.0
+    return result
+
+
+__all__ = ["get_mode_scores"]

--- a/tests/test_llm_mode_blend.py
+++ b/tests/test_llm_mode_blend.py
@@ -1,0 +1,37 @@
+import importlib
+
+import analysis.llm_client as lc
+import signals.mode_selector_v2 as ms
+from piphawk_ai.vote_arch.market_air_sensor import MarketSnapshot
+
+
+def test_llm_blend_base_overrides(monkeypatch):
+    monkeypatch.setattr(lc, "ask_openai", lambda *a, **k: {"TREND": 0.1, "BASE_SCALP": 0.9, "REBOUND_SCALP": 0.0})
+    importlib.reload(ms)
+    ctx = {
+        "ema_slope_15m": 0.3,
+        "adx_15m": 45,
+        "stddev_pct_15m": 0.2,
+        "ema12_15m": 1.0,
+        "ema26_15m": 1.0,
+        "atr_15m": 1.0,
+        "overshoot_flag": False,
+    }
+    snapshot = MarketSnapshot(0.05, 0.0, 0.0)
+    assert ms.select_mode(ctx, snapshot) == "BASE_SCALP"
+
+
+def test_llm_blend_respects_overshoot(monkeypatch):
+    monkeypatch.setattr(lc, "ask_openai", lambda *a, **k: {"TREND": 1.0, "BASE_SCALP": 0.0, "REBOUND_SCALP": 0.0})
+    importlib.reload(ms)
+    ctx = {
+        "ema_slope_15m": 0.0,
+        "adx_15m": 10,
+        "stddev_pct_15m": 0.5,
+        "ema12_15m": 1.0,
+        "ema26_15m": 1.0,
+        "atr_15m": 1.0,
+        "overshoot_flag": True,
+    }
+    snapshot = MarketSnapshot(0.05, 0.0, 0.0)
+    assert ms.select_mode(ctx, snapshot) == "REBOUND_SCALP"


### PR DESCRIPTION
## Summary
- add `analysis.llm_client` with `get_mode_scores` using GPT-4o
- blend LLM scores in `mode_selector_v2.select_mode`
- add tests for blending logic

## Testing
- `ruff check .`
- `isort .`
- `mypy .` *(fails: Source file found twice under different module names)*
- `pytest -q` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_684d97237ff88333ac3d95a0dfbf822e