### PR TITLE
feat: composite filter scoring

### DIFF
--- a/config/filters.yaml
+++ b/config/filters.yaml
@@ -4,3 +4,10 @@ volume_filter:
     usd_jpy: 25
     eur_usd: 30
     gbp_usd: 35
+
+composite_filter:
+  min_score: 2
+  weights:
+    rsi_edge: 1
+    bb_break: 1
+    ai_pattern: 1

--- a/signals/composite_filter.py
+++ b/signals/composite_filter.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+"""Composite scoring filter for trade signals."""
+
+import os
+from typing import Any, Callable
+
+from backend.utils import env_loader
+
+
+def rsi_edge(ctx: dict[str, Any]) -> float:
+    """Return ``1.0`` when RSI is outside the neutral band."""
+    rsi = ctx.get("rsi")
+    try:
+        val = float(rsi)
+    except Exception:
+        return 0.0
+    low = float(env_loader.get_env("RSI_EDGE_LOW", "30"))
+    high = float(env_loader.get_env("RSI_EDGE_HIGH", "70"))
+    return 1.0 if val <= low or val >= high else 0.0
+
+
+def bb_break(ctx: dict[str, Any]) -> float:
+    """Return ``1.0`` when price breaks the Bollinger Band."""
+    price = ctx.get("price")
+    upper = ctx.get("bb_upper")
+    lower = ctx.get("bb_lower")
+    try:
+        p = float(price)
+        u = float(upper)
+        l = float(lower)
+    except Exception:
+        return 0.0
+    return 1.0 if p >= u or p <= l else 0.0
+
+
+def ai_pattern(ctx: dict[str, Any]) -> float:
+    """Return pattern score from context."""
+    score = ctx.get("ai_pattern")
+    try:
+        return float(score)
+    except Exception:
+        return 0.0
+
+
+def _load_weights() -> dict[str, float]:
+    weights: dict[str, float] = {}
+    prefix = "COMPOSITE_FILTER_WEIGHTS_"
+    for key, val in os.environ.items():
+        if not key.startswith(prefix):
+            continue
+        name = key[len(prefix) :].lower()
+        try:
+            weights[name] = float(val)
+        except ValueError:
+            continue
+    return weights
+
+
+class CompositeFilter:
+    """Scoring filter aggregating multiple evaluators."""
+
+    def __init__(self, min_score: float | None = None, weights: dict[str, float] | None = None) -> None:
+        self.min_score = min_score if min_score is not None else float(
+            env_loader.get_env("COMPOSITE_FILTER_MIN_SCORE", "2")
+        )
+        self.weights = weights if weights is not None else _load_weights()
+        self.functions: dict[str, Callable[[dict[str, Any]], float]] = {}
+
+    def register(self, name: str, func: Callable[[dict[str, Any]], float]) -> None:
+        """Register evaluation function under ``name``."""
+        self.functions[name] = func
+
+    def evaluate(self, ctx: dict[str, Any]) -> float:
+        """Return weighted sum of registered scores."""
+        score = 0.0
+        for name, func in self.functions.items():
+            try:
+                val = float(func(ctx))
+            except Exception:
+                val = 0.0
+            w = self.weights.get(name, 1.0)
+            score += val * w
+        return score
+
+    def pass_(self, ctx: dict[str, Any]) -> bool:
+        """Return ``True`` when the evaluated score meets ``min_score``."""
+        return self.evaluate(ctx) >= self.min_score
+
+
+DEFAULT_FILTER = CompositeFilter()
+DEFAULT_FILTER.register("rsi_edge", rsi_edge)
+DEFAULT_FILTER.register("bb_break", bb_break)
+DEFAULT_FILTER.register("ai_pattern", ai_pattern)
+
+__all__ = [
+    "CompositeFilter",
+    "rsi_edge",
+    "bb_break",
+    "ai_pattern",
+    "DEFAULT_FILTER",
+]

--- a/tests/test_composite_filter.py
+++ b/tests/test_composite_filter.py
@@ -1,0 +1,25 @@
+import pytest
+
+from signals.composite_filter import CompositeFilter, ai_pattern, bb_break, rsi_edge
+
+CASES = [
+    ({"rsi": 25, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, True),
+    ({"rsi": 25, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, True),
+    ({"rsi": 50, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, True),
+    ({"rsi": 25, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, True),
+    ({"rsi": 25, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
+    ({"rsi": 50, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
+    ({"rsi": 50, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, False),
+    ({"rsi": 80, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, True),
+    ({"rsi": 80, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
+    ({"rsi": 50, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
+]
+
+
+@pytest.mark.parametrize("ctx, expected", CASES)
+def test_composite_filter(ctx, expected):
+    flt = CompositeFilter(min_score=2, weights={"rsi_edge": 1, "bb_break": 1, "ai_pattern": 1})
+    flt.register("rsi_edge", rsi_edge)
+    flt.register("bb_break", bb_break)
+    flt.register("ai_pattern", ai_pattern)
+    assert flt.pass_(ctx) is expected


### PR DESCRIPTION
## Summary
- implement `CompositeFilter` with scoring
- add default registration for `rsi_edge`, `bb_break`, and `ai_pattern`
- configure filter defaults in `filters.yaml`
- cover behaviour in `test_composite_filter`

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort --check .`
- `mypy .` *(fails: Source file found twice under different module names)*
- `pytest -q` *(fails: 37 failed, 63 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684d9713b0508333b893ea74a086e0e9