### PR TITLE
feature/exit-safety-fixes

### DIFF
--- a/monitoring/prom_exporter.py
+++ b/monitoring/prom_exporter.py
@@ -33,6 +33,12 @@ rl_override_total = Counter(
     registry=registry,
 )
 
+ai_pattern_model_missing_total = Counter(
+    "ai_pattern_model_missing_total",
+    "Number of times CNN pattern model missing",
+    registry=registry,
+)
+
 app = FastAPI()
 
 
@@ -56,6 +62,11 @@ def record_ai_confidence(value: float) -> None:
 def increment_rl_override() -> None:
     """rl_override_total をインクリメントする."""
     rl_override_total.inc()
+
+
+def increment_pattern_model_missing() -> None:
+    """ai_pattern_model_missing_total をインクリメントする."""
+    ai_pattern_model_missing_total.inc()
 
 
 def start(port: int = 8001) -> None:

--- a/signals/ai_pattern_filter.py
+++ b/signals/ai_pattern_filter.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 """AI-based pattern filter using CNN."""
 
+import logging
 from io import BytesIO
+from pathlib import Path
 from typing import Iterable, Mapping
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from ai.cnn_pattern import infer
+from backend.utils import env_loader
+from monitoring import prom_exporter as pe
+
+logger = logging.getLogger(__name__)
 
 
 def _candles_to_image(candles: Iterable[Mapping]) -> np.ndarray:
@@ -33,6 +39,18 @@ def _candles_to_image(candles: Iterable[Mapping]) -> np.ndarray:
 def pass_pattern_filter(candles: Iterable[Mapping]) -> tuple[bool, float]:
     """Return ``(True, prob)`` when CNN predicts chart pattern."""
     img = _candles_to_image(candles)
+
+    allow_fb = env_loader.get_env("ALLOW_FALLBACK_PATTERN", "no").lower() == "yes"
+    model_path = getattr(infer, "_MODEL_PATH", None)
+    if model_path and not Path(model_path).exists():
+        pe.increment_pattern_model_missing()
+        msg = f"CNN weight missing: {model_path}"
+        if allow_fb:
+            logger.warning(msg)
+        else:
+            logger.error(msg)
+            return False, 0.0
+
     res = infer.predict(img)
     prob = res.get("pattern", 0.0)
     return prob > 0.65, prob

--- a/tests/test_exit_max_hold.py
+++ b/tests/test_exit_max_hold.py
@@ -1,0 +1,30 @@
+import os
+import types
+from datetime import datetime, timedelta, timezone
+
+os.environ.setdefault("OANDA_API_KEY", "x")
+os.environ.setdefault("OANDA_ACCOUNT_ID", "x")
+
+import execution.exit_manager as em
+
+
+class DummyOM:
+    def __init__(self):
+        self.closed = []
+
+    def close_position(self, instrument):
+        self.closed.append(instrument)
+        return {}
+
+def test_check_max_hold(monkeypatch):
+    now = datetime.now(timezone.utc)
+    pos1 = {"instrument": "USD_JPY", "openTime": (now - timedelta(hours=7)).isoformat(), "unrealizedPL": "1"}
+    pos2 = {"instrument": "EUR_USD", "openTime": (now - timedelta(hours=8)).isoformat(), "unrealizedPL": "-1"}
+    monkeypatch.setattr(em, "get_open_positions", lambda: [pos1, pos2])
+    dummy = DummyOM()
+    monkeypatch.setattr(em, "OrderManager", lambda: dummy)
+    monkeypatch.setenv("MAX_HOLD_HOURS", "6")
+    em.check_max_hold()
+    assert dummy.closed == ["USD_JPY", "EUR_USD"]
+
+

--- a/tests/test_prom_exporter.py
+++ b/tests/test_prom_exporter.py
@@ -8,9 +8,11 @@ def test_metrics_endpoint():
     pe.increment_trade_mode("scalp")
     pe.record_ai_confidence(0.5)
     pe.increment_rl_override()
+    pe.increment_pattern_model_missing()
     resp = client.get("/metrics")
     assert resp.status_code == 200
     body = resp.text
     assert "trade_mode_count_total" in body
     assert "ai_confidence_bucket" in body
     assert "rl_override_total" in body
+    assert "ai_pattern_model_missing_total" in body

--- a/tests/test_split_orders.py
+++ b/tests/test_split_orders.py
@@ -1,23 +1,47 @@
-import os
+import types
 from datetime import datetime, timedelta, timezone
 
 import vcr
 
-from execution.position_manager import create_split_orders, update_trailing_sl
+from execution import position_manager as pm
+from execution.position_manager import update_trailing_sl
 from piphawk_ai.tech_arch.market_context import MarketContext
 from piphawk_ai.vote_arch.ai_entry_plan import EntryPlan
 
 my_vcr = vcr.VCR(cassette_library_dir='tests/cassettes')
 
 
-@my_vcr.use_cassette('split_orders.yaml', record_mode='none')
+class DummyOM:
+    def __init__(self):
+        self.calls: list[tuple[float, float]] = []
+
+    def place_market_with_tp_sl(self, instrument, units, side, tp_pips, sl_pips, comment_json=None):
+        self.calls.append((tp_pips, sl_pips))
+        return {"orderFillTransaction": {"id": "1", "tradeOpened": {"tradeID": "t"}}}
+
+
+class FakeSeries:
+    def __init__(self, val):
+        class _IL:
+            def __getitem__(self, idx):
+                return val
+
+        self.iloc = _IL()
+        self._val = val
+
+    def __getitem__(self, idx):
+        return self._val
+
+
 def test_create_split_orders(monkeypatch):
-    monkeypatch.setenv('OANDA_ACCOUNT_ID', 'acc')
-    monkeypatch.setenv('OANDA_API_KEY', 'k')
-    monkeypatch.setenv('OANDA_API_URL', 'http://localhost:9999')
-    plan = EntryPlan(side='long', tp=1.0, sl=0.5, lot=1.0)
-    orders = create_split_orders('trend_follow', plan)
+    dummy = DummyOM()
+    monkeypatch.setattr(pm, "OrderManager", lambda: dummy)
+    monkeypatch.setattr(pm, "calculate_atr", lambda *a, **k: FakeSeries(0.01))
+    plan = EntryPlan(side="long", tp=1.0, sl=0.5, lot=1.0)
+    orders = pm.create_split_orders("trend_follow", plan)
     assert len(orders) == 2
+    assert dummy.calls[0] == (1.0, 0.5)
+    assert dummy.calls[1] == (0.016, 0.007)
 
 
 @my_vcr.use_cassette('split_orders.yaml', record_mode='none')
@@ -32,3 +56,5 @@ def test_update_trailing_sl(monkeypatch):
         candles.append({'time': t, 'mid': {'h': '1.2', 'l': '1.0', 'c': '1.1'}})
     ctx = MarketContext(candles=candles, tick=None, spread=0.0)
     update_trailing_sl('t1', ctx)
+
+


### PR DESCRIPTION
## Summary
- update split order logic to handle mode-specific TP/SL
- harden CNN pattern filter and expose Prometheus metric
- introduce max-hold and stagnation checks
- update monitoring utilities and tests

## Testing
- `isort .`
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piphawk_ai.ai', ImportError: cannot import name 'FastAPI')*

------
https://chatgpt.com/codex/tasks/task_e_684e11de962083339447d0b25c28289c