### PR TITLE
fix: remove duplicate imports

### DIFF
--- a/signals/ai_pattern_filter.py
+++ b/signals/ai_pattern_filter.py
@@ -12,12 +12,9 @@ import numpy as np
 
 from ai.cnn_pattern import infer
 from backend.utils import env_loader
-
 from monitoring import prom_exporter
 
 PROB_THRESHOLD = float(env_loader.get_env("CNN_PROB_THRESHOLD", "0.65"))
-
-from monitoring import prom_exporter as pe
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +46,7 @@ def pass_pattern_filter(candles: Iterable[Mapping]) -> tuple[bool, float]:
     allow_fb = env_loader.get_env("ALLOW_FALLBACK_PATTERN", "no").lower() == "yes"
     model_path = getattr(infer, "_MODEL_PATH", None)
     if model_path and not Path(model_path).exists():
-        pe.increment_pattern_model_missing()
+        prom_exporter.increment_pattern_model_missing()
         msg = f"CNN weight missing: {model_path}"
         if allow_fb:
             logger.warning(msg)


### PR DESCRIPTION
## Summary
- remove duplicate imports in ai_pattern_filter

## Testing
- `ruff check .`
- `isort . --check`
- `mypy .` *(fails: monitoring/prom_exporter.py syntax error)*
- `pytest` *(fails: SyntaxError in monitoring/prom_exporter.py)*

------
https://chatgpt.com/codex/tasks/task_e_684e21bad7388333b835c244ead22c59