### PR TITLE
fix prom exporter

### DIFF
--- a/monitoring/prom_exporter.py
+++ b/monitoring/prom_exporter.py
@@ -44,6 +44,8 @@ position_max_age_seconds = Histogram(
     "position_max_age_seconds",
     "Distribution of max open position age",
     buckets=[0, 60, 300, 900, 3600, 7200],
+    registry=registry,
+)
 
 ai_pattern_model_missing_total = Counter(
     "ai_pattern_model_missing_total",

--- a/signals/ai_pattern_filter.py
+++ b/signals/ai_pattern_filter.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from ai.cnn_pattern import infer
 from backend.utils import env_loader
-
 from monitoring import prom_exporter
 
 PROB_THRESHOLD = float(env_loader.get_env("CNN_PROB_THRESHOLD", "0.65"))


### PR DESCRIPTION
## Summary
- close Histogram definition in prom exporter
- apply isort formatting

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest tests/test_prom_exporter.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e21fff0508333b7dc0b0bddf5b6cf