### PR TITLE
fix: reset OpenAI counter each job

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -17,7 +17,7 @@ except Exception:  # pragma: no cover - optional dependency or test stub
 
 from backend.core.ai_throttle import get_cooldown
 from backend.utils import env_loader, trade_age_seconds
-from backend.utils.openai_client import set_call_limit
+from backend.utils.openai_client import reset_call_counter, set_call_limit
 from backend.utils.restart_guard import can_restart
 from maintenance.disk_guard import maybe_cleanup
 
@@ -1268,6 +1268,7 @@ class JobRunner:
         log.info("Job Runner started.")
         while not self._stop:
             try:
+                reset_call_counter()
                 maybe_cleanup()
                 timer = PerfTimer("job_loop")
                 now = datetime.now(timezone.utc)

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover - optional dependency or test stub
 
 
 from backend.utils import env_loader, trade_age_seconds
-from backend.utils.openai_client import set_call_limit
+from backend.utils.openai_client import reset_call_counter, set_call_limit
 from backend.utils.restart_guard import can_restart
 
 try:
@@ -939,6 +939,7 @@ class JobRunner:
         logger.info("Job Runner started.")
         while not self._stop:
             try:
+                reset_call_counter()
                 timer = PerfTimer("job_loop")
                 now = datetime.now(timezone.utc)
                 # ---- Market‑hours guard ---------------------------------


### PR DESCRIPTION
## Summary
- reset OpenAI call counter at each job iteration
- import reset helper in both job runners

## Testing
- `isort backend/scheduler/job_runner.py piphawk_ai/runner/core.py`
- `ruff check backend/scheduler/job_runner.py piphawk_ai/runner/core.py`
- `mypy backend/scheduler/job_runner.py piphawk_ai/runner/core.py`
- `pytest` *(fails: 57 errors during collection)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684fb216231c8333becab0094acfebf1