### PR TITLE
feature: force trade side

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1576,6 +1576,26 @@ def get_trade_plan(
                     plan.setdefault("entry", {})["mode"] = "market"
     except Exception:
         pass
+
+    # --- Ensure side is long or short ---------------------------------
+    side_val = plan.get("entry", {}).get("side")
+    if side_val not in ("long", "short"):
+        probs = plan.get("probs", {}) or {}
+        try:
+            long_p = float(probs.get("long", 0))
+            short_p = float(probs.get("short", 0))
+        except Exception:
+            long_p = short_p = 0.0
+        if long_p > short_p:
+            forced = "long"
+        elif short_p > long_p:
+            forced = "short"
+        elif higher_tf_direction in ("long", "short"):
+            forced = higher_tf_direction
+        else:
+            forced = "long"
+        plan.setdefault("entry", {})["side"] = forced
+
     return plan
 
 

--- a/prompts/trade_plan.txt
+++ b/prompts/trade_plan.txt
@@ -1,16 +1,16 @@
 Your task:
 1. Clearly classify the current regime as "trend" or "range". If "trend", specify direction as "long" or "short". Output this at JSON key "regime".
-2. Decide whether to open a trade now, strictly adhering to the above criteria. Return JSON key "entry" with: {{ "side":"long"|"short"|"no", "rationale":"…" }}. Also include numeric key "entry_confidence" between 0 and 1 representing your confidence. Additionally return key "probs" as {{"long":float,"short":float,"no":float}} where all values sum to 1.
-3. If side is not "no", propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included. Use decimals for all probability values. When you output side "long" or "short", the risk object must contain both "tp_pips" and "sl_pips" or the trade will be skipped.
+2. Decide whether to open a trade now, strictly adhering to the above criteria. Return JSON key "entry" with: {{ "side":"long"|"short", "rationale":"…" }}. Also include numeric key "entry_confidence" between 0 and 1 representing your confidence. Additionally return key "probs" as {{"long":float,"short":float,"no":float}} where all values sum to 1 ("no" probability should be near zero).
+3. Propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included. Use decimals for all probability values. When you output side "long" or "short", the risk object must contain both "tp_pips" and "sl_pips" or the trade will be skipped.
    - Constraints:
     • tp_prob must be ≥ {MIN_TP_PROB:.2f}
     • Expected value (tp_pips*tp_prob - sl_pips*sl_prob) must be positive
     • Choose the take-profit level that maximises expected value = probability × pips, subject to RRR ≥ {MIN_RRR}
     • (tp_pips - spread_pips) must be ≥ {MIN_NET_TP_PIPS} pips
-    • If constraints are not met, set side to "no".
+    • If constraints are not met, pick the side with the higher success probability.
 
-4. When "entry.side" is "no", also return key "why" summarizing the reason.
-5. When "entry.side" is "yes", the "risk" object must include "tp_pips", "sl_pips", "tp_prob" and "sl_prob", and tp_prob must be ≥ 0.70.
+4. Always provide a brief "why" field explaining the trade logic.
+5. The "risk" object must include "tp_pips", "sl_pips", "tp_prob" and "sl_prob", and tp_prob must be ≥ 0.70.
 
 Respond with **one-line valid JSON** exactly as:
 {{"regime":{{...}},"entry":{{...}},"risk":{{...}},"entry_confidence":0.0,"probs":{{"long":0.5,"short":0.5,"no":0.0}}}}


### PR DESCRIPTION
## Summary
- ensure trade side is always long/short
- update trade plan prompt to forbid `"no"` entries

## Testing
- `ruff check .`
- `mypy .`
- `pytest` *(fails: ModuleNotFoundError for fastapi, requests, numpy, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_684fb4629d988333a10a567e9116ad58