### PR TITLE
fix: always use AI entry plan

### DIFF
--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -81,8 +81,9 @@ def run_cycle(
         if avg_plan:
             plan = avg_plan
 
+    # 最終フィルターの結果に関係なく計画を採用する
     passed = final_filter(plan, indicators)
-    return PipelineResult(plan if passed else None, mode=mode, regime=regime, passed=passed)
+    return PipelineResult(plan, mode=mode, regime=regime, passed=passed)
 
 
 __all__ = ["PipelineResult", "run_cycle"]


### PR DESCRIPTION
## Summary
- remove vote pipeline rejection so AI plans always execute

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_684fdd5e1eb48333942a40c82b892584