### PR TITLE
fix: ensure entry after filters

### DIFF
--- a/piphawk_ai/tech_arch/pipeline.py
+++ b/piphawk_ai/tech_arch/pipeline.py
@@ -31,8 +31,6 @@ def run_cycle() -> dict | None:
 
     if ENTRY_USE_AI:
         decision = call_llm(mode, signal, indicators)
-        if not decision.get("go"):
-            return None
     else:
         decision = {"go": True, "tp_mult": 2.0, "sl_mult": 1.0}
 

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -82,8 +82,8 @@ def run_cycle(
         if avg_plan:
             plan = avg_plan
 
-    passed = True if force_enter else final_filter(plan, indicators)
-    return PipelineResult(plan if passed else None, mode=mode, regime=regime, passed=passed)
+    passed = True
+    return PipelineResult(plan, mode=mode, regime=regime, passed=passed)
 
 
 __all__ = ["PipelineResult", "run_cycle"]


### PR DESCRIPTION
## Summary
- remove go check from technical entry pipeline
- always return plan in vote pipeline

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piphawk_ai.ai')*

------
https://chatgpt.com/codex/tasks/task_e_684fe2fd611c8333bca209518c7d6eb5