### PR TITLE
fix: unify SQLite path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,5 +73,5 @@ jobs:
               --name piphawk-app \
               --restart unless-stopped \
               -v /opt/piphawk/backend/logs:/app/backend/logs \
-              -v /opt/piphawk/data/trades.db:/app/trades.db \
+              -v /opt/piphawk/data/trades.db:/app/backend/logs/trades.db \
               ghcr.io/${{ github.repository_owner }}/piphawk:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     container_name: piphawk-app
     volumes:
       - ./models:/app/models
-      - ./trades.db:/app/trades.db
       - ./backend/logs:/app/backend/logs
     env_file:
       - .env
@@ -15,6 +14,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - KAFKA_SERVERS=kafka:9092
       - KAFKA_BROKERS=kafka:9092
+      - TRADES_DB_PATH=/app/backend/logs/trades.db
     depends_on:
       kafka:
         condition: service_healthy
@@ -24,7 +24,7 @@ services:
     ports:
       - "8080:8080"
     command: >
-      sh -c "test -f /app/.db_initialized || (sqlite3 /app/trades.db < /app/sql/schema.sql && touch /app/.db_initialized); python -m piphawk_ai.main job"
+      sh -c "test -f /app/.db_initialized || (sqlite3 /app/backend/logs/trades.db < /app/sql/schema.sql && touch /app/.db_initialized); python -m piphawk_ai.main job"
 
   kafka:
     image: bitnami/kafka:3.7

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -7,7 +7,7 @@
 ### TRADES_DB_PATH
 
 取引履歴を保存するSQLiteファイルのパス。デフォルトではプロジェクトルートの
-`trades.db` を利用し、Docker環境では `/app/trades.db` が使用されます。
+`trades.db` を利用し、Docker環境では `/app/backend/logs/trades.db` が使用されます。
 環境変数 `TRADES_DB_PATH` で別のパスを指定できます。
 
 ### INITIAL_TP_PIPS / INITIAL_SL_PIPS


### PR DESCRIPTION
## Summary
- align database path with `TRADES_DB_PATH` inside Docker
- document default path update
- update GitHub Actions deployment script

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684fe3ad6cf8833394ee8ae9ef2c671f