### PR TITLE
feature/force-entry

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -60,3 +60,6 @@ ENTRY_BUFFER_K=3
 # Rule-based regime detection
 REGIME_ADX_TREND=30
 REGIME_BB_NARROW=0.05
+
+# 強制エントリーフラグ
+FORCE_ENTER=true

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1491,18 +1491,7 @@ def get_trade_plan(
             plan["entry"]["side"] = "no"
             plan.setdefault("reason", "PROB_TOO_LOW")
 
-    # Composite score check
-    try:
-        if comp_val is not None and comp_val < COMPOSITE_MIN:
-            plan["entry"]["side"] = "no"
-            plan.setdefault("reason", "COMPOSITE_TOO_LOW")
-            logger.info(
-                "Composite score %.2f < %.2f → entry blocked",
-                comp_val,
-                COMPOSITE_MIN,
-            )
-    except Exception:
-        pass
+    # Composite score 判定を完全にスキップ
 
     if plan.get("entry", {}).get("side") == "no":
         plan["risk"] = {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - KAFKA_SERVERS=kafka:9092
       - KAFKA_BROKERS=kafka:9092
       - TRADES_DB_PATH=/app/backend/logs/trades.db
+      - FORCE_ENTER=true
     depends_on:
       kafka:
         condition: service_healthy

--- a/piphawk_ai/vote_arch/post_filters.py
+++ b/piphawk_ai/vote_arch/post_filters.py
@@ -25,15 +25,7 @@ def net_tp_ok(tp: float, spread: float) -> bool:
 
 
 def final_filter(plan: EntryPlan, indicators: dict) -> bool:
-    """Return True if plan passes all filters."""
-    diff = float(indicators.get("ema_diff", 0))
-    spread = float(indicators.get("spread", 0))
-    return all(
-        [
-            ema_divergence_ok(diff),
-            rrr_ok(plan.tp, plan.sl),
-            net_tp_ok(plan.tp, spread),
-        ]
-    )
+    """Post-filter を全て無効化して必ず True を返す."""
+    return True
 
 __all__ = ["final_filter"]


### PR DESCRIPTION
## Summary
- ensure the vote-arch pipeline always forwards AI entry plans when `FORCE_ENTER` is true
- disable post filters by always returning `True`
- skip composite score checks in the OpenAI analysis
- add `FORCE_ENTER` to example env and docker-compose

## Testing
- `ruff check piphawk_ai/vote_arch/pipeline.py piphawk_ai/vote_arch/post_filters.py backend/strategy/openai_analysis.py`
- `mypy piphawk_ai/vote_arch/pipeline.py piphawk_ai/vote_arch/post_filters.py backend/strategy/openai_analysis.py`
- `pytest tests/test_prom_exporter.py::test_metrics_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe790b81c8333860f94253fda52d5