### PR TITLE
feature: add token trimming for exit ai

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ line-bot-sdk
 prometheus-client
 openai
 httpx
+tiktoken
 numpy
 pandas
 requests

--- a/tests/test_openai_trim.py
+++ b/tests/test_openai_trim.py
@@ -1,0 +1,13 @@
+import backend.utils.openai_client as oc
+
+
+def test_trim_tokens_limit():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "x" * 50000},
+        {"role": "assistant", "content": "y" * 50000},
+    ]
+    trimmed = oc.trim_tokens(messages, limit=1000)
+    assert oc.num_tokens(trimmed) <= 1000
+    assert trimmed[0]["role"] == "system"
+


### PR DESCRIPTION
## Summary
- add num_tokens and trim_tokens utilities using tiktoken
- limit token count in exit_ai_decision.evaluate
- support passing prepared message lists to ask_openai
- include tiktoken in dev requirements
- add unit test for trimming helper

## Testing
- `ruff check backend/strategy/exit_ai_decision.py backend/utils/openai_client.py tests/test_openai_trim.py`
- `mypy backend/strategy/exit_ai_decision.py backend/utils/openai_client.py tests/test_openai_trim.py`
- `pytest -q tests/test_openai_trim.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piphawk_ai.ai')*

------
https://chatgpt.com/codex/tasks/task_e_684ff055fb20833380b734c83e501b9b