### PR TITLE
fix: add missing tiktoken dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,5 +40,6 @@ prometheus-client==0.20.0
 hdbscan==0.8.33  # optional
 d3rlpy==2.1.0
 transformers==4.41.2
+tiktoken>=0.6.0
 # CPU-only build
 torch==2.3.0+cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "hdbscan==0.8.33",
     "d3rlpy==2.1.0",
     "transformers==4.41.2",
+    "tiktoken>=0.6.0",
     "torch==2.3.0+cpu",
 ]
 


### PR DESCRIPTION
## Summary
- install tiktoken so token utilities work

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: ImportError: cannot import name 'FastAPI' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68501ddea1248333b4e96f1543adfd1b