### PR TITLE
feature/skip-regime-ai

### DIFF
--- a/ai/cnn_pattern/infer.py
+++ b/ai/cnn_pattern/infer.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-import torch
 from PIL import Image
+
+import torch
 
 from .model import PatternCNN
 


### PR DESCRIPTION
## Summary
- add `USE_LLM_REGIME` flag to disable Regime-AI
- skip regime and entry AI calls when entry filter fails
- update import order via isort

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError: cannot import name 'FastAPI')*

------
https://chatgpt.com/codex/tasks/task_e_68502689b4508333be2a9b44b2b80a29