### PR TITLE
fix market air sensor

### DIFF
--- a/piphawk_ai/vote_arch/market_air_sensor.py
+++ b/piphawk_ai/vote_arch/market_air_sensor.py
@@ -12,9 +12,10 @@ class MarketSnapshot:
 
 
 def air_index(m: MarketSnapshot) -> float:
+    """Return market air index based solely on technical indicators."""
     vol_heat = min(m.atr / 0.1, 1)
-    news_heat = min(abs(m.news_score) / 5, 1)
     flow_heat = abs(m.oi_bias)
-    return 0.5 * vol_heat + 0.3 * news_heat + 0.2 * flow_heat
+    # ニューススコアは一時的に無視する
+    return 0.7 * vol_heat + 0.3 * flow_heat
 
 __all__ = ["MarketSnapshot", "air_index"]


### PR DESCRIPTION
## Summary
- ignore news_score when calculating market air index

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError: cannot import name 'FastAPI' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6850280ac20c8333abfc3116a1247ff1