### PR TITLE
feature: add return_side option to process_entry

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -234,6 +234,7 @@ def process_entry(
     indicators_multi: dict[str, dict] | None = None,
     allow_delayed_entry: bool | None = None,
     risk_engine=None,
+    return_side: bool | None = False,
 ):
     """
     Ask OpenAI whether to enter a trade.
@@ -245,9 +246,13 @@ def process_entry(
         market_cond: output of get_market_condition()  e.g. {"market_condition":"trend","trend_direction":"long"}
         strategy_params: optional dict to pass extra parameters / overrides
         indicators_multi: multi-timeframe indicators for alignment adjustment
+        return_side   : if True, return only the AI-determined side without
+                        placing any order
 
     Returns:
-        True if an entry was placed, False otherwise.
+        True if an entry was placed, False otherwise. When ``return_side`` is
+        True, return the side string ("long"/"short") determined by the AI
+        without executing an order.
     """
     # If the caller did not pass a dict (JobRunner passes candles), fall back to an empty dict
     if not isinstance(strategy_params, dict):
@@ -671,6 +676,9 @@ def process_entry(
             logger.debug("reject: reason=%s", plan.get("reason"))
             logging.info("AI says no trade entry → early exit")
             return False
+
+    if return_side:
+        return side if side in ("long", "short") else None
 
     if spread_pips is not None:
         from backend.risk_manager import cost_guard

--- a/tests/test_process_entry_return.py
+++ b/tests/test_process_entry_return.py
@@ -59,3 +59,30 @@ def test_process_entry_returns_false(monkeypatch):
         indicators, candles, market_data, candles_dict={"M5": candles}, tf_align=None
     )
     assert result is False
+
+
+def test_process_entry_return_side(monkeypatch):
+    monkeypatch.setattr(entry_logic, "decide_trade_mode", lambda *_a, **_k: "trend")
+    monkeypatch.setattr(entry_logic, "decide_trade_mode_detail", lambda *_a, **_k: ("trend", 0.0, {}))
+    monkeypatch.setattr(
+        "backend.strategy.openai_analysis.get_trade_plan",
+        lambda *a, **k: {"entry": {"side": "short", "mode": "market"}, "risk": {}}
+    )
+    monkeypatch.setenv("PIP_SIZE", "0.01")
+
+    indicators = {"atr": FakeSeries([0.1])}
+    candles = []
+    market_data = {
+        "prices": [
+            {"instrument": "USD_JPY", "bids": [{"price": "1.0"}], "asks": [{"price": "1.01"}]}
+        ]
+    }
+    side = entry_logic.process_entry(
+        indicators,
+        candles,
+        market_data,
+        candles_dict={"M5": candles},
+        tf_align=None,
+        return_side=True,
+    )
+    assert side == "short"


### PR DESCRIPTION
## Summary
- allow `process_entry` to return the trade side without submitting an order
- test that the new option returns the AI-decided side

## Testing
- `isort backend/strategy/entry_logic.py tests/test_process_entry_return.py`
- `ruff check backend/strategy/entry_logic.py tests/test_process_entry_return.py`
- `mypy backend/strategy/entry_logic.py tests/test_process_entry_return.py`
- `pytest tests/test_process_entry_return.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685033949eb48333ba7900e68ca65a66