### PR TITLE
feature/atmosphere-signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ For detailed instructions, refer to [Setup](#setup).
 
 - Offline reinforcement policy integration for strategy selection.
 - See [docs/training_guide.md](docs/training_guide.md) for training scripts.
+- Usage of the new atmosphere signal is documented in
+  [docs/atmosphere_signal.md](docs/atmosphere_signal.md).
 
 ## Setup
 

--- a/analysis/atmosphere/__init__.py
+++ b/analysis/atmosphere/__init__.py
@@ -1,0 +1,11 @@
+"""Atmosphere analysis utilities."""
+
+from .feature_extractor import AtmosphereFeatures
+from .regime_classifier import RegimeClassifier
+from .score_calculator import AtmosphereScore
+
+__all__ = [
+    "AtmosphereFeatures",
+    "AtmosphereScore",
+    "RegimeClassifier",
+]

--- a/analysis/atmosphere/feature_extractor.py
+++ b/analysis/atmosphere/feature_extractor.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Calculate atmosphere-related market features."""
+
+from typing import Any, Sequence
+
+from backend.indicators.vwap_band import get_vwap_bias
+
+
+class AtmosphereFeatures:
+    """Market feature extractor for atmosphere analysis."""
+
+    def __init__(self, candles: Sequence[dict[str, Any]]) -> None:
+        self.candles = list(candles)
+
+    def vwap_bias(self) -> float:
+        """Return VWAP bias of the latest close price."""
+        prices = [float(c.get("close", c.get("c", 0))) for c in self.candles]
+        volumes = [float(c.get("volume", c.get("v", 0))) for c in self.candles]
+        return get_vwap_bias(prices, volumes)
+
+    def volume_delta(self) -> float:
+        """Return normalized volume delta (up minus down volume)."""
+        up = 0.0
+        down = 0.0
+        for c in self.candles:
+            vol = float(c.get("volume", c.get("v", 0)))
+            open_p = float(c.get("open", c.get("o", 0)))
+            close_p = float(c.get("close", c.get("c", 0)))
+            if close_p >= open_p:
+                up += vol
+            else:
+                down += vol
+        total = up + down
+        if total == 0:
+            return 0.0
+        return (up - down) / total
+
+    def extract(self) -> dict[str, float]:
+        """Return feature dictionary."""
+        return {
+            "vwap_bias": self.vwap_bias(),
+            "volume_delta": self.volume_delta(),
+        }
+
+
+__all__ = ["AtmosphereFeatures"]

--- a/analysis/atmosphere/regime_classifier.py
+++ b/analysis/atmosphere/regime_classifier.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Classify market regime based on atmosphere score."""
+
+
+class RegimeClassifier:
+    """スコアをタグへ変換する単純な分類クラス."""
+
+    def __init__(self, on_threshold: float = 70.0, off_threshold: float = 30.0) -> None:
+        self.on_threshold = on_threshold
+        self.off_threshold = off_threshold
+
+    def classify(self, score: float) -> str:
+        """Return regime tag from score."""
+        if score >= self.on_threshold:
+            return "Risk-On"
+        if score <= self.off_threshold:
+            return "Risk-Off"
+        return "Neutral"
+
+
+__all__ = ["RegimeClassifier"]

--- a/analysis/atmosphere/score_calculator.py
+++ b/analysis/atmosphere/score_calculator.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Convert atmosphere features to a score."""
+
+from typing import Mapping
+
+
+class AtmosphereScore:
+    """特徴量を 0-100 点に正規化するクラス."""
+
+    def __init__(self, weights: Mapping[str, float] | None = None) -> None:
+        self.weights = {
+            "vwap_bias": 0.5,
+            "volume_delta": 0.5,
+        }
+        if weights:
+            self.weights.update(weights)
+
+    def calc(self, features: Mapping[str, float]) -> float:
+        """Return total score from features."""
+        bias = abs(float(features.get("vwap_bias", 0.0)))
+        delta = float(features.get("volume_delta", 0.0))
+        bias_score = min(bias * 2000, 100.0)
+        delta_score = (delta + 1) * 50
+        total = (
+            bias_score * self.weights.get("vwap_bias", 0)
+            + delta_score * self.weights.get("volume_delta", 0)
+        )
+        return max(0.0, min(total, 100.0))
+
+
+__all__ = ["AtmosphereScore"]

--- a/docs/atmosphere_signal.md
+++ b/docs/atmosphere_signal.md
@@ -1,0 +1,22 @@
+# Atmosphere Signal
+
+Atmosphere モジュールは VWAP 乖離率と Volume Delta を用いて市場の"雰囲気"を数値化します。`AtmosphereFeatures` で特徴量を計算し、`AtmosphereScore` で 0--100 点のスコアへ変換します。`RegimeClassifier` を使うと Risk-On/Off のタグに分類できます。
+
+```python
+from analysis.atmosphere.feature_extractor import AtmosphereFeatures
+from analysis.atmosphere.score_calculator import AtmosphereScore
+from analysis.atmosphere.regime_classifier import RegimeClassifier
+from signals.atmosphere_signal import generate_signal
+
+candles = [
+    {"open": 100, "close": 101, "volume": 10},
+    {"open": 101, "close": 102, "volume": 12},
+]
+
+features = AtmosphereFeatures(candles).extract()
+score = AtmosphereScore().calc(features)
+regime = RegimeClassifier().classify(score)
+entry = generate_signal(score, rsi=25)
+```
+
+`generate_signal` は RSI とスコアを組み合わせ、条件を満たすと ``"long"`` または ``"short"`` を返します。

--- a/signals/atmosphere_signal.py
+++ b/signals/atmosphere_signal.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Simple entry signal using atmosphere score and RSI."""
+
+from typing import Mapping
+
+from analysis.atmosphere.regime_classifier import RegimeClassifier
+
+
+def generate_signal(score: float, rsi: float, *, classifier: RegimeClassifier | None = None) -> str | None:
+    """Return order side if conditions meet."""
+    classifier = classifier or RegimeClassifier()
+    tag = classifier.classify(score)
+    if tag == "Risk-On" and rsi < 30:
+        return "long"
+    if tag == "Risk-Off" and rsi > 70:
+        return "short"
+    return None
+
+
+__all__ = ["generate_signal"]

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -1,0 +1,32 @@
+from analysis.atmosphere.feature_extractor import AtmosphereFeatures
+from analysis.atmosphere.regime_classifier import RegimeClassifier
+from analysis.atmosphere.score_calculator import AtmosphereScore
+from signals.atmosphere_signal import generate_signal
+
+
+def _sample_candles():
+    return [
+        {"open": 100, "close": 101, "volume": 10},
+        {"open": 101, "close": 102, "volume": 12},
+        {"open": 102, "close": 101, "volume": 8},
+    ]
+
+
+def test_feature_extractor():
+    feats = AtmosphereFeatures(_sample_candles()).extract()
+    assert "vwap_bias" in feats
+    assert "volume_delta" in feats
+
+
+def test_score_and_classify():
+    feats = AtmosphereFeatures(_sample_candles()).extract()
+    score = AtmosphereScore().calc(feats)
+    tag = RegimeClassifier().classify(score)
+    assert tag in {"Risk-On", "Risk-Off", "Neutral"}
+
+
+def test_generate_signal():
+    feats = AtmosphereFeatures(_sample_candles()).extract()
+    score = AtmosphereScore().calc(feats)
+    sig = generate_signal(score, rsi=20)
+    assert sig in {None, "long", "short"}


### PR DESCRIPTION
## Summary
- implement AtmosphereFeatures for VWAP bias and volume delta
- add AtmosphereScore to convert features to 0-100
- add RegimeClassifier and new atmosphere signal
- document usage in `docs/atmosphere_signal.md` and reference from README
- provide unit tests for the atmosphere module

## Testing
- `pip install -r requirements-test.txt`
- `isort .`
- `ruff check .`
- `mypy .`
- `pytest tests/test_atmosphere.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'FastAPI' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68503acbe0508333af3a60f01498599b