### PR TITLE
docs: add docstring to offline policy learning

### DIFF
--- a/training/offline_policy_learning.py
+++ b/training/offline_policy_learning.py
@@ -1,3 +1,5 @@
+"""簡易 Q 学習を用いたオフラインポリシー学習スクリプト."""
+
 import json
 import sqlite3
 from collections import defaultdict


### PR DESCRIPTION
## Summary
- add short module docstring to offline_policy_learning.py

## Testing
- `ruff check .`
- `isort --check --diff .` *(shows "Skipped 1 files" which is acceptable)*
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68503acf60548333b43bae8208c1fd92