### PR TITLE
docs: add Atmosphere module guide

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -63,3 +63,8 @@ REGIME_BB_NARROW=0.05
 
 # 強制エントリーフラグ
 FORCE_ENTER=true
+
+# Atmosphere module settings
+ATMOS_EMA_WEIGHT=0.4
+ATMOS_RSI_WEIGHT=0.3
+ATMOS_THRESHOLD=0.5

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ For detailed instructions, refer to [Setup](#setup).
 - Multi-timeframe indicators and regime detection.
 - Parameterized `mode_detector` allows tuning without any LLM calls.
 - Optional chart pattern detection via OpenAI or a local scanner.
+- Atmosphere module adjusts strategy weights using EMA slope and RSI bias.
+  See [docs/atmosphere_module.md](docs/atmosphere_module.md) for details.
 - CVaR-based portfolio risk management.
 - Parameters managed via environment variables and YAML with hot reload.
 - Trade and parameter history stored in SQLite.
@@ -154,6 +156,19 @@ Ticks → openai_micro_scalp.py → enter: true → submit order
 ```
 
 設定変更後はコンテナを再起動して反映します。
+
+### Atmosphere module
+
+The Atmosphere module adjusts strategy weights based on EMA slope and RSI bias.
+Add the following variables to `.env` and tune as needed.
+
+```bash
+ATMOS_EMA_WEIGHT=0.4
+ATMOS_RSI_WEIGHT=0.3
+ATMOS_THRESHOLD=0.5
+```
+
+See [docs/atmosphere_module.md](docs/atmosphere_module.md) for usage details.
 
 ### Directory Structure
 

--- a/docs/atmosphere_module.md
+++ b/docs/atmosphere_module.md
@@ -1,0 +1,21 @@
+# Atmosphere Module
+
+市場の"雰囲気"を数値化し、戦略重みを調整する拡張モジュールです。EMAの傾きやRSIバイアスからスコアを算出し、一定値を超えたときのみエントリーを許可します。
+
+## Usage
+
+```python
+from backend.analysis.atmosphere import evaluate
+
+score, bias = evaluate(context)
+```
+
+`bias` はリスク割合などの自動調整に利用できます。
+
+## Environment Variables
+
+- `ATMOS_EMA_WEIGHT` — EMA傾きをスコアへ加える重み (default: 0.4)
+- `ATMOS_RSI_WEIGHT` — RSIバイアスの重み (default: 0.3)
+- `ATMOS_THRESHOLD` — エントリーを許可する最小スコア (default: 0.5)
+
+`.env` へこれらの値を設定して挙動をカスタマイズしてください。

--- a/docs/env_reference.md
+++ b/docs/env_reference.md
@@ -29,5 +29,8 @@
 | LINE_USER_ID | (なし) | LINE通知先ユーザーID | `LINE_USER_ID=yyyy` |
 | CORS_ALLOW_ORIGINS | (なし) | APIで許可するオリジン | `CORS_ALLOW_ORIGINS=http://localhost:3000` |
 | LOG_LEVEL | INFO | ログ出力レベル | `LOG_LEVEL=DEBUG` |
+| ATMOS_EMA_WEIGHT | 0.4 | AtmosphereモジュールでEMA傾きを評価する重み | `ATMOS_EMA_WEIGHT=0.5` |
+| ATMOS_RSI_WEIGHT | 0.3 | AtmosphereモジュールのRSI重み | `ATMOS_RSI_WEIGHT=0.2` |
+| ATMOS_THRESHOLD | 0.5 | Atmosphereスコアがこの値以上ならエントリー | `ATMOS_THRESHOLD=0.6` |
 
 より詳細な変数や追加の設定は [docs/env_vars.md](env_vars.md) を参照してください。

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -416,3 +416,9 @@ FALLBACK_DEFAULT_TP_PIPS=15
 FALLBACK_DYNAMIC_RISK=true
 FORCE_ENTRY_AFTER_AI=true
 ```
+
+### Atmosphere module
+
+- `ATMOS_EMA_WEIGHT`: EMA傾きの重み付け。デフォルトは `0.4`。
+- `ATMOS_RSI_WEIGHT`: RSIバイアスの重み付け。デフォルトは `0.3`。
+- `ATMOS_THRESHOLD`: Atmosphereスコアがこの値以上でエントリーを許可。デフォルト `0.5`。

--- a/docs/quick_start_en.md
+++ b/docs/quick_start_en.md
@@ -33,3 +33,5 @@
 Past performance does not guarantee future results. Use at your own risk.
 
 When the AI returns `side: "no"`, the plan includes a `why` field briefly stating the reason. When it responds with `side: "yes"`, the `risk` object must contain `tp_pips`, `sl_pips`, `tp_prob` and `sl_prob`; `tp_prob` should be at least 0.70.
+
+For the new Atmosphere module see [atmosphere_module.md](atmosphere_module.md).

--- a/docs/quick_start_ja.md
+++ b/docs/quick_start_ja.md
@@ -57,3 +57,5 @@ fallback:
 ```
 
 `force_on_no_side` を `true` にすると AI が "no" と答えてもトレンド方向へエントリーを強制します。`default_sl_pips` と `default_tp_pips` は AI から数値が得られないときのデフォルト幅です。`dynamic_risk` が `true` の場合、指標を基に自動で SL/TP を計算します。これらは `FALLBACK_FORCE_ON_NO_SIDE` などの環境変数からも設定可能です。
+
+Atmosphere モジュールの概要は [atmosphere_module.md](atmosphere_module.md) を参照してください。


### PR DESCRIPTION
## Summary
- describe Atmosphere module in Features and Setup
- add new environment variables to `.env.template`
- document `ATMOS_*` variables in env reference
- link to new doc from quick start guides

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: 58 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68503ad1d43c83338c2813cd245959fb