### PR TITLE
Refactor: centralize atmosphere utilities

### DIFF
--- a/analysis/atmosphere/__init__.py
+++ b/analysis/atmosphere/__init__.py
@@ -1,6 +1,7 @@
 """Atmosphere analysis utilities."""
 
 from .feature_extractor import AtmosphereFeatures
+from .market_air_sensor import MarketSnapshot, air_index
 from .regime_classifier import RegimeClassifier
 from .score_calculator import AtmosphereScore
 
@@ -8,4 +9,6 @@ __all__ = [
     "AtmosphereFeatures",
     "AtmosphereScore",
     "RegimeClassifier",
+    "MarketSnapshot",
+    "air_index",
 ]

--- a/analysis/atmosphere/market_air_sensor.py
+++ b/analysis/atmosphere/market_air_sensor.py
@@ -1,0 +1,21 @@
+"""Calculate market air index used in prompts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MarketSnapshot:
+    atr: float
+    news_score: float
+    oi_bias: float
+
+
+def air_index(m: MarketSnapshot) -> float:
+    """Return market air index based solely on technical indicators."""
+    vol_heat = min(m.atr / 0.1, 1)
+    flow_heat = abs(m.oi_bias)
+    # ニューススコアは一時的に無視する
+    return 0.7 * vol_heat + 0.3 * flow_heat
+
+__all__ = ["MarketSnapshot", "air_index"]

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -161,8 +161,8 @@ from piphawk_ai.analysis.regime_detector import RegimeDetector
 from piphawk_ai.tech_arch.pipeline import run_cycle as tech_run_cycle
 
 try:
+    from analysis.atmosphere.market_air_sensor import MarketSnapshot
     from piphawk_ai.vote_arch.entry_buffer import PlanBuffer
-    from piphawk_ai.vote_arch.market_air_sensor import MarketSnapshot
     from piphawk_ai.vote_arch.pipeline import (
         PipelineResult,
     )

--- a/docs/file_roles.md
+++ b/docs/file_roles.md
@@ -371,7 +371,7 @@
 | `piphawk_ai/vote_arch/ai_entry_plan.py` | OpenAI経由の決定論的エントリプランの生成。 |
 | `piphawk_ai/vote_arch/ai_strategy_selector.py` | Openaiおよび多数決を介して貿易戦略を選択します。 |
 | `piphawk_ai/vote_arch/entry_buffer.py` | エントリープラン用のシンプルな垂直アンサンブルバッファー。 |
-| `piphawk_ai/vote_arch/market_air_sensor.py` | プロンプトで使用される市場空気インデックスを計算します。 |
+| `analysis/atmosphere/market_air_sensor.py` | プロンプトで使用される市場空気インデックスを計算します。 |
 | `piphawk_ai/vote_arch/pipeline.py` | 過半数の投票取引アーキテクチャのオーケストレーションパイプライン。 |
 | `piphawk_ai/vote_arch/post_filters.py` | エントリープランの最終的な安全チェック。 |
 | `piphawk_ai/vote_arch/regime_detector.py` | 単純なルールベースの体制検出。 |

--- a/piphawk_ai/vote_arch/__init__.py
+++ b/piphawk_ai/vote_arch/__init__.py
@@ -1,10 +1,10 @@
 """Majority-vote trading pipeline components."""
+from analysis.atmosphere.market_air_sensor import MarketSnapshot, air_index
 from signals.mode_selector_v2 import select_mode
 
 from .ai_entry_plan import EntryPlan, generate_plan
 from .ai_strategy_selector import select_strategy
 from .entry_buffer import PlanBuffer
-from .market_air_sensor import MarketSnapshot, air_index
 from .pipeline import PipelineResult, run_cycle
 from .post_filters import final_filter
 from .regime_detector import MarketMetrics, rule_based_regime

--- a/piphawk_ai/vote_arch/market_air_sensor.py
+++ b/piphawk_ai/vote_arch/market_air_sensor.py
@@ -1,21 +1,6 @@
-"""Calculate market air index used in prompts."""
-from __future__ import annotations
+"""Wrapper for market air utilities (deprecated)."""
+from analysis.atmosphere.market_air_sensor import MarketSnapshot, air_index
 
-from dataclasses import dataclass
-
-
-@dataclass
-class MarketSnapshot:
-    atr: float
-    news_score: float
-    oi_bias: float
-
-
-def air_index(m: MarketSnapshot) -> float:
-    """Return market air index based solely on technical indicators."""
-    vol_heat = min(m.atr / 0.1, 1)
-    flow_heat = abs(m.oi_bias)
-    # ニューススコアは一時的に無視する
-    return 0.7 * vol_heat + 0.3 * flow_heat
+# 互換性維持のための薄いラッパー
 
 __all__ = ["MarketSnapshot", "air_index"]

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -6,13 +6,13 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
+from analysis.atmosphere.market_air_sensor import MarketSnapshot, air_index
 from backend.strategy.signal_filter import pass_entry_filter
 from signals.mode_selector_v2 import select_mode
 
 from .ai_entry_plan import EntryPlan, generate_plan
 from .ai_strategy_selector import select_strategy
 from .entry_buffer import PlanBuffer
-from .market_air_sensor import MarketSnapshot, air_index
 from .post_filters import final_filter
 from .regime_detector import MarketMetrics, rule_based_regime
 

--- a/tests/test_llm_mode_blend.py
+++ b/tests/test_llm_mode_blend.py
@@ -2,7 +2,7 @@ import importlib
 
 import analysis.llm_client as lc
 import signals.mode_selector_v2 as ms
-from piphawk_ai.vote_arch.market_air_sensor import MarketSnapshot
+from analysis.atmosphere.market_air_sensor import MarketSnapshot
 
 
 def test_llm_blend_base_overrides(monkeypatch):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,9 +14,9 @@ pandas_stub.Series = object
 pandas_stub.DataFrame = object
 sys.modules.setdefault("pandas", pandas_stub)
 
+from analysis.atmosphere.market_air_sensor import MarketSnapshot
 from piphawk_ai.vote_arch.ai_entry_plan import EntryPlan
 from piphawk_ai.vote_arch.entry_buffer import PlanBuffer
-from piphawk_ai.vote_arch.market_air_sensor import MarketSnapshot
 from piphawk_ai.vote_arch.pipeline import PipelineResult, run_cycle
 from piphawk_ai.vote_arch.regime_detector import MarketMetrics
 

--- a/tests/test_pipeline_mode_integration.py
+++ b/tests/test_pipeline_mode_integration.py
@@ -1,8 +1,8 @@
 import pytest
 
+from analysis.atmosphere.market_air_sensor import MarketSnapshot
 from piphawk_ai.vote_arch.ai_entry_plan import EntryPlan
 from piphawk_ai.vote_arch.entry_buffer import PlanBuffer
-from piphawk_ai.vote_arch.market_air_sensor import MarketSnapshot
 from piphawk_ai.vote_arch.pipeline import PipelineResult, run_cycle
 from piphawk_ai.vote_arch.regime_detector import MarketMetrics
 


### PR DESCRIPTION
## Summary
- centralize market air sensor utilities under `analysis/atmosphere`
- keep backward-compatible wrapper in vote_arch package
- update imports and docs for new path

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: module import and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68514913a1648333a095db8b81f78cf6