### PR TITLE
feat: relax market filter

### DIFF
--- a/filters/market_filters.py
+++ b/filters/market_filters.py
@@ -17,13 +17,20 @@ def _in_trade_hours(ts: datetime | None = None) -> bool:
     return ts.hour >= start or ts.hour < end
 
 
-def is_tradeable(pair: str, timeframe: str, spread: float) -> bool:
-    """スプレッドと時間帯が条件を満たすか確認する.
+def is_tradeable(pair: str, timeframe: str, spread: float, atr: float | None = None) -> bool:
+    """Check if market conditions allow trading."""
 
-    pair と timeframe は現段階では未使用.
-    """
-    max_spread = float(env_loader.get_env("MAX_SPREAD", "0.0002"))
-    if spread > max_spread:
+    # 日本語コメント: スプレッドとボラティリティをピップスで比較する
+
+    pip_size = 0.01 if pair.endswith("_JPY") else 0.0001
+    max_spread = float(env_loader.get_env("MAX_SPREAD_PIPS", "2"))
+    if spread / pip_size > max_spread:
         return False
+
+    if atr is not None:
+        min_atr = float(env_loader.get_env("MIN_ATR_PIPS", "2"))
+        if atr / pip_size < min_atr:
+            return False
+
     return _in_trade_hours()
 

--- a/signals/scalping_signal.py
+++ b/signals/scalping_signal.py
@@ -10,7 +10,12 @@ _predictor = GPTPredictor()
 
 def make_signal(features: dict) -> str | None:
     """必ずエントリーする方向を返す."""
-    if not is_tradeable(features.get("pair", ""), "M1", features.get("spread", 0.0)):
+    if not is_tradeable(
+        features.get("pair", ""),
+        "M1",
+        features.get("spread", 0.0),
+        features.get("atr"),
+    ):
         return None
     probs = _predictor.predict(features)
     return "BUY" if probs["prob_long"] >= probs["prob_short"] else "SELL"

--- a/tests/test_basic_signals.py
+++ b/tests/test_basic_signals.py
@@ -13,7 +13,7 @@ class DummyPredictor:
 
 def test_scalping_signal(monkeypatch):
     monkeypatch.setattr(scalping_signal, "_predictor", DummyPredictor())
-    res = scalping_signal.make_signal({"pair": "USD_JPY", "spread": 0.0001})
+    res = scalping_signal.make_signal({"pair": "USD_JPY", "spread": 0.0001, "atr": 0.03})
     assert res in ("BUY", "SELL")
 
 

--- a/tests/test_market_filter.py
+++ b/tests/test_market_filter.py
@@ -1,0 +1,13 @@
+import os
+
+from filters.market_filters import is_tradeable
+
+
+def test_is_tradeable_basic(monkeypatch):
+    monkeypatch.setenv("TRADE_START_H", "0")
+    monkeypatch.setenv("TRADE_END_H", "24")
+    monkeypatch.setenv("MAX_SPREAD_PIPS", "2")
+    monkeypatch.setenv("MIN_ATR_PIPS", "2")
+    assert is_tradeable("USD_JPY", "M1", 0.01, 0.03)
+    assert not is_tradeable("USD_JPY", "M1", 0.03, 0.03)
+    assert not is_tradeable("USD_JPY", "M1", 0.01, 0.01)


### PR DESCRIPTION
## Summary
- simplify market condition check with spread/volatility thresholds
- pass ATR info to scalping signal
- update basic signal test
- add tests for market filter

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi, requests, yaml, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6852010e946c8333b44d01af3dcc6017