### PR TITLE
feat: add quick 2pips mode

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -290,6 +290,11 @@ BASE_LOT=1.0                    # マイクロスキャルプロット
 MICRO_SCALP_LOOKBACK=3          # マイクロスキャルプ参照本数
 MICRO_SCALP_MIN_PIPS=1.5          # マイクロスキャルプ判定幅
 
+# === Quick TP mode ===
+QUICK_TP_MODE=false           # 2pips利確を繰り返す専用モード
+QUICK_TP_INTERVAL_SEC=360     # エントリー間隔(秒)
+QUICK_TP_UNITS=1000           # 発注ユニット数
+
 AUTO_RESTART=false
 RESTART_MIN_INTERVAL=60      # 最小再起動間隔(秒)
 # === Trade mode matrix ===

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,8 +31,13 @@ def main() -> None:
         port = int(env_loader.get_env("API_PORT", "8080"))
         uvicorn.run("backend.api.main:app", host="0.0.0.0", port=port)
     else:
-        runner = JobRunner()
-        runner.run()
+        if env_loader.get_env("QUICK_TP_MODE", "false").lower() == "true":
+            from execution.quick_tp_mode import run_loop
+
+            run_loop()
+        else:
+            runner = JobRunner()
+            runner.run()
 
 
 if __name__ == "__main__":

--- a/docs/aggressive_scalp.md
+++ b/docs/aggressive_scalp.md
@@ -34,6 +34,18 @@ MICRO_SCALP_MIN_PIPS=1
 
 設定後にジョブランナーを再起動するとマイクロ構造モードが有効になります。
 
+## Quick TP モード
+
+AI で方向を判断し 2pips で利確する超短期売買を繰り返す場合は以下を設定します。
+
+```bash
+QUICK_TP_MODE=true
+QUICK_TP_INTERVAL_SEC=360
+QUICK_TP_UNITS=1000
+```
+
+有効化すると通常のジョブランナー処理は実行されず、このモードのみが動作します。
+
 ## 反映手順
 
 1. `backend/config/settings.env` に上記を追記または変更します。

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -308,6 +308,9 @@ SCALE_TRIGGER_ATR=0.5
   移行・維持する際のしきい値。推奨 `0.20` / `0.15`。
 - RANGE_ADX_MIN: ADX がこの値を下回るとカウンターを加算し、連続
   `RANGE_ADX_COUNT` 回でスキャルプモードへ切替。推奨 `15`。
+- QUICK_TP_MODE: true で2pips利確を高速に繰り返す専用モードを起動
+- QUICK_TP_INTERVAL_SEC: Quick TP モードでのエントリー間隔秒数
+- QUICK_TP_UNITS: Quick TP モードで使う発注ユニット数
 
 ### OANDA_MATCH_SEC
 

--- a/execution/quick_tp_mode.py
+++ b/execution/quick_tp_mode.py
@@ -1,0 +1,57 @@
+"""Quick 2-pip scalping loop."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+from backend.market_data.tick_fetcher import fetch_tick_data
+from backend.market_data.tick_metrics import calc_tick_features
+from backend.orders.order_manager import OrderManager
+from backend.orders.position_manager import get_open_positions
+from backend.strategy.openai_micro_scalp import get_plan
+from backend.utils import env_loader
+
+logger = logging.getLogger(__name__)
+
+
+def run_loop() -> None:
+    """Run micro scalp mode that aims for 2 pips repeatedly."""
+    instrument = env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
+    interval = int(env_loader.get_env("QUICK_TP_INTERVAL_SEC", "360"))
+    units = int(env_loader.get_env("QUICK_TP_UNITS", "1000"))
+
+    om = OrderManager()
+
+    while True:
+        try:
+            positions = get_open_positions() or []
+            if positions:
+                time.sleep(interval)
+                continue
+
+            tick = fetch_tick_data(instrument)
+            bid = float(tick["prices"][0]["bids"][0]["price"])
+            ask = float(tick["prices"][0]["asks"][0]["price"])
+            feats = calc_tick_features([{"bid": bid, "ask": ask}])
+            plan = get_plan(feats)
+            side = plan.get("side")
+            if side not in ("long", "short"):
+                time.sleep(interval)
+                continue
+
+            units_signed = units if side == "long" else -units
+            om.place_market_with_tp_sl(
+                instrument,
+                units_signed,
+                side,
+                tp_pips=2.0,
+                sl_pips=0.0,
+                comment_json=json.dumps({"mode": "quick_tp"}),
+            )
+            logger.info("Entered %s %s for 2 pips TP", side, instrument)
+        except Exception as exc:  # pragma: no cover - network or API error
+            logger.warning("quick_tp iteration failed: %s", exc)
+        time.sleep(interval)
+


### PR DESCRIPTION
## Summary
- add QUICK_TP_MODE config and loop for fast 2 pip scalps
- enable QUICK_TP_MODE in backend main entry
- document QUICK_TP settings

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68521417d4b08333ae8a017411743911