### PR TITLE
Remove post filter call

### DIFF
--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -85,7 +85,8 @@ def run_cycle(
         if avg_plan:
             plan = avg_plan
 
-    passed = final_filter(plan, indicators)
+    # Post-filter は廃止されたため常に True とする
+    passed = True
     # FORCE_ENTER が true の場合はフィルタ結果を無視して必ず発注
     if FORCE_ENTER:
         return PipelineResult(plan, mode=mode, regime=regime, passed=True)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -52,12 +52,6 @@ def test_run_cycle(monkeypatch):
         "piphawk_ai.vote_arch.pipeline.generate_plan", fake_plan
     )
 
-    monkeypatch.setattr(
-        "piphawk_ai.vote_arch.post_filters.final_filter", lambda p, i: True
-    )
-    monkeypatch.setattr(
-        "piphawk_ai.vote_arch.pipeline.final_filter", lambda p, i: True
-    )
 
     metrics = MarketMetrics(adx_m5=30, ema_fast=1.1, ema_slow=1.0, bb_width_m5=0.1)
     snapshot = MarketSnapshot(atr=0.05, news_score=0.0, oi_bias=0.0)

--- a/tests/test_pipeline_mode_integration.py
+++ b/tests/test_pipeline_mode_integration.py
@@ -32,12 +32,6 @@ def test_run_cycle_returns_valid_mode(monkeypatch, mode_raw, conf_ok):
         lambda _p: EntryPlan(side="long", tp=10, sl=5, lot=1),
     )
 
-    monkeypatch.setattr(
-        "piphawk_ai.vote_arch.post_filters.final_filter", lambda p, i: True
-    )
-    monkeypatch.setattr(
-        "piphawk_ai.vote_arch.pipeline.final_filter", lambda p, i: True
-    )
 
     metrics = MarketMetrics(adx_m5=30, ema_fast=1.1, ema_slow=1.0, bb_width_m5=0.1)
     snapshot = MarketSnapshot(atr=0.05, news_score=0.0, oi_bias=0.0)


### PR DESCRIPTION
## Summary
- always return `True` for post filter result
- clean up tests to remove final filter patches

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError for `fastapi`, `requests`, `numpy`, `yaml`)*

------
https://chatgpt.com/codex/tasks/task_e_6852154307c083338d0215b650cfd8ef