### PR TITLE
fix: force entry after initial filter

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -2498,36 +2498,7 @@ class JobRunner:
                                     },
                                     risk_engine=self.risk_mgr,
                                 )
-                            if not self.use_vote_arch and not result:
-                                pend = get_pending_entry_order(DEFAULT_PAIR)
-                                if pend and pend.get("order_id"):
-                                    age = time.time() - pend.get("ts", 0)
-                                    if age >= self.pending_grace_sec:
-                                        try:
-                                            order_mgr.cancel_order(pend["order_id"])
-                                            log.info(
-                                                f"AI declined entry; canceled pending LIMIT {pend['order_id']}"
-                                            )
-                                        except Exception as exc:
-                                            log.warning(
-                                                f"Failed to cancel pending LIMIT {pend['order_id']}: {exc}"
-                                            )
-                                        for key, rec in list(_pending_limits.items()):
-                                            if rec.get("order_id") == pend["order_id"]:
-                                                _pending_limits.pop(key, None)
-                                                break
-                                    else:
-                                        log.info(
-                                            f"Pending LIMIT age {age:.0f}s < grace period; keeping order"
-                                        )
-                                log.info(
-                                    "process_entry returned False → aborting entry and continuing loop"
-                                )
-                                self.last_run = now
-                                update_oanda_trades()
-                                time.sleep(self.interval_seconds)
-                                timer.stop()
-                                continue
+                            # process_entry 結果に関わらず必ず進める
                             # Send LINE notification on entry
                             price = float(tick_data["prices"][0]["bids"][0]["price"])
                             send_line_message(

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -264,9 +264,8 @@ def process_entry(
         )
 
     forced_entry = False
-    force_entry_after_ai = (
-        env_loader.get_env("FORCE_ENTRY_AFTER_AI", "true").lower() == "true"
-    )
+    # AI判断後は必ず発注するよう強制する
+    force_entry_after_ai = True
     use_dynamic_risk = (
         env_loader.get_env("FALLBACK_DYNAMIC_RISK", "false").lower() == "true"
     )

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -16,7 +16,8 @@ from .entry_buffer import PlanBuffer
 from .post_filters import final_filter
 from .regime_detector import MarketMetrics, rule_based_regime
 
-FORCE_ENTER = os.getenv("FORCE_ENTER", "true").lower() == "true"
+# 常にエントリーを実行する
+FORCE_ENTER = True
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- force entry after AI call in entry logic
- always enter in vote_arch pipeline
- don't abort entry even if process_entry returns False

## Testing
- `isort .`
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685215957b088333a4cd1813412dbb82