### PR TITLE
Remove regime detector

### DIFF
--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -153,7 +153,6 @@ import requests
 from backend.strategy import pattern_scanner
 from backend.strategy.higher_tf_analysis import analyze_higher_tf
 from backend.strategy.momentum_follow import follow_breakout
-from piphawk_ai.analysis.regime_detector import RegimeDetector
 
 try:
     from signals.composite_mode import decide_trade_mode, decide_trade_mode_detail
@@ -389,22 +388,7 @@ class JobRunner:
         self.last_position_review_ts = None  # datetime of last position review
         # Epoch timestamp of last AI call (seconds)
         self.last_ai_call = datetime.min
-        self.regime_detector = RegimeDetector()
-        model_file = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-            "models",
-            "regime_gmm.pkl",
-        )
-        if os.path.exists(model_file):
-            try:
-                from piphawk_ai.analysis.cluster_regime import ClusterRegime
-
-                self.cluster_regime = ClusterRegime(model_file)
-            except Exception as exc:  # pragma: no cover - optional model
-                logger.warning(f"ClusterRegime load failed: {exc}")
-                self.cluster_regime = None
-        else:
-            self.cluster_regime = None
+        self.cluster_regime = None
         # Entry cooldown settings
         self.entry_cooldown_sec = int(env_loader.get_env("ENTRY_COOLDOWN_SEC", "30"))
         self.last_close_ts: datetime | None = None
@@ -985,15 +969,12 @@ class JobRunner:
                             "close": price,
                             "volume": bid_liq + ask_liq,
                         }
-                        rd_res = self.regime_detector.update(tick)
-                        if rd_res.get("transition"):
-                            self.last_ai_call = datetime.min
                         if self.cluster_regime:
                             cr_res = self.cluster_regime.update(tick)
                             if cr_res.get("transition"):
                                 self.last_ai_call = datetime.min
                     except Exception as exc:
-                        logger.debug(f"RegimeDetector update failed: {exc}")
+                        logger.debug(f"ClusterRegime update failed: {exc}")
 
                     # ---- Market closed guard (price feed says non‑tradeable) ----
                     try:
@@ -1106,7 +1087,7 @@ class JobRunner:
                     )
                     perf = recent_strategy_performance()
                     self.current_context = build_context(
-                        self.regime_detector.state, indicators, perf
+                        indicators, perf
                     )
                     selected = self.strategy_selector.select(self.current_context)
                     self.current_strategy_name = selected.name

--- a/prompts/trade_plan.txt
+++ b/prompts/trade_plan.txt
@@ -1,7 +1,6 @@
 Your task:
-1. Clearly classify the current regime as "trend" or "range". If "trend", specify direction as "long" or "short". Output this at JSON key "regime".
-2. Decide whether to open a trade now, strictly adhering to the above criteria. Return JSON key "entry" with: {{ "side":"long"|"short", "rationale":"…" }}. Also include numeric key "entry_confidence" between 0 and 1 representing your confidence. Additionally return key "probs" as {{"long":float,"short":float,"no":float}} where all values sum to 1 ("no" probability should be near zero).
-3. Propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included. Use decimals for all probability values. When you output side "long" or "short", the risk object must contain both "tp_pips" and "sl_pips" or the trade will be skipped.
+1. Decide whether to open a trade now using both technical indicators and market atmosphere. Return JSON key "entry" with: {{ "side":"long"|"short", "rationale":"…" }}. Also include numeric key "entry_confidence" between 0 and 1 representing your confidence. Additionally return key "probs" as {{"long":float,"short":float,"no":float}} where all values sum to 1 ("no" probability should be near zero).
+2. Propose TP/SL distances **in pips** along with their {TP_PROB_HOURS}-hour hit probabilities: {{ "tp_pips":int, "sl_pips":int, "tp_prob":float, "sl_prob":float }}. Output this at JSON key "risk". These four keys must always be included. Use decimals for all probability values. When you output side "long" or "short", the risk object must contain both "tp_pips" and "sl_pips" or the trade will be skipped.
    - Constraints:
     • tp_prob must be ≥ {MIN_TP_PROB:.2f}
     • Expected value (tp_pips*tp_prob - sl_pips*sl_prob) must be positive
@@ -9,8 +8,8 @@ Your task:
     • (tp_pips - spread_pips) must be ≥ {MIN_NET_TP_PIPS} pips
     • If constraints are not met, pick the side with the higher success probability.
 
-4. Always provide a brief "why" field explaining the trade logic.
-5. The "risk" object must include "tp_pips", "sl_pips", "tp_prob" and "sl_prob", and tp_prob must be ≥ 0.70.
+3. Always provide a brief "why" field explaining the trade logic.
+4. The "risk" object must include "tp_pips", "sl_pips", "tp_prob" and "sl_prob", and tp_prob must be ≥ 0.70.
 
 Respond with **one-line valid JSON** exactly as:
-{{"regime":{{...}},"entry":{{...}},"risk":{{...}},"entry_confidence":0.0,"probs":{{"long":0.5,"short":0.5,"no":0.0}}}}
+{{"entry":{{...}},"risk":{{...}},"entry_confidence":0.0,"probs":{{"long":0.5,"short":0.5,"no":0.0}}}}

--- a/prompts/trade_plan_instruction.txt
+++ b/prompts/trade_plan_instruction.txt
@@ -1,10 +1,5 @@
-⚠️【Market Regime Classification – Flexible Criteria】
-Classify as "TREND" if ANY TWO of the following conditions are met:
-- ADX ≥ {TREND_ADX_THRESH} maintained over at least the last 3 candles.
-- EMA consistently sloping upwards or downwards without major reversals within the last 3 candles.
-- Price consistently outside the Bollinger Band midline (above for bullish, below for bearish).
-
-If these conditions are not clearly met, classify the market as "RANGE".
+⚠️【Strategy Selection – Flexible Criteria】
+Use ADX, EMA slope and Bollinger Band width to judge whether a trend-follow or scalp approach is more suitable. If the metrics are mixed, favor quick scalp trades.
 {RANGE_ENTRY_NOTE}
 
 🚫【Counter-trend Trade Prohibition】

--- a/strategies/context_builder.py
+++ b/strategies/context_builder.py
@@ -36,11 +36,9 @@ def recent_strategy_performance(limit: int = 10) -> Dict[str, float]:
     return {k: sum(v) / len(v) for k, v in perf.items() if v}
 
 
-def build_context(regime: str, indicators: Dict[str, Any], perf: Dict[str, float] | None = None) -> Dict[str, float]:
+def build_context(indicators: Dict[str, Any], perf: Dict[str, float] | None = None) -> Dict[str, float]:
     """Assemble context dictionary for StrategySelector."""
-    ctx: Dict[str, float] = {
-        "regime_trend": 1.0 if regime == "TREND" else 0.0,
-    }
+    ctx: Dict[str, float] = {}
     try:
         adx_series = indicators.get("adx")
         if adx_series is not None:


### PR DESCRIPTION
## Summary
- drop market regime classification from prompts
- stop using RegimeDetector in schedulers
- simplify strategy context builder

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError)*


------
https://chatgpt.com/codex/tasks/task_e_685220ef530c83338501b93ccfe33408