### PR TITLE
fix imports

### DIFF
--- a/analysis/mode_detector.py
+++ b/analysis/mode_detector.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 """Compatibility wrapper for mode_hybrid."""
 
-from .mode_hybrid import MarketContext, detect_mode, detect_mode_simple, load_config
+try:
+    # When imported as a package module
+    from .mode_hybrid import MarketContext, detect_mode, detect_mode_simple, load_config
+except ImportError:  # pragma: no cover - fallback for direct execution
+    # Fallback to absolute import when executed as a script
+    from analysis.mode_hybrid import (
+        MarketContext,
+        detect_mode,
+        detect_mode_simple,
+        load_config,
+    )
 
 __all__ = [
     "MarketContext",

--- a/piphawk_ai/policy/__init__.py
+++ b/piphawk_ai/policy/__init__.py
@@ -1,0 +1,1 @@
+"""Policy package."""

--- a/piphawk_ai/risk/__init__.py
+++ b/piphawk_ai/risk/__init__.py
@@ -1,0 +1,1 @@
+"""Risk package."""


### PR DESCRIPTION
## Summary
- handle standalone execution of `analysis.mode_detector`
- add missing init for `piphawk_ai.policy`
- add missing init for `piphawk_ai.risk`

## Testing
- `ruff check analysis/mode_detector.py piphawk_ai/risk/__init__.py piphawk_ai/policy/__init__.py`
- `mypy analysis/mode_detector.py piphawk_ai/risk/__init__.py piphawk_ai/policy/__init__.py`
- `pytest tests/test_mode_detector_cfg.py tests/test_portfolio_risk_manager.py -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852a43cd38c8333b824c01bd54b442a