### PR TITLE
fix: apply market filter to trend signal

### DIFF
--- a/signals/trend_signal.py
+++ b/signals/trend_signal.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 """トレンド戦略向けのシグナル."""
 
 from analysis.ai_strategy.gpt_predictor import GPTPredictor
+from filters.market_filters import is_tradeable
 
 _predictor = GPTPredictor()
 
 
-def recheck(features: dict) -> dict:
+def recheck(features: dict) -> dict | None:
     """プルバック中の再評価を行う."""
+    if not is_tradeable(
+        features.get("pair", ""),
+        features.get("timeframe", "M5"),
+        features.get("spread", 0.0),
+        features.get("atr"),
+    ):
+        return None
     features = dict(features)
     features["mode"] = "trend_pending"
     return _predictor.predict(features)

--- a/tests/test_basic_signals.py
+++ b/tests/test_basic_signals.py
@@ -19,6 +19,8 @@ def test_scalping_signal(monkeypatch):
 
 def test_trend_signal(monkeypatch):
     monkeypatch.setattr(trend_signal, "_predictor", DummyPredictor())
-    res = trend_signal.recheck({"mode": "trend"})
+    res = trend_signal.recheck(
+        {"pair": "USD_JPY", "spread": 0.0001, "atr": 0.03, "mode": "trend"}
+    )
     assert set(res.keys()) == {"prob_long", "prob_short", "prob_flat"}
 


### PR DESCRIPTION
## Summary
- check `market_filters.is_tradeable` before calling GPT for trend signals
- update basic signal tests

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest tests/test_basic_signals.py -q`
- `pytest -q` *(fails: ImportError and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853ca788c7083339c0dc35a96725771