### PR TITLE
fix: improve quick_tp plan parsing

### DIFF
--- a/backend/strategy/openai_micro_scalp.py
+++ b/backend/strategy/openai_micro_scalp.py
@@ -36,9 +36,10 @@ def get_plan(features: dict) -> dict:
         logger.warning("get_plan failed: %s", exc)
         return {"enter": False}
     plan, _ = parse_json_answer(raw)
-    if plan is None:
+    if not isinstance(plan, dict):
+        logger.warning("plan not dict: %s", plan)
         return {"enter": False}
-    return plan
+    return plan or {"enter": False}
 
 
 __all__ = ["get_plan", "MICRO_SCALP_MODEL", "load_prompt", "PROMPT_PATH"]

--- a/execution/quick_tp_mode.py
+++ b/execution/quick_tp_mode.py
@@ -67,6 +67,6 @@ def run_loop() -> None:
                     logger.info("Reattached TP for trade %s", trade_id)
             logger.info("Entered %s %s for 2 pips TP", side, instrument)
         except Exception as exc:  # pragma: no cover - network or API error
-            logger.warning("quick_tp iteration failed: %s", exc)
+            logger.warning("quick_tp iteration failed: %s", exc, exc_info=True)
         time.sleep(interval)
 


### PR DESCRIPTION
## Summary
- prevent invalid plan types in micro scalp
- show stacktrace when quick TP loop fails

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: ImportError, AttributeError, vcr errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853cb1c90048333bddbbd4441ca453c