### PR TITLE
feat: add force entry flag

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -264,8 +264,10 @@ def process_entry(
         )
 
     forced_entry = False
-    # AI判断後は必ず発注するよう強制する
-    force_entry_after_ai = True
+    # FORCE_ENTRY_AFTER_AI 環境変数でフィルタを無視するかを制御
+    force_entry_after_ai = (
+        env_loader.get_env("FORCE_ENTRY_AFTER_AI", "true").lower() == "true"
+    )
     use_dynamic_risk = (
         env_loader.get_env("FALLBACK_DYNAMIC_RISK", "false").lower() == "true"
     )

--- a/docs/quick_start_ja.md
+++ b/docs/quick_start_ja.md
@@ -59,3 +59,9 @@ fallback:
 `force_on_no_side` を `true` にすると AI が "no" と答えてもトレンド方向へエントリーを強制します。`default_sl_pips` と `default_tp_pips` は AI から数値が得られないときのデフォルト幅です。`dynamic_risk` が `true` の場合、指標を基に自動で SL/TP を計算します。これらは `FALLBACK_FORCE_ON_NO_SIDE` などの環境変数からも設定可能です。
 
 Atmosphere モジュールの概要は [atmosphere_module.md](atmosphere_module.md) を参照してください。
+
+## force_entry_after_ai の利用
+
+AI の判断を信頼して取引を必ず実行したい場合は `force_entry_after_ai` を `true`
+に設定します。後段のフィルタでキャンセルされずに注文が行われます。環境変数
+`FORCE_ENTRY_AFTER_AI` を利用しても同じ効果が得られます。


### PR DESCRIPTION
## Summary
- support `FORCE_ENTRY_AFTER_AI` environment variable in entry logic
- document how to enable `force_entry_after_ai` in Japanese quick start guide

## Testing
- `isort backend/strategy/entry_logic.py docs/quick_start_ja.md`
- `ruff check backend/strategy/entry_logic.py docs/quick_start_ja.md`
- `mypy backend/strategy/entry_logic.py`
- `pytest -k none -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6853ca90f71c8333859b1ba23822f6eb