### PR TITLE
fix scalp template placeholder

### DIFF
--- a/prompts/scalp_llm_prompt.txt
+++ b/prompts/scalp_llm_prompt.txt
@@ -3,4 +3,4 @@ Analyze the latest tick indicators and decide whether to open a short-term posit
 Order flow imbalance: {of_imbalance}
 Volume burst ratio: {vol_burst}
 Average spread (pips): {spd_avg}
-Respond only with JSON as {"enter":true|false,"side":"long|short","tp_pips":float,"sl_pips":float}.
+Respond only with JSON as {{"enter":true|false,"side":"long|short","tp_pips":float,"sl_pips":float}}.


### PR DESCRIPTION
## Summary
- escape braces in the micro-scalp LLM prompt

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError in many tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853cf55337483338f618c9f9396628c