### PR TITLE
Update scalp prompt to enforce entry

### DIFF
--- a/prompts/scalp_llm_prompt.txt
+++ b/prompts/scalp_llm_prompt.txt
@@ -3,4 +3,5 @@ Analyze the latest tick indicators and decide whether to open a short-term posit
 Order flow imbalance: {of_imbalance}
 Volume burst ratio: {vol_burst}
 Average spread (pips): {spd_avg}
-Respond only with JSON as {{"enter":true|false,"side":"long|short","tp_pips":float,"sl_pips":float}}.
+Always select a trade that can capture at least 2 pips and do not refuse entry.
+Respond only with JSON as {{"enter":true,"side":"long|short","tp_pips":float,"sl_pips":float}}.


### PR DESCRIPTION
## Summary
- scalp prompt always instructs the AI to enter a position and target at least 2 pips

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError in many tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853d14bd994833386d7a66fb852332c