### PR TITLE
feature/pre_ai_market_filter

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -2402,6 +2402,9 @@ class JobRunner:
                                     news_score=float(market_cond.get("news_score", 0.0)),
                                     oi_bias=float(market_cond.get("oi_bias", 0.0)),
                                 )
+                                spread = float(tick_data["prices"][0]["asks"][0]["price"]) - float(
+                                    tick_data["prices"][0]["bids"][0]["price"]
+                                )
                                 if self.use_vote_pipeline:
                                     log.info("Using vote pipeline for entry")
                                     res = vote_run_cycle(
@@ -2409,6 +2412,10 @@ class JobRunner:
                                         metrics,
                                         snapshot,
                                         self.plan_buffer,
+                                        pair=DEFAULT_PAIR,
+                                        timeframe="M5",
+                                        spread=spread,
+                                        atr=atr_val,
                                         force_enter=True,
                                     )
                                     if not res or not res.plan:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -55,7 +55,16 @@ def test_run_cycle(monkeypatch):
 
     metrics = MarketMetrics(adx_m5=30, ema_fast=1.1, ema_slow=1.0, bb_width_m5=0.1)
     snapshot = MarketSnapshot(atr=0.05, news_score=0.0, oi_bias=0.0)
-    result = run_cycle({}, metrics, snapshot, PlanBuffer())
+    result = run_cycle(
+        {},
+        metrics,
+        snapshot,
+        PlanBuffer(),
+        pair="USD_JPY",
+        timeframe="M5",
+        spread=0.01,
+        atr=0.05,
+    )
 
     assert isinstance(result, PipelineResult)
     assert result.passed is True
@@ -73,7 +82,15 @@ def test_run_cycle_filter_block(monkeypatch):
     )
     metrics = MarketMetrics(0, 0, 0, 0)
     snapshot = MarketSnapshot(0, 0, 0)
-    result = run_cycle({}, metrics, snapshot)
+    result = run_cycle(
+        {},
+        metrics,
+        snapshot,
+        pair="USD_JPY",
+        timeframe="M5",
+        spread=0.01,
+        atr=0.05,
+    )
     assert result.passed is False
     assert result.plan is None
 

--- a/tests/test_pipeline_mode_integration.py
+++ b/tests/test_pipeline_mode_integration.py
@@ -36,7 +36,16 @@ def test_run_cycle_returns_valid_mode(monkeypatch, mode_raw, conf_ok):
     metrics = MarketMetrics(adx_m5=30, ema_fast=1.1, ema_slow=1.0, bb_width_m5=0.1)
     snapshot = MarketSnapshot(atr=0.05, news_score=0.0, oi_bias=0.0)
 
-    result = run_cycle({}, metrics, snapshot, PlanBuffer())
+    result = run_cycle(
+        {},
+        metrics,
+        snapshot,
+        PlanBuffer(),
+        pair="USD_JPY",
+        timeframe="M5",
+        spread=0.01,
+        atr=0.05,
+    )
 
     assert isinstance(result, PipelineResult)
     assert result.mode in {"TREND", "BASE_SCALP", "REBOUND_SCALP"}


### PR DESCRIPTION
## Summary
- check market filter before AI entry logic
- supply new parameters to vote pipeline
- adapt pipeline-related tests

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest tests/test_pipeline.py tests/test_pipeline_mode_integration.py -q`
- `pytest -q` *(fails: module not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853d948c5008333ae1d79366be5cb29