### PR TITLE
fix logging context

### DIFF
--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -2262,7 +2262,10 @@ class JobRunner:
                             self.last_entry_context = self.current_context
                             self.last_entry_strategy = self.current_strategy_name
                         else:
-                            logger.info("Filter NG → AI entry decision skipped.")
+                            reason = filter_ctx.get("reason", "unknown")
+                            logger.info(
+                                f"Filter NG ({reason}) → AI entry decision skipped."
+                            )
                             self.last_position_review_ts = None
                     # (removed: periodic exit check block)
                 # Update OANDA trade history every second

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -50,7 +50,9 @@ def run_cycle(
 
     ok, _ = pre_check(indicators, price)
     if not ok:
-    # 取引不可ならAI呼び出しを行わず即終了する
+        # 取引不可ならAI呼び出しを行わず即終了する
+        return PipelineResult(None, mode="", regime="", passed=False)
+
     pair = pair or env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
     if atr is None:
         atr = snapshot.atr


### PR DESCRIPTION
## Summary
- show filter reason when AI entry is skipped
- ensure vote pipeline returns early on filter fail

## Testing
- `ruff check .`
- `mypy piphawk_ai/vote_arch/pipeline.py piphawk_ai/runner/core.py`
- `pytest -q` *(fails: 202 failed, 166 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6853e82cb9cc83338434ec9a6edc998f