### PR TITLE
fix: respect filter check in vote pipeline

### DIFF
--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -50,16 +50,15 @@ def run_cycle(
 
     ok, _ = pre_check(indicators, price)
     if not ok:
-    # 取引不可ならAI呼び出しを行わず即終了する
-    pair = pair or env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
-    if atr is None:
-        atr = snapshot.atr
-    if not is_tradeable(pair, timeframe, spread, atr):
-        return PipelineResult(None, mode="", regime="", passed=False)
+        # 取引不可ならAI呼び出しを行わず即終了する
+        pair = pair or env_loader.get_env("DEFAULT_PAIR", "USD_JPY")
+        if atr is None:
+            atr = snapshot.atr
+        if not is_tradeable(pair, timeframe, spread, atr):
+            return PipelineResult(None, mode="", regime="", passed=False)
 
-    if not pass_entry_filter(indicators, price):
-
-        return PipelineResult(None, mode="", regime="", passed=False)
+        if not pass_entry_filter(indicators, price):
+            return PipelineResult(None, mode="", regime="", passed=False)
 
     regime = rule_based_regime(metrics)
     air = air_index(snapshot)


### PR DESCRIPTION
## Summary
- ensure `run_cycle` exits early when pre-check fails to avoid unnecessary AI calls

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853e85f8374833381a7f34d24749d32