### PR TITLE
Remove ai_pattern from composite filter

### DIFF
--- a/config/filters.yaml
+++ b/config/filters.yaml
@@ -10,4 +10,3 @@ composite_filter:
   weights:
     rsi_edge: 1
     bb_break: 1
-    ai_pattern: 1

--- a/signals/composite_filter.py
+++ b/signals/composite_filter.py
@@ -91,12 +91,11 @@ class CompositeFilter:
 DEFAULT_FILTER = CompositeFilter()
 DEFAULT_FILTER.register("rsi_edge", rsi_edge)
 DEFAULT_FILTER.register("bb_break", bb_break)
-DEFAULT_FILTER.register("ai_pattern", ai_pattern)
+# ai_pattern はフィルター後に AI で評価するため除外する
 
 __all__ = [
     "CompositeFilter",
     "rsi_edge",
     "bb_break",
-    "ai_pattern",
     "DEFAULT_FILTER",
 ]

--- a/tests/test_composite_filter.py
+++ b/tests/test_composite_filter.py
@@ -1,25 +1,24 @@
 import pytest
 
-from signals.composite_filter import CompositeFilter, ai_pattern, bb_break, rsi_edge
+from signals.composite_filter import CompositeFilter, bb_break, rsi_edge
 
 CASES = [
-    ({"rsi": 25, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, True),
-    ({"rsi": 25, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, True),
-    ({"rsi": 50, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, True),
-    ({"rsi": 25, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, True),
-    ({"rsi": 25, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
-    ({"rsi": 50, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
-    ({"rsi": 50, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 1}, False),
-    ({"rsi": 80, "price": 102, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, True),
-    ({"rsi": 80, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
-    ({"rsi": 50, "price": 100, "bb_upper": 101, "bb_lower": 99, "ai_pattern": 0}, False),
+    ({"rsi": 25, "price": 102, "bb_upper": 101, "bb_lower": 99}, True),
+    ({"rsi": 25, "price": 100, "bb_upper": 101, "bb_lower": 99}, False),
+    ({"rsi": 50, "price": 102, "bb_upper": 101, "bb_lower": 99}, False),
+    ({"rsi": 25, "price": 102, "bb_upper": 101, "bb_lower": 99}, True),
+    ({"rsi": 25, "price": 100, "bb_upper": 101, "bb_lower": 99}, False),
+    ({"rsi": 50, "price": 102, "bb_upper": 101, "bb_lower": 99}, False),
+    ({"rsi": 50, "price": 100, "bb_upper": 101, "bb_lower": 99}, False),
+    ({"rsi": 80, "price": 102, "bb_upper": 101, "bb_lower": 99}, True),
+    ({"rsi": 80, "price": 100, "bb_upper": 101, "bb_lower": 99}, False),
+    ({"rsi": 50, "price": 100, "bb_upper": 101, "bb_lower": 99}, False),
 ]
 
 
 @pytest.mark.parametrize("ctx, expected", CASES)
 def test_composite_filter(ctx, expected):
-    flt = CompositeFilter(min_score=2, weights={"rsi_edge": 1, "bb_break": 1, "ai_pattern": 1})
+    flt = CompositeFilter(min_score=2, weights={"rsi_edge": 1, "bb_break": 1})
     flt.register("rsi_edge", rsi_edge)
     flt.register("bb_break", bb_break)
-    flt.register("ai_pattern", ai_pattern)
     assert flt.pass_(ctx) is expected


### PR DESCRIPTION
## Summary
- stop registering `ai_pattern` in composite filter
- adjust default filter weights config
- update composite filter tests

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError, AttributeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853ef496f208333856e2e388f54968f