### PR TITLE
fix: make entry filter optional via env

### DIFF
--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -423,8 +423,9 @@ def pass_entry_filter(
     global _last_overshoot_ts
     if context is None:
         context = {}
-    # フィルターを完全に無効化する
-    return True
+    # DISABLE_ENTRY_FILTER が true ならチェックをスキップ
+    if env_loader.get_env("DISABLE_ENTRY_FILTER", "false").lower() == "true":
+        return True
 
     # --- Time‑of‑day block (JST decimal hours) --------------------------
     quiet_start = float(

--- a/backend/tests/test_entry_filter_rsi.py
+++ b/backend/tests/test_entry_filter_rsi.py
@@ -179,6 +179,14 @@ class TestEntryFilterRSICross(unittest.TestCase):
         result = pass_entry_filter(ind, price=1.2, indicators_m1=m1, indicators_h1=None, context={})
         self.assertFalse(result)
 
+    def test_disable_entry_filter_env_skips_all_checks(self):
+        os.environ["DISABLE_ENTRY_FILTER"] = "true"
+        ind = self._base_indicators()
+        m1 = {"rsi": FakeSeries([31, 33])}
+        result = pass_entry_filter(ind, price=1.2, indicators_m1=m1, indicators_h1=None, context={})
+        self.assertTrue(result)
+        os.environ["DISABLE_ENTRY_FILTER"] = "false"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add DISABLE_ENTRY_FILTER check in entry filter
- test that DISABLE_ENTRY_FILTER overrides filter

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: ImportError and AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853f05c8b448333a10324a2cddaa89c