### PR TITLE
Simplify entry filter behavior

### DIFF
--- a/backend/tests/test_entry_filter_rsi.py
+++ b/backend/tests/test_entry_filter_rsi.py
@@ -40,6 +40,7 @@ class TestEntryFilterRSICross(unittest.TestCase):
         pandas_stub = types.ModuleType("pandas")
         pandas_stub.Series = FakeSeries
         add_module("pandas", pandas_stub)
+        add_module("numpy", types.ModuleType("numpy"))
         add_module("requests", types.ModuleType("requests"))
 
         stub_modules = [
@@ -111,7 +112,7 @@ class TestEntryFilterRSICross(unittest.TestCase):
         ind = self._base_indicators()
         m1 = {"rsi": FakeSeries([31, 33])}
         result = pass_entry_filter(ind, price=1.2, indicators_m1=m1, indicators_h1=None, context={})
-        self.assertFalse(result)
+        self.assertTrue(result)
 
     def test_pass_entry_filter_allows_with_cross_up(self):
         ind = self._base_indicators()
@@ -153,10 +154,8 @@ class TestEntryFilterRSICross(unittest.TestCase):
         ind["bb_lower"] = FakeSeries([1.0, 1.0])
         ind["rsi"] = FakeSeries([85, 85])
         m1 = {"rsi": FakeSeries([29, 35])}
-        with self.assertLogs(self.sf_logger, level="DEBUG") as cm:
-            result = pass_entry_filter(ind, price=1.02, indicators_m1=m1, indicators_h1=None, context={})
-        self.assertFalse(result)
-        self.assertTrue(any("Bollinger band width" in m for m in cm.output))
+        result = pass_entry_filter(ind, price=1.02, indicators_m1=m1, indicators_h1=None, context={})
+        self.assertTrue(result)
 
     def test_rsi_atr_block_logs(self):
         ind = self._base_indicators()
@@ -164,12 +163,8 @@ class TestEntryFilterRSICross(unittest.TestCase):
         ind["atr"] = FakeSeries([0.05, 0.05])
         ind["ema_fast"] = FakeSeries([1, 1])
         ind["ema_slow"] = FakeSeries([1, 1])
-        with self.assertLogs(self.sf_logger, level="DEBUG") as cm:
-            result = pass_entry_filter(ind, price=1.2, indicators_m1={"rsi": FakeSeries([29, 35])}, indicators_h1=None, context={})
-        self.assertFalse(result)
-        msg = " ".join(cm.output)
-        self.assertIn("ATR", msg)
-        self.assertIn("RSI", msg)
+        result = pass_entry_filter(ind, price=1.2, indicators_m1={"rsi": FakeSeries([29, 35])}, indicators_h1=None, context={})
+        self.assertTrue(result)
 
     def test_ema_convergence_blocks_entry(self):
         ind = self._base_indicators()
@@ -177,7 +172,7 @@ class TestEntryFilterRSICross(unittest.TestCase):
         ind["ema_slow"] = FakeSeries([0.9, 1.0, 1.05])
         m1 = {"rsi": FakeSeries([29, 35])}
         result = pass_entry_filter(ind, price=1.2, indicators_m1=m1, indicators_h1=None, context={})
-        self.assertFalse(result)
+        self.assertTrue(result)
 
     def test_disable_entry_filter_env_skips_all_checks(self):
         os.environ["DISABLE_ENTRY_FILTER"] = "true"

--- a/backend/tests/test_rapid_reversal_block.py
+++ b/backend/tests/test_rapid_reversal_block.py
@@ -33,6 +33,7 @@ class TestRapidReversalBlock(unittest.TestCase):
         pandas_stub = types.ModuleType("pandas")
         pandas_stub.Series = FakeSeries
         add("pandas", pandas_stub)
+        add("numpy", types.ModuleType("numpy"))
         add("requests", types.ModuleType("requests"))
 
         stub_names = [
@@ -105,7 +106,7 @@ class TestRapidReversalBlock(unittest.TestCase):
             indicators_h1=None,
             context={},
         )
-        self.assertFalse(res)
+        self.assertTrue(res)
 
 
 if __name__ == "__main__":

--- a/tests/test_overshoot_dynamic.py
+++ b/tests/test_overshoot_dynamic.py
@@ -1,6 +1,14 @@
 import importlib
+import sys
+import types
 
-import pandas as pd
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas may be missing
+    stub = types.ModuleType("pandas")
+    stub.Series = list
+    sys.modules["pandas"] = stub
+    pd = stub
 
 
 def test_dynamic_overshoot(monkeypatch):
@@ -12,6 +20,8 @@ def test_dynamic_overshoot(monkeypatch):
     monkeypatch.setenv("BAND_WIDTH_THRESH_PIPS", "100")
     monkeypatch.setenv("PIP_SIZE", "0.01")
     monkeypatch.setenv("HIGHER_TF_ENABLED", "false")
+    sys.modules.setdefault("requests", types.ModuleType("requests"))
+    sys.modules.setdefault("numpy", types.ModuleType("numpy"))
     import backend.strategy.signal_filter as sf
 
     importlib.reload(sf)

--- a/tests/test_overshoot_window.py
+++ b/tests/test_overshoot_window.py
@@ -1,6 +1,14 @@
 import importlib
+import sys
+import types
 
-import pandas as pd
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas may be missing
+    stub = types.ModuleType("pandas")
+    stub.Series = list
+    sys.modules["pandas"] = stub
+    pd = stub
 
 
 def _base_indicators():
@@ -28,6 +36,8 @@ def test_overshoot_window(monkeypatch):
     monkeypatch.setenv("PIP_SIZE", "1.0")
     monkeypatch.setenv("BAND_WIDTH_THRESH_PIPS", "0")
     monkeypatch.setenv("HIGHER_TF_ENABLED", "false")
+    sys.modules.setdefault("requests", types.ModuleType("requests"))
+    sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 
     import backend.strategy.signal_filter as sf
 


### PR DESCRIPTION
## Summary
- simplify entry filter to pass except for quiet hours and market closed
- adjust tests for new always-pass behavior
- stub pandas requests and numpy in overshoot tests

## Testing
- `ruff check backend/strategy/signal_filter.py backend/tests/test_entry_filter_rsi.py backend/tests/test_rapid_reversal_block.py tests/test_overshoot_dynamic.py tests/test_overshoot_window.py`
- `mypy backend/strategy/signal_filter.py backend/tests/test_entry_filter_rsi.py backend/tests/test_rapid_reversal_block.py tests/test_overshoot_dynamic.py tests/test_overshoot_window.py`
- `pytest backend/tests/test_entry_filter_rsi.py backend/tests/test_rapid_reversal_block.py tests/test_overshoot_dynamic.py tests/test_overshoot_window.py -q` *(fails: module 'pandas' has no attribute 'Series')*


------
https://chatgpt.com/codex/tasks/task_e_6853f2b676b48333848dc48d086b9e7d