### PR TITLE
fix: enforce entry after filter

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1354,6 +1354,9 @@ def get_trade_plan(
         why = plan.get("why") or plan.get("entry", {}).get("why")
         if isinstance(why, str) and why:
             plan["reason"] = why
+        plan["entry"]["side"] = (
+            market_cond.get("trend_direction") if market_cond else "long"
+        )
 
     entry_conf = plan.get("entry_confidence")
     try:

--- a/prompts/trade_plan_instruction.txt
+++ b/prompts/trade_plan_instruction.txt
@@ -2,6 +2,8 @@
 Use ADX, EMA slope and Bollinger Band width to judge whether a trend-follow or scalp approach is more suitable. If the metrics are mixed, favor quick scalp trades.
 {RANGE_ENTRY_NOTE}
 
+Always return an entry with side "long" or "short". Never output "no".
+
 🚫【Counter-trend Trade Prohibition】
 Under clearly identified TREND conditions, avoid counter-trend trades and never rely solely on RSI extremes. Treat pullbacks as trend continuation. However, if a strong reversal pattern such as a double top/bottom or head-and-shoulders is detected and ADX is turning down, a small counter-trend position is acceptable.
 


### PR DESCRIPTION
## Summary
- ensure trade plan always returns a side when GPT says "no"
- update prompt to disallow "no" entry

## Testing
- `isort backend/strategy/openai_analysis.py`
- `ruff check backend/strategy/openai_analysis.py`
- `mypy backend/strategy/openai_analysis.py`
- `pip install -r requirements-test.txt`
- `pytest` *(fails: 203 failed, 166 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6853f4d7e5088333af17c7a9e276b504