### PR TITLE
feat: add scalp regime pipeline

### DIFF
--- a/ai/scalp_trend_classifier.py
+++ b/ai/scalp_trend_classifier.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""市場レジームをスキャルかトレンドに分類するクラス."""
+
+from typing import Dict
+
+
+class MarketRegimeClassifier:
+    """シンプルな指標ロジックによるレジーム判定クラス."""
+
+    def __init__(self, scalp_atr_min: float = 0.05, trend_atr_min: float = 0.2) -> None:
+        self.scalp_atr_min = scalp_atr_min
+        self.trend_atr_min = trend_atr_min
+
+    def classify(self, indicators: Dict[str, float]) -> str:
+        """ATR、ADX、MA角度などからレジームを返す."""
+        atr = indicators.get("atr", 0.0)
+        adx = indicators.get("adx", 0.0)
+        ma1 = indicators.get("ma_angle_m1", 0.0)
+        ma5 = indicators.get("ma_angle_m5", 0.0)
+        bb_ratio = indicators.get("bb_atr_ratio", 0.0)
+        scalp_score = 0
+        if self.scalp_atr_min <= atr < self.trend_atr_min:
+            scalp_score += 1
+        if abs(ma1) <= 3 and abs(ma5) <= 3:
+            scalp_score += 1
+        if adx < 18:
+            scalp_score += 1
+        if atr and bb_ratio < 1.5:
+            scalp_score += 1
+        return "scalp" if scalp_score >= 2 else "trend"

--- a/ai/tp_sl_calculator.py
+++ b/ai/tp_sl_calculator.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+"""ATR を元に TP/SL を決定するヘルパー."""
+
+
+def calc_tp_sl(regime: str, atr: float) -> tuple[int, int]:
+    """レジーム別の TP/SL 値を返す."""
+    if regime == "scalp":
+        tp = int(max(3, min(12, 0.5 * atr)))
+        sl = int(max(6, 1.0 * atr))
+    else:
+        tp = int(max(15, min(100, 2.0 * atr)))
+        sl = int(max(20, 1.5 * atr))
+    return tp, sl

--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -102,6 +102,12 @@ class OrderManager:
             **kwargs,
         )
 
+    def fallback_tp_sl(self, atr_pips: float) -> tuple[int, int]:
+        """ATR からフォールバック TP/SL を計算する."""
+        tp = max(3, int(atr_pips * 0.6))
+        sl = max(6, int(tp * 1.5))
+        return tp, sl
+
     # ------------------------------------------------------------------
     # LIMIT order helpers
     # ------------------------------------------------------------------
@@ -462,6 +468,7 @@ class OrderManager:
         force_limit_only: bool = False,
         *,
         with_oco: bool = True,
+        forced: bool | None = None,
     ):
         min_lot = float(env_loader.get_env("MIN_TRADE_LOT", "0.01"))
         max_lot = float(env_loader.get_env("MAX_TRADE_LOT", "0.1"))
@@ -644,6 +651,8 @@ class OrderManager:
             tp_pips=tp_pips,
             sl_pips=sl_pips,
             rrr=rrr,
+            regime=strategy_params.get("regime"),
+            forced=forced,
             is_manual=False,
         )
         info(
@@ -968,6 +977,8 @@ class OrderManager:
             units=0,
             ai_reason="SL dynamically updated",
             ai_response=json.dumps(result),
+            regime=None,
+            forced=False,
             is_manual=False,
         )
         logger.debug(f"SL update response: {result}")

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -1180,6 +1180,8 @@ def process_entry(
             ai_reason=ai_raw,
             ai_response=ai_raw,
             entry_regime=entry_type,
+            regime=strategy_params.get("regime"),
+            forced=forced_entry,
             tp_pips=tp_pips,
             sl_pips=sl_pips,
             rrr=rrr,

--- a/filters/session_filter.py
+++ b/filters/session_filter.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""セッション判定と超低ボラチェック用フィルター."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from backend.utils import env_loader
+
+
+def is_quiet_hours(now: datetime | None = None) -> bool:
+    """JST 03-06時を静寂時間帯として判定する."""
+    jst = (now or datetime.utcnow()).astimezone(timezone(timedelta(hours=9)))
+    return 3 <= jst.hour < 6
+
+
+def apply_filters(atr: float, bb_width_pct: float, *, tradeable: bool = True) -> tuple[bool, dict[str, Any] | None, str | None]:
+    """禁止3条件を評価し、regime_hint を返す."""
+    if is_quiet_hours():
+        return False, None, "session"
+    if not tradeable:
+        return False, None, "market_closed"
+    scalp_min = float(env_loader.get_env("SCALP_ATR_MIN", "0.05"))
+    trend_min = float(env_loader.get_env("TREND_ATR_MIN", "0.2"))
+    if atr < scalp_min and bb_width_pct < 0.05:
+        return False, None, "ultra_low_vol"
+    ctx = {"regime_hint": "scalp" if atr < trend_min else "trend"}
+    return True, ctx, None

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -31,8 +31,10 @@ CREATE TABLE IF NOT EXISTS trades (
     ai_reason TEXT,
     ai_response TEXT,
     entry_regime TEXT,
+    regime TEXT,
     exit_reason TEXT,
     is_manual INTEGER,
+    forced INTEGER,
     score_version INTEGER DEFAULT 1
 );
 CREATE TABLE IF NOT EXISTS ai_decisions (


### PR DESCRIPTION
## Summary
- add session filter and regime classifier
- compute auto TP/SL based on ATR
- log forced entries and regime in DB

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: 60 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6853f914e8d083339c541dc56a732ae9