### PR TITLE
fix: disable entry filters

### DIFF
--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -102,7 +102,6 @@ except Exception:  # pragma: no cover - test stubs may remove module
 
 
 try:
-    from backend.filters import pre_check
     from backend.strategy.signal_filter import (
         consecutive_higher_highs,
         consecutive_lower_lows,
@@ -112,7 +111,6 @@ try:
         pass_entry_filter,
     )
 except Exception:  # pragma: no cover - test stubs may lack filter_pre_ai
-    from backend.filters import pre_check
     from backend.strategy.signal_filter import pass_entry_filter
 
     def filter_pre_ai(*_args, **_kwargs):
@@ -1892,15 +1890,8 @@ class JobRunner:
                             tick_data["prices"][0]["bids"][0]["price"]
                         )
                         filter_ctx = {}
-                        filter_ok, _ = pre_check(
-                            indicators,
-                            current_price,
-                            indicators_m1=self.indicators_M1,
-                            indicators_m15=self.indicators_M15,
-                            indicators_h1=self.indicators_H1,
-                            mode=self.trade_mode,
-                            context=filter_ctx,
-                        )
+                        # Skip all entry filters
+                        filter_ok = True
                         force_ai = (
                             env_loader.get_env("FORCE_ENTRY_AFTER_AI", "true").lower() == "true"
                         )

--- a/piphawk_ai/runner/entry.py
+++ b/piphawk_ai/runner/entry.py
@@ -7,7 +7,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from backend.filters import pre_check
 from backend.strategy.openai_analysis import get_market_condition, get_trade_plan, should_convert_limit_to_market
 from backend.strategy.risk_manager import calc_lot_size
 from backend.utils import env_loader
@@ -32,20 +31,7 @@ def manage_pending_limits(
                 runner._pending_limits.pop(key, None)
         return
 
-    # Run entry filter before performing any AI-intensive checks
-    current_price = float(tick_data["prices"][0]["bids"][0]["price"])
-    filter_ok, _ = pre_check(
-        indicators,
-        current_price,
-        indicators_m1=runner.indicators_M1,
-        indicators_m15=runner.indicators_M15,
-        indicators_h1=runner.indicators_H1,
-        mode=runner.trade_mode,
-        context={},
-    )
-    if not filter_ok:
-        runner.logger.info("Filter NG -> skipping pending limit AI checks.")
-        return
+    # Skip entry filter when managing pending LIMIT orders
 
     local_info = None
     for key, info in runner._pending_limits.items():


### PR DESCRIPTION
## Summary
- skip entry filters in core job loop
- remove filter checks when managing pending LIMIT orders

## Testing
- `ruff check piphawk_ai/runner/core.py piphawk_ai/runner/entry.py`
- `mypy piphawk_ai/runner/core.py piphawk_ai/runner/entry.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853fd843bf48333bf39464f73a9b173