### PR TITLE
feature/enable filters in tech pipeline

### DIFF
--- a/piphawk_ai/tech_arch/pipeline.py
+++ b/piphawk_ai/tech_arch/pipeline.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """M5 technical entry pipeline orchestrator."""
 
+import logging
+
 from backend.orders import get_order_manager
 from backend.utils import env_loader
 from monitoring import metrics_publisher
@@ -35,7 +37,11 @@ def run_cycle() -> dict | None:
         return None
 
     if ENTRY_USE_AI:
-        decision = call_llm(mode, signal, indicators)
+        try:
+            decision = call_llm(mode, signal, indicators)
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logging.getLogger(__name__).warning("call_llm failed: %s", exc)
+            return None
     else:
         decision = {"tp_mult": 2.0, "sl_mult": 1.0}
 

--- a/piphawk_ai/tech_arch/prefilters.py
+++ b/piphawk_ai/tech_arch/prefilters.py
@@ -2,13 +2,40 @@ from __future__ import annotations
 
 """Prefilter utilities for the technical pipeline."""
 
+from datetime import datetime
+
+from backend.filters import session_ok, spread_ok, volatility_ok
 from backend.utils import env_loader
 
 
+def _last(series):
+    if series is None:
+        return None
+    try:
+        if hasattr(series, "iloc"):
+            return float(series.iloc[-1]) if len(series) else None
+        if isinstance(series, (list, tuple)):
+            return float(series[-1]) if series else None
+        return float(series)
+    except Exception:
+        return None
+
+
+def _pip_size() -> float:
+    return 0.01 if env_loader.get_env("DEFAULT_PAIR", "USD_JPY").endswith("_JPY") else 0.0001
+
+
 def generic_prefilters(indicators: dict, spread: float) -> bool:
-    """Return True when generic conditions pass."""
-    # フィルター無効化のため常に True
-    return True
+    """Return True when basic session/volatility/spread checks pass."""
+
+    atr = _last(indicators.get("atr"))
+    pip_size = _pip_size()
+    ctx = {
+        "atr": atr,
+        "spread": spread / pip_size if spread is not None else None,
+        "hour": datetime.utcnow().hour,
+    }
+    return volatility_ok(ctx) and spread_ok(ctx) and session_ok(ctx)
 
 
 def trend_filters(indicators: dict) -> bool:

--- a/piphawk_ai/tech_arch/risk_filters.py
+++ b/piphawk_ai/tech_arch/risk_filters.py
@@ -84,8 +84,13 @@ def vol_spike_guard(indicators: dict) -> bool:
 
 
 def check_risk(ctx, indicators: dict) -> bool:
-    # すべてのリスクフィルターを無効化して常に True を返す
-    return True
+    """Evaluate core risk filters and return ``True`` when all pass."""
+
+    return (
+        margin_filter(getattr(ctx, "account", None))
+        and spread_filter(indicators, getattr(ctx, "spread", 0.0))
+        and vol_spike_guard(indicators)
+    )
 
 
 __all__ = ["check_risk", "spread_filter", "margin_filter", "duplicate_guard", "vol_spike_guard"]


### PR DESCRIPTION
## Summary
- check session, volatility and spread in the technical pipeline
- activate risk checks and handle AI failure

## Testing
- `ruff check piphawk_ai/tech_arch/pipeline.py piphawk_ai/tech_arch/prefilters.py piphawk_ai/tech_arch/risk_filters.py`
- `mypy piphawk_ai/tech_arch/pipeline.py piphawk_ai/tech_arch/prefilters.py piphawk_ai/tech_arch/risk_filters.py`
- `pytest -q tests/test_tech_arch_flow.py tests/test_tech_arch_no_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_6853fc6f158083339d521f6ae4e15d7c