### PR TITLE
fix: evaluate market condition after filters

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1494,15 +1494,6 @@ class JobRunner:
                             continue
 
 
-                    # 市場コンディションを一度だけ評価し再利用する
-                    market_cond = self._evaluate_market_condition(
-                        candles_m1,
-                        candles_m5,
-                        candles_d1,
-                        higher_tf,
-                    )
-                    log.debug(f"Market condition: {market_cond}")
-
                     pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
                     try:
                         atr_val = (
@@ -1533,6 +1524,13 @@ class JobRunner:
                         time.sleep(self.interval_seconds)
                         timer.stop()
                         continue
+                    market_cond = self._evaluate_market_condition(
+                        candles_m1,
+                        candles_m5,
+                        candles_d1,
+                        higher_tf,
+                    )
+                    log.debug(f"Market condition: {market_cond}")
                     regime_hint = (filter_ctx or {}).get("regime_hint")
 
                     # ポジション確認


### PR DESCRIPTION
## Summary
- フィルター適用後に `get_market_condition()` を呼び出すよう `JobRunner` を修正

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError)*


------
https://chatgpt.com/codex/tasks/task_e_68540058fc3c8333bf1573eecd548e96