### PR TITLE
docs: remove pre-ai low vol step

### DIFF
--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -1516,30 +1516,6 @@ def get_trade_plan(
     if plan.get("entry", {}).get("side") == "no":
         plan["risk"] = {}
 
-    # Over-cool filter using Bollinger Band width and ATR
-    try:
-        bb_upper = ind_m5.get("bb_upper")
-        bb_lower = ind_m5.get("bb_lower")
-        atr_series = ind_m5.get("atr")
-        if hasattr(bb_upper, "iloc"):
-            bb_upper = bb_upper.iloc[-1]
-        else:
-            bb_upper = bb_upper[-1]
-        if hasattr(bb_lower, "iloc"):
-            bb_lower = bb_lower.iloc[-1]
-        else:
-            bb_lower = bb_lower[-1]
-        if hasattr(atr_series, "iloc"):
-            atr_val = float(atr_series.iloc[-1])
-        else:
-            atr_val = float(atr_series[-1])
-        bw = float(bb_upper) - float(bb_lower)
-        if (bw / atr_val) < COOL_BBWIDTH_PCT or atr_val < COOL_ATR_PCT:
-            plan["entry"]["side"] = "no"
-            plan.setdefault("reason", "OVERCOOL")
-    except (TypeError, ValueError, IndexError, ZeroDivisionError):
-        pass
-
     # ADX no-trade zone enforcement (skipped when ENABLE_RANGE_ENTRY is true)
     try:
         adx_series = ind_m5.get("adx")

--- a/docs/low_vol_entry.md
+++ b/docs/low_vol_entry.md
@@ -6,7 +6,7 @@
 - 5分足ボリンジャーバンド幅 ÷ ATR が `COOL_BBWIDTH_PCT` 未満
 - ATR 自体が `COOL_ATR_PCT` を下回る
 
-どちらかを満たすと AI には `side: "no"` を返させ、エントリーしません。
+どちらかを満たすとエントリーフィルターでブロックします。
 各値は環境変数 `COOL_BBWIDTH_PCT` と `COOL_ATR_PCT` で調整できます。
 0 を指定すると判定を無効化できます。デフォルトではスキャルプ用に
 `COOL_ATR_PCT=0.06`, `COOL_BBWIDTH_PCT=0.08` が設定されています。


### PR DESCRIPTION
## Summary
- remove low volatility AI check so entry filters handle it instead
- update documentation accordingly

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError: module backend.strategy.pattern_scanner not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_685406ba80d48333a5f3519b9a4f31ff