### PR TITLE
fix: remove flat mode

### DIFF
--- a/analysis/mode_hybrid.py
+++ b/analysis/mode_hybrid.py
@@ -103,7 +103,7 @@ def detect_mode(ctx: MarketContext) -> str:
     if adx is not None and adx >= adx_min / 2:
         return "scalp_momentum"
 
-    return "flat"
+    return "scalp_momentum"
 
 
 def _norm(value: float, scale: float) -> float:

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -212,7 +212,7 @@ try:
 except Exception:  # pragma: no cover - test stubs may remove module
 
     def decide_trade_mode_detail(*_a, **_k):
-        return "flat", 0.0, []
+        return "scalp_momentum", 0.0, []
 
 
 from backend.strategy.risk_manager import calc_lot_size
@@ -2427,7 +2427,6 @@ class JobRunner:
                                         timeframe="M5",
                                         spread=spread,
                                         atr=atr_val,
-                                        force_enter=True,
                                     )
                                     if not res or not res.plan:
                                         log.info("Pipeline declined entry → skipping")

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -159,10 +159,10 @@ try:
 except Exception:  # pragma: no cover - test stubs may remove module
 
     def decide_trade_mode(*_a, **_k):
-        return "flat"
+        return "scalp_momentum"
 
     def decide_trade_mode_detail(*_a, **_k):
-        return "flat", 0.0, []
+        return "scalp_momentum", 0.0, []
 
 
 from backend.logs.trade_logger import ExitReason, log_trade

--- a/signals/composite_mode.py
+++ b/signals/composite_mode.py
@@ -131,15 +131,13 @@ def decide_trade_mode_matrix(
 ) -> str:
     """Return mode based on volatility and trend strength."""
     if atr_base <= 0:
-        return "flat"
+        return "scalp_momentum"
     atr_ratio = atr / atr_base
-    if atr_ratio >= atr_high_thr and adx <= adx_flat_thr:
-        return "scalp_range"
     if atr_ratio >= atr_high_thr and adx >= adx_trend_thr:
         return "scalp_momentum"
     if atr_ratio <= atr_low_thr and adx >= adx_trend_thr:
         return "trend_follow"
-    return "flat"
+    return "scalp_momentum"
 
 
 def _quantile(data: Iterable, q: float) -> float | None:
@@ -323,42 +321,9 @@ def decide_trade_mode_detail(
     elif score >= TREND_ENTER_SCORE:
         mode = "trend_follow"
     elif score >= SCALP_ENTER_SCORE:
-        if (
-            _LAST_MODE is None
-            and atr_val is not None
-            and atr_val < HIGH_ATR_PIPS / 100
-            and adx_val is not None
-            and adx_val < MODE_ADX_MIN
-        ):
-            mode = "flat"
-        else:
-            mode = "scalp_momentum"
+        mode = "scalp_momentum"
     else:
-        mode = _LAST_MODE or "flat"
-
-    if mode == "flat":
-        try:
-            rsi_val = _last(m5.get("rsi"))
-            bb_u = _last(m5.get("bb_upper"))
-            bb_l = _last(m5.get("bb_lower"))
-            price = None
-            if candles:
-                c = candles[-1]
-                price = float(c.get("mid", {}).get("c", c.get("c")))
-            if (
-                adx_val is not None
-                and adx_val <= SCALP_REV_ADX_MAX
-                and rsi_val is not None
-                and bb_u is not None
-                and bb_l is not None
-                and price is not None
-            ):
-                if price > bb_u and rsi_val >= SCALP_REV_RSI_HIGH:
-                    mode = "scalp_reversion"
-                elif price < bb_l and rsi_val <= SCALP_REV_RSI_LOW:
-                    mode = "scalp_reversion"
-        except Exception:
-            pass
+        mode = _LAST_MODE or "scalp_momentum"
 
     if _RANGE_ADX_COUNTER >= RANGE_ADX_COUNT:
         mode = "scalp_momentum"

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -115,7 +115,7 @@ def test_decide_trade_mode_scalp(monkeypatch):
         "volume": [20, 30, 40, 50, 60],
     }
     ctx = md.MarketContext(price=0.0, indicators=inds)
-    assert md.detect_mode(ctx) == "flat"
+    assert md.detect_mode(ctx) == "scalp_momentum"
 
 
 def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
@@ -134,10 +134,10 @@ def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
     }
     ctx = md.MarketContext(price=0.0, indicators=inds)
     assert md.detect_mode(ctx) == "scalp_momentum"
-    assert cm.decide_trade_mode_matrix(1.5, 1.0, 10) == "scalp_range"
+    assert cm.decide_trade_mode_matrix(1.5, 1.0, 10) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(1.5, 1.0, 30) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(0.7, 1.0, 30) == "trend_follow"
-    assert cm.decide_trade_mode_matrix(1.0, 1.0, 20) == "flat"
+    assert cm.decide_trade_mode_matrix(1.0, 1.0, 20) == "scalp_momentum"
 
 
 def test_detect_mode_direct(monkeypatch):

--- a/tests/test_composite_scoring.py
+++ b/tests/test_composite_scoring.py
@@ -58,7 +58,7 @@ def test_mode_scores_scalp(monkeypatch):
         "volume": [60, 60, 60, 60, 60],
     }
     mode, score, _ = cm.decide_trade_mode_detail(inds)
-    assert mode == "flat"
+    assert mode == "scalp_momentum"
     assert score == 0.0
 
 


### PR DESCRIPTION
## Summary
- adjust decide_trade_mode_matrix to never return flat
- simplify trade mode decision tail logic
- return scalp momentum by default in detect_mode_simple
- update stubs and scheduler pipeline call
- adjust tests for new defaults

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ImportError and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6854083e70148333937309ce1668abf8