### PR TITLE
refactor: remove flat mode

### DIFF
--- a/analysis/mode_hybrid.py
+++ b/analysis/mode_hybrid.py
@@ -103,7 +103,7 @@ def detect_mode(ctx: MarketContext) -> str:
     if adx is not None and adx >= adx_min / 2:
         return "scalp_momentum"
 
-    return "flat"
+    return "scalp_momentum"
 
 
 def _norm(value: float, scale: float) -> float:

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -212,7 +212,7 @@ try:
 except Exception:  # pragma: no cover - test stubs may remove module
 
     def decide_trade_mode_detail(*_a, **_k):
-        return "flat", 0.0, []
+        return "scalp_momentum", 0.0, []
 
 
 from backend.strategy.risk_manager import calc_lot_size
@@ -2427,7 +2427,6 @@ class JobRunner:
                                         timeframe="M5",
                                         spread=spread,
                                         atr=atr_val,
-                                        force_enter=True,
                                     )
                                     if not res or not res.plan:
                                         log.info("Pipeline declined entry → skipping")

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -159,10 +159,10 @@ try:
 except Exception:  # pragma: no cover - test stubs may remove module
 
     def decide_trade_mode(*_a, **_k):
-        return "flat"
+        return "scalp_momentum"
 
     def decide_trade_mode_detail(*_a, **_k):
-        return "flat", 0.0, []
+        return "scalp_momentum", 0.0, []
 
 
 from backend.logs.trade_logger import ExitReason, log_trade
@@ -555,11 +555,9 @@ class JobRunner:
             config_file = "config/scalp_params.yml"
         elif mode in ("trend", "trend_follow"):
             config_file = "config/trend.yml"
-        elif mode == "flat":
-            config_file = "config/strategy.yml"
         else:
-            # 想定外のモードは戦略デフォルト
-            config_file = "config/strategy.yml"
+            # 想定外のモードはスキャル設定
+            config_file = "config/scalp_params.yml"
         # デバッグ: マッピング結果を記録
         logger.debug("[DEBUG] mapped mode %r → config_file=%s", mode, config_file)
         try:

--- a/tests/test_adx_mode.py
+++ b/tests/test_adx_mode.py
@@ -115,7 +115,7 @@ def test_decide_trade_mode_scalp(monkeypatch):
         "volume": [20, 30, 40, 50, 60],
     }
     ctx = md.MarketContext(price=0.0, indicators=inds)
-    assert md.detect_mode(ctx) == "flat"
+    assert md.detect_mode(ctx) == "scalp_momentum"
 
 
 def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
@@ -134,10 +134,10 @@ def test_decide_trade_mode_high_atr_low_adx(monkeypatch):
     }
     ctx = md.MarketContext(price=0.0, indicators=inds)
     assert md.detect_mode(ctx) == "scalp_momentum"
-    assert cm.decide_trade_mode_matrix(1.5, 1.0, 10) == "scalp_range"
+    assert cm.decide_trade_mode_matrix(1.5, 1.0, 10) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(1.5, 1.0, 30) == "scalp_momentum"
     assert cm.decide_trade_mode_matrix(0.7, 1.0, 30) == "trend_follow"
-    assert cm.decide_trade_mode_matrix(1.0, 1.0, 20) == "flat"
+    assert cm.decide_trade_mode_matrix(1.0, 1.0, 20) == "scalp_momentum"
 
 
 def test_detect_mode_direct(monkeypatch):

--- a/tests/test_composite_scoring.py
+++ b/tests/test_composite_scoring.py
@@ -58,7 +58,7 @@ def test_mode_scores_scalp(monkeypatch):
         "volume": [60, 60, 60, 60, 60],
     }
     mode, score, _ = cm.decide_trade_mode_detail(inds)
-    assert mode == "flat"
+    assert mode == "scalp_momentum"
     assert score == 0.0
 
 


### PR DESCRIPTION
## Summary
- remove flat branch in signal mode logic and default to scalp_momentum
- drop flat from mode hybrid detection
- simplify reload params to use scalp settings for unknown modes
- adjust scheduler vote entry and fallbacks
- update tests for new logic

## Testing
- `isort .`
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ImportError in backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_685408653ee483338da60276dce8cdb3