### PR TITLE
fix: enforce AI entry

### DIFF
--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -250,46 +250,11 @@ def consecutive_lower_highs(candles: list[dict], count: int = 3) -> bool:
 def filter_pre_ai(
     candles: list[dict], indicators: dict, market_cond: dict | None = None
 ) -> bool:
-    """Return True when the last candle is a large trend bar.
+    """AI前フィルターを無効化する。"""
 
-    The function checks the body length of the most recent candle and
-    compares it with the current ATR value. When the candle body exceeds
-    ``1.5 × ATR`` and its direction matches ``market_cond['trend_direction']``
-    we skip the AI entry decision.
-    """
-
-    try:
-        if not candles:
-            return False
-        last = candles[-1]
-        if "mid" in last:
-            o_val = float(last["mid"].get("o", 0))
-            c_val = float(last["mid"].get("c", 0))
-        else:
-            o_val = float(last.get("o", 0))
-            c_val = float(last.get("c", 0))
-        body_len = c_val - o_val
-
-        atr_series = indicators.get("atr")
-        if atr_series is None or len(atr_series) == 0:
-            return False
-        atr = (
-            float(atr_series.iloc[-1])
-            if hasattr(atr_series, "iloc")
-            else float(atr_series[-1])
-        )
-
-        follow_trend = None
-        if market_cond is not None:
-            follow_trend = market_cond.get("trend_direction")
-
-        side = "long" if body_len > 0 else "short"
-
-        skip_entry = abs(body_len) > 1.5 * atr and side == follow_trend
-        return bool(skip_entry)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug(f"filter_pre_ai failed: {exc}")
-        return False
+    # 以前は大陽線・大陰線でエントリーを抑制していたが、
+    # AI 利用時は必ずエントリーする方針とするため常に False を返す。
+    return False
 
 
 # ────────────────────────────────────────────────

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -1637,7 +1637,11 @@ class JobRunner:
                     elapsed_seconds = (
                         datetime.now() - self.last_ai_call
                     ).total_seconds()
-                    if (not due_for_review) and elapsed_seconds < self.ai_cooldown:
+                    if (
+                        has_position
+                        and (not due_for_review)
+                        and elapsed_seconds < self.ai_cooldown
+                    ):
                         logger.info(
                             f"AI cooldown active ({elapsed_seconds:.1f}s < {self.ai_cooldown}s). Skipping AI call."
                         )


### PR DESCRIPTION
## Summary
- disable `filter_pre_ai` so AI entry isn't skipped
- limit AI cooldown check to active positions only

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68540bd5c1408333b544fdb5ef43f155