### PR TITLE
fix: check current position before review

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1573,6 +1573,8 @@ class JobRunner:
                         timer.stop()
                         continue
 
+                    has_position = check_current_position(DEFAULT_PAIR)
+
                     due_for_review = False
                     elapsed_review = None
                     if has_position and self.review_enabled:


### PR DESCRIPTION
## Summary
- check current positions before running review logic in job loop

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError from many tests)*


------
https://chatgpt.com/codex/tasks/task_e_685412330b74833394adb659438b2b40