### PR TITLE
fix: ensure cooldown env defaults use settings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,8 +5,8 @@ OANDA_ACCOUNT_ID=
 ALLOW_NO_PULLBACK_WHEN_ADX=20
 BYPASS_PULLBACK_ADX_MIN=
 
-AI_COOLDOWN_SEC_OPEN=30  # ポジション保有時のAI待機時間
-AI_COOLDOWN_SEC_FLAT=15  # ノーポジション時のAI待機時間
+AI_COOLDOWN_SEC_OPEN=60  # ポジション保有時のAI待機時間
+AI_COOLDOWN_SEC_FLAT=60  # ノーポジション時のAI待機時間
 
 # GPT model settings
 AI_MODEL=gpt-3.5-turbo-0125          # 汎用モデル

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -139,7 +139,7 @@ def get_error_logs():
 # In-memory settings store
 current_settings = {
     "ai_cooldown_flat": int(env_loader.get_env("AI_COOLDOWN_SEC_FLAT", "60")),
-    "ai_cooldown_open": int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", "30")),
+    "ai_cooldown_open": int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", "60")),
     "review_sec": int(env_loader.get_env("POSITION_REVIEW_SEC", "60")),
 }
 

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -480,7 +480,7 @@ class JobRunner:
         # --- AI cooldown values ---------------------------------------
         #   * AI_COOLDOWN_SEC_OPEN : エントリー用クールダウン時間
         #   * AI_COOLDOWN_SEC_FLAT : エグジット用クールダウン時間
-        self.ai_cooldown_open = int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", "30"))
+        self.ai_cooldown_open = int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", "60"))
         self.ai_cooldown_flat = int(env_loader.get_env("AI_COOLDOWN_SEC_FLAT", "60"))
         # 現在のクールダウン（ループ毎に更新）
         self.ai_cooldown = self.ai_cooldown_open

--- a/backend/strategy/openai_analysis.py
+++ b/backend/strategy/openai_analysis.py
@@ -71,7 +71,7 @@ macro_analyzer = MacroAnalyzer()
 # Config – driven by environment variables
 # ----------------------------------------------------------------------
 AI_COOLDOWN_SEC_FLAT: int = int(env_loader.get_env("AI_COOLDOWN_SEC_FLAT", 60))
-AI_COOLDOWN_SEC_OPEN: int = int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", 30))
+AI_COOLDOWN_SEC_OPEN: int = int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", 60))
 # Regime‑classification specific cooldown (defaults to flat cooldown)
 AI_REGIME_COOLDOWN_SEC: int = int(env_loader.get_env("AI_REGIME_COOLDOWN_SEC", AI_COOLDOWN_SEC_FLAT))
 

--- a/docs/env_reference.md
+++ b/docs/env_reference.md
@@ -17,7 +17,7 @@
 | MIN_RRR | 0.9 | 最低リスクリワード比 | `MIN_RRR=1.2` |
 | ENFORCE_RRR | false | RRRを強制するか | `ENFORCE_RRR=true` |
 | AI_COOLDOWN_SEC_OPEN | 60 | ポジション保有時のAI待機秒 | `AI_COOLDOWN_SEC_OPEN=30` |
-| AI_COOLDOWN_SEC_FLAT | 15 | ノーポジ時のAI待機秒 | `AI_COOLDOWN_SEC_FLAT=30` |
+| AI_COOLDOWN_SEC_FLAT | 60 | ノーポジ時のAI待機秒 | `AI_COOLDOWN_SEC_FLAT=30` |
 | MIN_TRADE_LOT | 30.0 | 最小ロット数 | `MIN_TRADE_LOT=10` |
 | MAX_TRADE_LOT | 40.0 | 最大ロット数 | `MAX_TRADE_LOT=100` |
 | SCALE_LOT_SIZE | 0.5 | 追加エントリー時のロット | `SCALE_LOT_SIZE=0.3` |

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -60,7 +60,7 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
 
 ### AI_COOLDOWN_SEC_OPEN / AI_COOLDOWN_SEC_FLAT / AI_REGIME_COOLDOWN_SEC
 
- AI呼び出しの最小間隔（秒）を個別に設定する。OPENはポジション保有時、FLATはノーポジ時、REGIMEはトレンド判定用。デフォルトは OPEN=30、FLAT=15、REGIME=60。
+ AI呼び出しの最小間隔（秒）を個別に設定する。OPENはポジション保有時、FLATはノーポジ時、REGIMEはトレンド判定用。デフォルトは OPEN=60、FLAT=60、REGIME=60。
 
 ### フィルター設定（AI呼び出し制御用）
 

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -358,7 +358,7 @@ class JobRunner:
         # --- AI cooldown values ---------------------------------------
         #   * AI_COOLDOWN_SEC_OPEN : エントリー用クールダウン時間
         #   * AI_COOLDOWN_SEC_FLAT : エグジット用クールダウン時間
-        self.ai_cooldown_open = int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", "30"))
+        self.ai_cooldown_open = int(env_loader.get_env("AI_COOLDOWN_SEC_OPEN", "60"))
         self.ai_cooldown_flat = int(env_loader.get_env("AI_COOLDOWN_SEC_FLAT", "60"))
         # 現在のクールダウン（ループ毎に更新）
         self.ai_cooldown = self.ai_cooldown_open


### PR DESCRIPTION
## Summary
- update AI cooldown defaults to 60 seconds
- keep doc references in sync

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6854154e7dd08333af3fd738a813dbe1