### PR TITLE
Add trade side decision to CNN pattern filter

### DIFF
--- a/tests/test_ai_pattern_filter.py
+++ b/tests/test_ai_pattern_filter.py
@@ -6,7 +6,7 @@ from ai.cnn_pattern import infer
 pytest.importorskip("fastapi")
 pytest.skip("skip pattern filter on limited environment", allow_module_level=True)
 
-from signals.ai_pattern_filter import pass_pattern_filter
+from signals.ai_pattern_filter import decide_entry_side, pass_pattern_filter
 
 
 def _dummy_candles() -> list[dict]:
@@ -36,5 +36,24 @@ def test_pattern_filter_true(monkeypatch):
     ok, prob = pass_pattern_filter(_dummy_candles())
     assert ok
     assert prob > 0.65
+
+
+def test_decide_entry_side_long(monkeypatch):
+    def fake(img: np.ndarray) -> dict[str, float]:
+        return {"pattern": 0.8}
+
+    monkeypatch.setattr(infer, "predict", fake)
+    side, prob = decide_entry_side(_dummy_candles())
+    assert side == "long"
+    assert prob == 0.8
+
+
+def test_decide_entry_side_none(monkeypatch):
+    def fake(img: np.ndarray) -> dict[str, float]:
+        return {"pattern": 0.55}
+
+    monkeypatch.setattr(infer, "predict", fake)
+    side, prob = decide_entry_side(_dummy_candles())
+    assert side is None
 
 


### PR DESCRIPTION
## Summary
- extend `ai_pattern_filter` with `decide_entry_side` to choose `long` or `short`
- keep `pass_pattern_filter` for compatibility
- add unit tests for the new function

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort . --check --diff`
- `mypy .`
- `TRADE_START_H=0 TRADE_END_H=24 pytest tests/test_ai_pattern_filter.py tests/test_basic_signals.py::test_scalping_signal tests/test_basic_signals.py::test_trend_signal -q`

------
https://chatgpt.com/codex/tasks/task_e_685418e01dcc8333897a3ef722d84fb3