### PR TITLE
fix: remove duplicate definition

### DIFF
--- a/signals/ai_pattern_filter.py
+++ b/signals/ai_pattern_filter.py
@@ -82,14 +82,5 @@ def pass_pattern_filter(candles: Iterable[Mapping]) -> tuple[bool, float]:
 
     return True, prob
 
-    side = _decide_side(prob)
-    return side, prob
-
-
-def pass_pattern_filter(candles: Iterable[Mapping]) -> tuple[bool, float]:
-    """Return ``(True, prob)`` when CNN probability exceeds ``PROB_THRESHOLD``."""
-    side, prob = decide_entry_side(candles)
-    return side is not None, prob
-
 
 __all__ = ["decide_entry_side", "pass_pattern_filter"]


### PR DESCRIPTION
## Summary
- remove duplicate definition of `pass_pattern_filter`

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68541e35b61c83338917cd7aa3e8b35d