### PR TITLE
fix missing SafetyTrigger import

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -20,6 +20,8 @@ from backend.utils import env_loader, trade_age_seconds
 from backend.utils.openai_client import reset_call_counter, set_call_limit
 from backend.utils.restart_guard import can_restart
 from maintenance.disk_guard import maybe_cleanup
+from monitoring import metrics_publisher
+from monitoring.safety_trigger import SafetyTrigger
 
 try:
     from config import params_loader


### PR DESCRIPTION
## Summary
- fix SafetyTrigger NameError by importing SafetyTrigger and metrics_publisher in `job_runner`

## Testing
- `ruff check backend/scheduler/job_runner.py`
- `mypy backend/scheduler/job_runner.py`
- `pytest -q` *(fails: 60 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685422a5c04883338abd1dc178d4fb66