### PR TITLE
fix import cycle

### DIFF
--- a/analysis/detect_mode.py
+++ b/analysis/detect_mode.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Sequence
 
-from signals.composite_mode import decide_trade_mode_detail
-
 
 @dataclass
 class MarketContext:
@@ -32,6 +30,7 @@ def detect_mode(indicators: dict, candles: Sequence[dict] | None = None) -> Mark
     MarketContext
         Detected mode, score and reasons.
     """
+    from signals.composite_mode import decide_trade_mode_detail
     mode, score, reasons = decide_trade_mode_detail(indicators, candles)
     return MarketContext(mode=mode, score=score, reasons=reasons)
 


### PR DESCRIPTION
## Summary
- avoid circular import in detect_mode by importing composite module lazily

## Testing
- `ruff check analysis/detect_mode.py`
- `isort analysis/detect_mode.py`
- `mypy analysis/detect_mode.py`
- `pytest tests/test_range_adx_count.py::test_range_adx_single_dip_no_switch -q`

------
https://chatgpt.com/codex/tasks/task_e_68542501aabc8333997afd9d92ade2ac