### PR TITLE
feat: add ALWAYS_ENTRY option

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -333,3 +333,4 @@ LOG_LEVEL=INFO                  # ログ出力レベル
 RESTART_STATE_PATH=/tmp/piphawk_last_restart  # 再起動状態ファイルパス
 FORCE_ENTRY_AFTER_AI=true
 FALLBACK_FORCE_ON_NO_SIDE=true
+ALWAYS_ENTRY=true

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1430,21 +1430,29 @@ class JobRunner:
                     current_price = float(
                         tick_data["prices"][0]["bids"][0]["price"]
                     )
-                    if not pass_entry_filter(
+                    filter_pass = pass_entry_filter(
                         indicators,
                         current_price,
                         self.indicators_M1,
                         self.indicators_M15,
                         self.indicators_H1,
                         mode=self.trade_mode,
-                    ):
-                        log.info("Entry blocked by filter → skip any AI calls.")
-                        self.last_position_review_ts = None
-                        self.last_run = now
-                        update_oanda_trades()
-                        time.sleep(self.interval_seconds)
-                        timer.stop()
-                        continue
+                    )
+                    if not filter_pass:
+                        if env_loader.get_env("ALWAYS_ENTRY", "false").lower() == "true":
+                            log.info(
+                                "Filter NG but ALWAYS_ENTRY → continuing with AI."
+                            )
+                        else:
+                            log.info(
+                                "Entry blocked by filter → skip any AI calls."
+                            )
+                            self.last_position_review_ts = None
+                            self.last_run = now
+                            update_oanda_trades()
+                            time.sleep(self.interval_seconds)
+                            timer.stop()
+                            continue
 
                     # 指標からトレードモードを判定
                     new_mode, _score, reasons = decide_trade_mode_detail(

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -401,6 +401,10 @@ AI が `side:"no"` を返しても、現在のトレンド方向へエントリ�
 
 AI 判断後にフィルタで拒否されても必ず注文を実行するかどうかを決めます。デフォルトは `true` です。
 
+### ALWAYS_ENTRY
+
+フィルタに阻まれても毎回エントリー処理を行うかどうか。デフォルトは `false` です。
+
 ### FALLBACK_DEFAULT_SL_PIPS
 
 AI が SL 値を返さない場合に利用する予備の幅(pips)。デフォルトは `8` です。
@@ -422,6 +426,7 @@ FALLBACK_DEFAULT_SL_PIPS=10
 FALLBACK_DEFAULT_TP_PIPS=15
 FALLBACK_DYNAMIC_RISK=true
 FORCE_ENTRY_AFTER_AI=true
+ALWAYS_ENTRY=true
 ```
 
 ### Atmosphere module


### PR DESCRIPTION
## Summary
- エントリーフィルタを無視してAI処理を続行できる`ALWAYS_ENTRY`設定を追加
- 環境変数ドキュメントを更新
- サンプル設定ファイルにも`ALWAYS_ENTRY`を追記

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(216 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854290195bc8333bb2d36e7123846f4