### PR TITLE
Remove ADX/EMA checks from filters

### DIFF
--- a/backend/filters/breakout_entry.py
+++ b/backend/filters/breakout_entry.py
@@ -1,8 +1,6 @@
-"""Breakout entry filter."""
+"""直近高値・安値を抜けたかのみを判定するブレイクアウトフィルター."""
 
 from typing import Dict, List
-
-from backend.utils import env_loader
 
 
 def _get_val(candle: Dict, key: str) -> float:
@@ -11,30 +9,11 @@ def _get_val(candle: Dict, key: str) -> float:
     return float(base.get(key))
 
 
-def _last_val(series):
-    if series is None:
-        return None
-    try:
-        if hasattr(series, "iloc"):
-            return float(series.iloc[-1])
-        if isinstance(series, (list, tuple)):
-            return float(series[-1])
-        return float(series)
-    except Exception:
-        return None
 
 
 def should_enter_breakout(candles: List[Dict], indicators: Dict) -> bool:
-    """Return True when ADX is high and latest close breaks previous high/low."""
+    """最新足が前足の高値または安値を超えた場合に True を返す."""
     if len(candles) < 2:
-        return False
-
-    adx_val = _last_val(indicators.get("adx"))
-    if adx_val is None:
-        return False
-
-    adx_thresh = float(env_loader.get_env("BREAKOUT_ADX_MIN", "30"))
-    if adx_val < adx_thresh:
         return False
 
     last = candles[-1]

--- a/backend/filters/scalp_entry.py
+++ b/backend/filters/scalp_entry.py
@@ -1,9 +1,7 @@
-"""スキャルプ用エントリーフィルター."""
+"""ADX・EMA を使わない簡素なスキャルプフィルター."""
 from __future__ import annotations
 
 from typing import Dict, List
-
-from backend.utils import env_loader
 
 
 def _val(candle: Dict, key: str) -> float:
@@ -11,30 +9,11 @@ def _val(candle: Dict, key: str) -> float:
     return float(base.get(key))
 
 
-def _last_val(series):
-    if series is None:
-        return None
-    try:
-        if hasattr(series, "iloc"):
-            return float(series.iloc[-1])
-        if isinstance(series, (list, tuple)):
-            return float(series[-1])
-        return float(series)
-    except Exception:
-        return None
 
 
 def should_enter_long(candles: List[Dict], indicators: dict) -> bool:
     """Return True if scalping long conditions are met."""
     if not candles:
-        return False
-    adx_val = _last_val(indicators.get("adx"))
-    ema_fast = _last_val(indicators.get("ema_fast"))
-    ema_slow = _last_val(indicators.get("ema_slow"))
-    if adx_val is None or ema_fast is None or ema_slow is None:
-        return False
-    adx_min = float(env_loader.get_env("SCALP_ADX_MIN", "15"))
-    if adx_val < adx_min or ema_fast <= ema_slow:
         return False
     last_close = _val(candles[-1], "c")
     last_open = _val(candles[-1], "o")
@@ -44,14 +23,6 @@ def should_enter_long(candles: List[Dict], indicators: dict) -> bool:
 def should_enter_short(candles: List[Dict], indicators: dict) -> bool:
     """Return True if scalping short conditions are met."""
     if not candles:
-        return False
-    adx_val = _last_val(indicators.get("adx"))
-    ema_fast = _last_val(indicators.get("ema_fast"))
-    ema_slow = _last_val(indicators.get("ema_slow"))
-    if adx_val is None or ema_fast is None or ema_slow is None:
-        return False
-    adx_min = float(env_loader.get_env("SCALP_ADX_MIN", "15"))
-    if adx_val < adx_min or ema_fast >= ema_slow:
         return False
     last_close = _val(candles[-1], "c")
     last_open = _val(candles[-1], "o")

--- a/backend/filters/trend_pullback.py
+++ b/backend/filters/trend_pullback.py
@@ -1,8 +1,6 @@
-"""Trend pullback entry filter."""
+"""ADX や EMA を参照しない単純なプルバックフィルター."""
 
 from typing import Dict, List, Sequence
-
-from backend.utils import env_loader
 
 
 def _get_val(candle: Dict, key: str) -> float:
@@ -11,28 +9,7 @@ def _get_val(candle: Dict, key: str) -> float:
     return float(base.get(key))
 
 
-def _ema(values: Sequence[float], period: int) -> float:
-    """Simple EMA calculation used for deviation checks."""
-    if not values:
-        return 0.0
-    k = 2 / (period + 1)
-    ema = values[0]
-    for v in values[1:]:
-        ema = v * k + ema * (1 - k)
-    return ema
 
-
-def _last_val(series):
-    if series is None:
-        return None
-    try:
-        if hasattr(series, "iloc"):
-            return float(series.iloc[-1])
-        if isinstance(series, (list, tuple)):
-            return float(series[-1])
-        return float(series)
-    except Exception:
-        return None
 
 
 def should_enter_long(candles: List[Dict], indicators: dict) -> bool:
@@ -40,40 +17,16 @@ def should_enter_long(candles: List[Dict], indicators: dict) -> bool:
     if len(candles) < 2:
         return False
 
-    adx_val = _last_val(indicators.get("adx"))
-    ema_fast = _last_val(indicators.get("ema_fast"))
-    ema_slow = _last_val(indicators.get("ema_slow"))
-    atr_val = _last_val(indicators.get("atr"))
-
-    if adx_val is None or ema_fast is None or ema_slow is None or atr_val is None:
-        return False
-
-    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
-    adx_thresh = float(env_loader.get_env("TREND_PB_ADX", "25"))
-    min_atr_pips = float(env_loader.get_env("TREND_PB_MIN_ATR_PIPS", "0"))
-
-    # --- ADX と ATR によるフィルタ ---
-    if adx_val < adx_thresh or atr_val / pip_size < min_atr_pips:
-        return False
-
-    # --- EMA の並びを確認し上昇トレンドかを判断 ---
-    if ema_fast <= ema_slow:
-        return False
 
     last = candles[-1]
     prev = candles[-2]
     last_open = _get_val(last, "o")
     last_close = _get_val(last, "c")
-    last_low = _get_val(last, "l")
     prev_open = _get_val(prev, "o")
     prev_close = _get_val(prev, "c")
 
     # --- 押し目形成を確認（前足陰線 → 最新足陽線） ---
     if prev_close >= prev_open or last_close <= last_open:
-        return False
-
-    # --- EMA 付近から反発しているか判定 ---
-    if last_low > ema_fast and last_low > ema_slow:
         return False
 
     return True
@@ -84,31 +37,10 @@ def should_enter_short(candles: List[Dict], indicators: dict) -> bool:
     if len(candles) < 2:
         return False
 
-    adx_val = _last_val(indicators.get("adx"))
-    ema_fast = _last_val(indicators.get("ema_fast"))
-    ema_slow = _last_val(indicators.get("ema_slow"))
-    atr_val = _last_val(indicators.get("atr"))
-
-    if adx_val is None or ema_fast is None or ema_slow is None or atr_val is None:
-        return False
-
-    pip_size = float(env_loader.get_env("PIP_SIZE", "0.01"))
-    adx_thresh = float(env_loader.get_env("TREND_PB_ADX", "25"))
-    min_atr_pips = float(env_loader.get_env("TREND_PB_MIN_ATR_PIPS", "0"))
-
-    # --- ADX と ATR によるフィルタ ---
-    if adx_val < adx_thresh or atr_val / pip_size < min_atr_pips:
-        return False
-
-    # --- EMA の並びを確認し下降トレンドかを判断 ---
-    if ema_fast >= ema_slow:
-        return False
-
     last = candles[-1]
     prev = candles[-2]
     last_open = _get_val(last, "o")
     last_close = _get_val(last, "c")
-    last_high = _get_val(last, "h")
     prev_open = _get_val(prev, "o")
     prev_close = _get_val(prev, "c")
 
@@ -116,30 +48,11 @@ def should_enter_short(candles: List[Dict], indicators: dict) -> bool:
     if prev_close <= prev_open or last_close >= last_open:
         return False
 
-    # --- EMA 付近から反落しているか判定 ---
-    if last_high < ema_fast and last_high < ema_slow:
-        return False
-
     return True
 
 
 def should_skip(candles: List[Dict], ema_period: int = 20) -> bool:
-    """EMA乖離からの強い戻しがあればエントリーを避ける."""
-    if len(candles) < ema_period + 1:
-        return False
-
-    closes = [_get_val(c, "c") for c in candles[-(ema_period + 1) :]]
-    ema_val = _ema(closes[:-1], ema_period)
-    if not ema_val:
-        return False
-
-    last = candles[-1]
-    open_v = _get_val(last, "o")
-    close_v = _get_val(last, "c")
-    dev = abs(open_v - ema_val) / ema_val
-    if dev > 0.01 and ((open_v > ema_val and close_v < ema_val) or (open_v < ema_val and close_v > ema_val)):
-        return True
-
+    """常に False を返してフィルターを無効化する."""
     return False
 
 

--- a/backend/tests/test_breakout_entry.py
+++ b/backend/tests/test_breakout_entry.py
@@ -24,23 +24,22 @@ def _c(o, h, l, c):
 
 class TestBreakoutEntry(unittest.TestCase):
     def setUp(self):
-        os.environ["BREAKOUT_ADX_MIN"] = "30"
         import backend.filters.breakout_entry as be
         importlib.reload(be)
         self.be = be
 
     def tearDown(self):
-        os.environ.pop("BREAKOUT_ADX_MIN", None)
+        pass
 
     def test_breakout_true(self):
-        indicators = {"adx": FakeSeries([35])}
+        indicators = {}
         candles = [_c(1.0, 1.1, 0.9, 1.05), _c(1.05, 1.2, 1.0, 1.21)]
         self.assertTrue(self.be.should_enter_breakout(candles, indicators))
 
     def test_breakout_false_low_adx(self):
-        indicators = {"adx": FakeSeries([20])}
+        indicators = {}
         candles = [_c(1.0, 1.1, 0.9, 1.05), _c(1.05, 1.2, 1.0, 1.21)]
-        self.assertFalse(self.be.should_enter_breakout(candles, indicators))
+        self.assertTrue(self.be.should_enter_breakout(candles, indicators))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_trend_pullback.py
+++ b/backend/tests/test_trend_pullback.py
@@ -25,25 +25,15 @@ def _c(o, h, l, c):
 
 class TestTrendPullback(unittest.TestCase):
     def setUp(self):
-        os.environ["PIP_SIZE"] = "0.01"
-        os.environ["TREND_PB_ADX"] = "25"
-        os.environ["TREND_PB_MIN_ATR_PIPS"] = "5"
         import backend.filters.trend_pullback as tp
         importlib.reload(tp)
         self.tp = tp
 
     def tearDown(self):
-        os.environ.pop("PIP_SIZE", None)
-        os.environ.pop("TREND_PB_ADX", None)
-        os.environ.pop("TREND_PB_MIN_ATR_PIPS", None)
+        pass
 
     def test_should_enter_true(self):
-        indicators = {
-            "adx": FakeSeries([20, 30]),
-            "ema_fast": FakeSeries([1.0, 1.05]),
-            "ema_slow": FakeSeries([0.99, 1.02]),
-            "atr": FakeSeries([0.1]),
-        }
+        indicators = {}
         candles = [
             _c(1.05, 1.06, 1.02, 1.03),
             _c(1.03, 1.07, 0.99, 1.06),
@@ -51,38 +41,23 @@ class TestTrendPullback(unittest.TestCase):
         self.assertTrue(self.tp.should_enter_long(candles, indicators))
 
     def test_adx_below_threshold(self):
-        indicators = {
-            "adx": FakeSeries([10]),
-            "ema_fast": FakeSeries([1.0, 1.05]),
-            "ema_slow": FakeSeries([0.99, 1.02]),
-            "atr": FakeSeries([0.1]),
-        }
+        indicators = {}
         candles = [
             _c(1.05, 1.06, 1.02, 1.03),
             _c(1.03, 1.07, 0.99, 1.06),
         ]
-        self.assertFalse(self.tp.should_enter_long(candles, indicators))
+        self.assertTrue(self.tp.should_enter_long(candles, indicators))
 
     def test_atr_below_min(self):
-        indicators = {
-            "adx": FakeSeries([30]),
-            "ema_fast": FakeSeries([1.0, 1.05]),
-            "ema_slow": FakeSeries([0.99, 1.02]),
-            "atr": FakeSeries([0.02]),
-        }
+        indicators = {}
         candles = [
             _c(1.05, 1.06, 1.02, 1.03),
             _c(1.03, 1.07, 0.99, 1.06),
         ]
-        self.assertFalse(self.tp.should_enter_long(candles, indicators))
+        self.assertTrue(self.tp.should_enter_long(candles, indicators))
 
     def test_should_enter_short_true(self):
-        indicators = {
-            "adx": FakeSeries([20, 30]),
-            "ema_fast": FakeSeries([1.05, 1.0]),
-            "ema_slow": FakeSeries([1.05, 1.04]),
-            "atr": FakeSeries([0.1]),
-        }
+        indicators = {}
         candles = [
             _c(1.03, 1.07, 0.99, 1.06),
             _c(1.06, 1.08, 1.02, 1.03),
@@ -90,12 +65,7 @@ class TestTrendPullback(unittest.TestCase):
         self.assertTrue(self.tp.should_enter_short(candles, indicators))
 
     def test_should_enter_short_false(self):
-        indicators = {
-            "adx": FakeSeries([20, 30]),
-            "ema_fast": FakeSeries([1.05, 1.0]),
-            "ema_slow": FakeSeries([1.05, 1.04]),
-            "atr": FakeSeries([0.1]),
-        }
+        indicators = {}
         candles = [
             _c(1.03, 1.07, 0.99, 1.06),
             _c(1.06, 1.08, 1.02, 1.07),
@@ -109,7 +79,7 @@ class TestTrendPullback(unittest.TestCase):
             _c(1.0, 1.01, 0.99, 1.0),
             _c(1.02, 1.03, 0.98, 0.99),
         ]
-        self.assertTrue(self.tp.should_skip(candles, ema_period=3))
+        self.assertFalse(self.tp.should_skip(candles, ema_period=3))
 
     def test_should_skip_false(self):
         candles = [


### PR DESCRIPTION
## Summary
- drop ADX/EMA logic from breakout, scalp, and trend pullback filters
- adjust corresponding tests
- tidy docstring in trend pullback filter

## Testing
- `isort backend/filters/breakout_entry.py backend/filters/scalp_entry.py backend/filters/trend_pullback.py backend/tests/test_breakout_entry.py backend/tests/test_trend_pullback.py`
- `ruff check backend/filters/breakout_entry.py backend/filters/scalp_entry.py backend/filters/trend_pullback.py backend/tests/test_breakout_entry.py backend/tests/test_trend_pullback.py`
- `mypy backend/filters/breakout_entry.py backend/filters/scalp_entry.py backend/filters/trend_pullback.py backend/tests/test_breakout_entry.py backend/tests/test_trend_pullback.py`
- `pytest backend/tests/test_breakout_entry.py backend/tests/test_trend_pullback.py -q`
- `pytest -q` *(fails: ImportError: module backend.strategy.pattern_scanner not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_68542acdd67c8333836f2fe158ecb027