### PR TITLE
fix: remove local tp_only_condition import

### DIFF
--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -470,8 +470,6 @@ def process_entry(
             }
             with_oco = True
             try:
-                from backend.risk_manager import tp_only_condition
-
                 if tp_only_condition(sl_pips, noise_pips):
                     with_oco = False
             except Exception:


### PR DESCRIPTION
## Summary
- remove nested import causing UnboundLocalError

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError: cannot import name 'split_complex_to_pairs' from 'onnx.helper')*

------
https://chatgpt.com/codex/tasks/task_e_68543c73910c83339a464425ab26dd3b