### PR TITLE
fix: entry guard for quiet hours

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1560,8 +1560,9 @@ class JobRunner:
                     except Exception:
                         bb_pct = 0.0
 
+                    tradeable = instrument_is_tradeable(DEFAULT_PAIR)
                     allow_trade, filter_ctx, reason = apply_filters(
-                        atr_pips, bb_pct, tradeable=True
+                        atr_pips, bb_pct, tradeable=tradeable
                     )
                     if not allow_trade:
                         log_entry_skip(DEFAULT_PAIR, None, reason)

--- a/filters/session_filter.py
+++ b/filters/session_filter.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from backend.utils import env_loader
+from filters.market_filters import _in_trade_hours
 
 
 def is_quiet_hours(now: datetime | None = None) -> bool:
@@ -18,7 +19,8 @@ def apply_filters(atr: float, bb_width_pct: float, *, tradeable: bool = True) ->
     """禁止3条件を評価し、regime_hint を返す."""
     if is_quiet_hours():
         return False, None, "session"
-    if not tradeable:
+    # 市場が開いているか、取引可能かを判定
+    if not _in_trade_hours() or not tradeable:
         return False, None, "market_closed"
     scalp_min = float(env_loader.get_env("SCALP_ATR_MIN", "0.03"))
     trend_min = float(env_loader.get_env("TREND_ATR_MIN", "0.1"))

--- a/tests/test_session_filter.py
+++ b/tests/test_session_filter.py
@@ -1,0 +1,15 @@
+from filters import session_filter
+
+
+def test_apply_filters_market_closed(monkeypatch):
+    monkeypatch.setattr(session_filter, "_in_trade_hours", lambda: False)
+    ok, ctx, reason = session_filter.apply_filters(0.1, 0.2, tradeable=True)
+    assert not ok
+    assert reason == "market_closed"
+
+
+def test_apply_filters_quiet_hours(monkeypatch):
+    monkeypatch.setattr(session_filter, "is_quiet_hours", lambda *a, **k: True)
+    ok, ctx, reason = session_filter.apply_filters(0.1, 0.2, tradeable=True)
+    assert not ok
+    assert reason == "session"


### PR DESCRIPTION
## Summary
- prohibit trading outside the configured trading hours
- integrate market hours check into session filter
- test session filter logic

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685479faed908333a2dc9ef9900ad0a9