### PR TITLE
feature/exit-vol-stance

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -143,6 +143,8 @@ class OrderManager:
             "entry_uuid": entry_uuid,
             "order_type": "limit",
             "mode": exec_mode,
+            "vol": strategy_params.get("entry_vol_pips"),
+            "stance": strategy_params.get("entry_stance"),
         }
         if risk_info:
             comment_dict.update(
@@ -555,6 +557,8 @@ class OrderManager:
                 "order_type": mode,
                 "mode": strategy_params.get("exec_mode", "auto"),
                 "entry_uuid": entry_uuid,
+                "vol": strategy_params.get("entry_vol_pips"),
+                "stance": strategy_params.get("entry_stance"),
             }
             # ---- embed AI risk info (tp/sl & probabilities) if present ----
             risk_info = strategy_params.get("risk", {})

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -1077,6 +1077,8 @@ def process_entry(
             "valid_for_sec": valid_sec,
             "ai_response": ai_raw,
             "market_cond": market_cond,
+            "entry_vol_pips": noise_pips,
+            "entry_stance": trade_mode,
         }
         risk_pct = float(env_loader.get_env("ENTRY_RISK_PCT", "0.01"))
         if entry_type == "breakout":
@@ -1125,6 +1127,8 @@ def process_entry(
             "limit_price": limit_price,
             "ai_response": ai_raw,
             "market_cond": market_cond,
+            "entry_vol_pips": noise_pips,
+            "entry_stance": trade_mode,
         }
 
     risk_pct = float(env_loader.get_env("ENTRY_RISK_PCT", "0.01"))

--- a/backend/strategy/exit_logic.py
+++ b/backend/strategy/exit_logic.py
@@ -135,6 +135,8 @@ def decide_exit(
         "indicators": indicators,
         "entry_regime": entry_regime,
         "market_cond": market_cond,
+        "entry_vol_pips": None if not entry_regime else entry_regime.get("vol"),
+        "entry_stance": None if not entry_regime else entry_regime.get("stance"),
     }
     oa = importlib.import_module("backend.strategy.openai_analysis")
     exit_eval = getattr(oa, "evaluate_exit", None)


### PR DESCRIPTION
## Summary
- エントリー時のボラ(ATR由来)とスタンスを `entry_vol_pips` と `entry_stance` として保存
- 保存した情報を注文コメントに含め、Exit 判断用コンテキストへ展開

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(失敗: onnx ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68543e567f6c8333afeba0a2ad6b15d3