### PR TITLE
Enable filters

### DIFF
--- a/backend/filters/trend_pullback.py
+++ b/backend/filters/trend_pullback.py
@@ -52,7 +52,19 @@ def should_enter_short(candles: List[Dict], indicators: dict) -> bool:
 
 
 def should_skip(candles: List[Dict], ema_period: int = 20) -> bool:
-    """常に False を返してフィルターを無効化する."""
+    """Return True when price is overextended from EMA."""
+
+    if len(candles) < ema_period + 1:
+        return False
+
+    closes = [_get_val(c, "c") for c in candles[-(ema_period + 1) : -1]]
+    ema = sum(closes) / len(closes)
+    last = _get_val(candles[-1], "c")
+    prev = _get_val(candles[-2], "c")
+    if last > ema and prev > ema:
+        return True
+    if last < ema and prev < ema:
+        return True
     return False
 
 

--- a/backend/strategy/entry_logic.py
+++ b/backend/strategy/entry_logic.py
@@ -264,8 +264,9 @@ def process_entry(
         )
 
     forced_entry = False
-    # フィルター通過後は必ずエントリーするため常に True
-    force_entry_after_ai = True
+    force_entry_after_ai = (
+        env_loader.get_env("FORCE_ENTRY_AFTER_AI", "false").lower() == "true"
+    )
     use_dynamic_risk = (
         env_loader.get_env("FALLBACK_DYNAMIC_RISK", "false").lower() == "true"
     )

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -488,6 +488,11 @@ def pass_entry_filter(
                 context["overshoot_flag"] = True
                 logger.info("Overshoot range detected: flag set")
 
+    if context.get("overshoot_flag") and env_loader.get_env("OVERSHOOT_MODE", "block").lower() != "warn":
+        context["reason"] = "overshoot"
+        logger.info("Filter blocked: overshoot")
+        return False
+
     return True
 
 

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -14,8 +14,7 @@ from .ai_strategy_selector import select_strategy
 from .entry_buffer import PlanBuffer
 from .regime_detector import MarketMetrics, rule_based_regime
 
-# 常にエントリーを実行する
-FORCE_ENTER = True
+FORCE_ENTER = env_loader.get_env("FORCE_ENTER", "false").lower() == "true"
 
 
 


### PR DESCRIPTION
## Summary
- activate entry and pre-check filters
- implement overextension detection in trend pullback filter
- enforce overshoot blocking in signal filter
- respect env vars for forced AI entry and vote arch
- log filter reasons in job runner

## Testing
- `isort .`
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68547dea7b3c8333a983157bdb211253