### PR TITLE
fix: enable filter modules

### DIFF
--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -55,8 +55,8 @@ USE_CANDLE_SUMMARY=false        # ローソク足を平均値で要約してプ�
 RSI_EXIT_LOWER=30                # RSIがこの値以下で利確検討
 RSI_EXIT_UPPER=70                # RSIがこの値以上で利確検討
 ATR_EXIT_THRESHOLD=0.06          # ATRがこの値以上で利確検討
-DISABLE_ENTRY_FILTER=true       # パッチ: エントリーフィルタ完全スキップ
-DISABLE_EXIT_FILTER=true         # エグジットフィルタ無効化
+DISABLE_ENTRY_FILTER=false       # パッチ: エントリーフィルタ完全スキップ
+DISABLE_EXIT_FILTER=false         # エグジットフィルタ無効化
 
 # === EMA設定 ===
 EMA_FAST_PERIOD=9                # EMA短期


### PR DESCRIPTION
## Summary
- エントリー/エグジットフィルタを有効化

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(失敗: ImportError: split_complex_to_pairs)*

------
https://chatgpt.com/codex/tasks/task_e_6854a9a08ccc83338722cd8d8747a593