### PR TITLE
docs: adjust prompts for tp and rrr

### DIFF
--- a/prompts/trade_plan.txt
+++ b/prompts/trade_plan.txt
@@ -4,8 +4,8 @@ Your task:
    - Constraints:
     • tp_prob must be ≥ {MIN_TP_PROB:.2f}
     • Expected value (tp_pips*tp_prob - sl_pips*sl_prob) must be positive
-    • Choose the take-profit level that maximises expected value = probability × pips, subject to RRR ≥ {MIN_RRR}
-    • (tp_pips - spread_pips) must be ≥ {MIN_NET_TP_PIPS} pips
+    • Choose the take-profit level that maximises expected value = probability × pips, subject to RRR ≥ {MIN_RRR}. If below the threshold, enlarge TP or tighten SL.
+    • (tp_pips - spread_pips) must be ≥ {MIN_NET_TP_PIPS} pips and generally not under 5 pips
     • If constraints are not met, pick the side with the higher success probability.
 
 3. Always provide a brief "why" field explaining the trade logic.

--- a/prompts/trade_plan_instruction.txt
+++ b/prompts/trade_plan_instruction.txt
@@ -13,7 +13,7 @@ Allow short-term counter-trend trades only when all of the following are true:
 - A clear reversal pattern (double top/bottom, head-and-shoulders) is present.
 - RSI ≤ 30 for LONG or ≥ 70 for SHORT, showing potential exhaustion.
 - Price action has stabilized with minor reversal candles.
-- TP kept small (5–10 pips) and risk tightly controlled.
+- TP は 5–10 pips 程度に抑えつつ、RRR が {MIN_RRR} 未満にならないよう調整する。
 
 Price has just printed multiple upper shadows and ADX(S10) fell >30% from its peak.
 Evaluate if a short scalp is favorable given potential exhaustion.


### PR DESCRIPTION
## Summary
- トレードプラン指示文を更新し、RRR が閾値を下回らないよう明記
- 逆張り許可条件の文言を修正し、TP を小さくし過ぎないよう注意を追加

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(失敗: onnx.helper の ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6854a9577dc483338c249926f71a2bcb