### PR TITLE
fix: include MIN_RRR in trade plan prompt

### DIFF
--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -271,6 +271,7 @@ def build_trade_plan_prompt(
     prompt = mode_header + TRADE_PLAN_PROMPT.format(
         TREND_ADX_THRESH=TREND_ADX_THRESH,
         RANGE_ENTRY_NOTE=RANGE_ENTRY_NOTE,
+        MIN_RRR=MIN_RRR,
         pullback_needed=pullback_needed,
         no_pullback_msg=no_pullback_msg,
         TREND_OVERSHOOT_SECTION=overshoot,


### PR DESCRIPTION
## Summary
- `build_trade_plan_prompt` で `MIN_RRR` をテンプレートに渡すよう修正

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(205 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854ade70aa88333a81ed2f4e8f2a645