### PR TITLE
fix: shorten order comments for OANDA

### DIFF
--- a/backend/orders/position_manager.py
+++ b/backend/orders/position_manager.py
@@ -117,7 +117,15 @@ def get_position_details(instrument: str) -> Optional[Dict[str, Any]]:
                     sl_pips = entry_regime.get("sl")
                     tp_pips = entry_regime.get("tp")
                 except json.JSONDecodeError:
-                    entry_regime = {"regime": "unknown"}
+                    parts = comment.split("_")
+                    if len(parts) >= 3:
+                        entry_regime = {
+                            "regime": parts[0],
+                            "stance": parts[1],
+                            "entry_uuid": parts[2],
+                        }
+                    else:
+                        entry_regime = {"entry_uuid": comment}
                 break
         for tr in trades:
             tp_comment = (

--- a/backend/utils/oanda_client.py
+++ b/backend/utils/oanda_client.py
@@ -93,12 +93,18 @@ def get_pending_entry_order(instrument: str) -> Optional[dict]:
         comment_text = order.get("clientExtensions", {}).get("comment", "")
         tag_text = order.get("clientExtensions", {}).get("tag", "0")
 
-        try:
-            meta = json.loads(comment_text)
-        except json.JSONDecodeError:
-            continue
+        entry_uuid = None
+        if comment_text.startswith("limit_"):
+            entry_uuid = comment_text.split("_", 1)[1]
+        else:
+            try:
+                meta = json.loads(comment_text)
+                if meta.get("mode") == "limit":
+                    entry_uuid = meta.get("entry_uuid")
+            except json.JSONDecodeError:
+                pass
 
-        if meta.get("mode") == "limit" and meta.get("entry_uuid"):
+        if entry_uuid:
             try:
                 ts_val = int(tag_text)
             except ValueError:


### PR DESCRIPTION
## Summary
- ensure clientExtensions.comment complies with OANDA restrictions
- parse new short comment format for open position queries and pending order lookup

## Testing
- `ruff check backend/orders/order_manager.py backend/orders/position_manager.py backend/utils/oanda_client.py`
- `isort backend/orders/order_manager.py backend/orders/position_manager.py backend/utils/oanda_client.py`
- `mypy backend/orders/order_manager.py backend/orders/position_manager.py backend/utils/oanda_client.py`
- `pytest` *(fails: 61 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6854b18d74408333a6880a7adad907c6