### PR TITLE
fix: sanitize order comment

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -23,11 +23,20 @@ from backend.utils.price import format_price
 
 
 def _sanitize_comment(comment: str, max_bytes: int = 240) -> str:
-    """Remove newlines and enforce max byte length for OANDA."""
-    sanitized = comment.replace("\n", " ").replace("\r", " ")
+    """Remove unsupported characters and enforce max byte length."""
+    tmp = comment.replace("\n", " ").replace("\r", " ")
+    allowed = []
+    for ch in tmp:
+        if ch == '"' or ch == "\\":
+            allowed.append("_")
+        elif 32 <= ord(ch) <= 126:
+            allowed.append(ch)
+        else:
+            allowed.append("_")
+    sanitized = "".join(allowed)
     if len(sanitized.encode("utf-8")) > max_bytes:
         sanitized = sanitized.encode("utf-8")[:max_bytes].decode("utf-8", "ignore")
-    return sanitized
+    return sanitized.strip()
 
 
 def _build_simple_comment(regime: str | None, stance: str | None, entry_uuid: str) -> str:


### PR DESCRIPTION
## Summary
- sanitize comment strings to avoid OANDA rejection

## Testing
- `ruff check backend/orders/order_manager.py`
- `mypy backend/orders/order_manager.py`
- `pytest -q` *(fails: 61 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6854b4a611248333a3b53e80ddf71ed4