### PR TITLE
Implement trade mode majority vote

### DIFF
--- a/backend/strategy/openai_prompt.py
+++ b/backend/strategy/openai_prompt.py
@@ -330,9 +330,6 @@ def build_trade_plan_prompt(
 
     prompt = mode_header + TRADE_PLAN_PROMPT.format_map(defaultdict(str, values))
     prompt += _instruction_text()
-    # scalp_momentum モードでは常に積極的バイアスを使用
-    if trade_mode == "scalp_momentum":
-    ) + _instruction_text()
     # scalp_momentum/micro_scalp モードでは常に積極的バイアスを使用
     if trade_mode in ("scalp_momentum", "micro_scalp"):
         bias = "aggressive"

--- a/piphawk_ai/vote_arch/__init__.py
+++ b/piphawk_ai/vote_arch/__init__.py
@@ -1,6 +1,6 @@
 """Majority-vote trading pipeline components."""
 from analysis.atmosphere.market_air_sensor import MarketSnapshot, air_index
-from signals.mode_selector_v2 import select_mode
+from signals.mode_selector_v2 import select_mode as select_mode_calc
 
 from .ai_entry_plan import EntryPlan, generate_plan
 from .ai_strategy_selector import select_strategy
@@ -8,12 +8,14 @@ from .entry_buffer import PlanBuffer
 from .pipeline import PipelineResult, run_cycle
 from .post_filters import final_filter
 from .regime_detector import MarketMetrics, rule_based_regime
+from .trade_mode_selector import select_mode
 
 __all__ = [
     "MarketMetrics",
     "rule_based_regime",
     "select_strategy",
     "select_mode",
+    "select_mode_calc",
     "generate_plan",
     "EntryPlan",
     "PlanBuffer",

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -7,12 +7,11 @@ from typing import Optional
 
 from analysis.atmosphere.market_air_sensor import MarketSnapshot, air_index
 from backend.utils import env_loader
-from signals.mode_selector_v2 import select_mode
 
 from .ai_entry_plan import EntryPlan, generate_plan
-from .ai_strategy_selector import select_strategy
 from .entry_buffer import PlanBuffer
 from .regime_detector import MarketMetrics, rule_based_regime
+from .trade_mode_selector import select_mode
 
 FORCE_ENTER = env_loader.get_env("FORCE_ENTER", "false").lower() == "true"
 
@@ -49,33 +48,7 @@ def run_cycle(
     air = air_index(snapshot)
 
     prompt = f"Regime: {regime}\nAir: {air:.2f}"
-    mode_raw, conf_ok = select_strategy(prompt)
-
-    def _last(v):
-        if v is None:
-            return 0.0
-        try:
-            if hasattr(v, "iloc"):
-                return float(v.iloc[-1]) if len(v) else 0.0
-            if isinstance(v, (list, tuple)):
-                return float(v[-1]) if v else 0.0
-            return float(v)
-        except Exception:
-            return 0.0
-
-    ctx = {
-        "ema_slope_15m": _last(indicators.get("ema_slope_15m") or indicators.get("ema_slope")),
-        "adx_15m": _last(indicators.get("adx_15m") or indicators.get("adx")),
-        "stddev_pct_15m": _last(indicators.get("stddev_pct_15m") or indicators.get("stddev_pct")),
-        "ema12_15m": _last(indicators.get("ema12_15m") or indicators.get("ema_fast")),
-        "ema26_15m": _last(indicators.get("ema26_15m") or indicators.get("ema_slow")),
-        "atr_15m": _last(indicators.get("atr_15m") or indicators.get("atr")),
-        "overshoot_flag": indicators.get("overshoot_flag", False),
-    }
-    # LLM提案が高信頼なら優先、そうでなければ数値モード
-    mode_llm = mode_raw if conf_ok else ""
-    mode_calc = select_mode(ctx)
-    mode = mode_llm or mode_calc
+    mode = select_mode(prompt, metrics)
 
     plan = generate_plan(f"trade_mode: {mode}")
     if not plan:

--- a/piphawk_ai/vote_arch/trade_mode_selector.py
+++ b/piphawk_ai/vote_arch/trade_mode_selector.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Trade mode selection with majority vote and rule fallback."""
+
+from .ai_strategy_selector import select_strategy
+from .regime_detector import MarketMetrics, rule_based_regime
+
+_ALLOWED = {
+    "micro_scalp",
+    "scalp_momentum",
+    "scalp_reversion",
+    "trend_follow",
+    "strong_trend",
+}
+
+_FALLBACK = {
+    "trend": "trend_follow",
+    "range": "scalp_momentum",
+    "vol_spike": "scalp_reversion",
+}
+
+
+def select_mode(prompt: str, metrics: MarketMetrics) -> str:
+    """Return final trade mode via majority vote with rule fallback."""
+    mode, ok = select_strategy(prompt)
+    if mode in _ALLOWED and ok:
+        return mode
+    regime = rule_based_regime(metrics)
+    return _FALLBACK.get(regime, "scalp_momentum")
+
+
+__all__ = ["select_mode"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -33,14 +33,14 @@ def test_run_cycle(monkeypatch):
         "piphawk_ai.vote_arch.pipeline.pass_entry_filter", fake_filter
     )
 
-    def fake_select(prompt: str, n=None):
-        return "scalp_momentum", True
+    def fake_select(prompt: str, metrics):
+        return "scalp_momentum"
 
     monkeypatch.setattr(
-        "piphawk_ai.vote_arch.ai_strategy_selector.select_strategy", fake_select
+        "piphawk_ai.vote_arch.trade_mode_selector.select_mode", fake_select
     )
     monkeypatch.setattr(
-        "piphawk_ai.vote_arch.pipeline.select_strategy", fake_select
+        "piphawk_ai.vote_arch.pipeline.select_mode", fake_select
     )
 
     def fake_plan(prompt: str):

--- a/tests/test_trade_mode_selector.py
+++ b/tests/test_trade_mode_selector.py
@@ -1,0 +1,22 @@
+import pytest
+
+from piphawk_ai.vote_arch.regime_detector import MarketMetrics
+from piphawk_ai.vote_arch.trade_mode_selector import select_mode
+
+
+def test_select_mode_majority(monkeypatch):
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.ai_strategy_selector.select_strategy",
+        lambda _p: ("trend_follow", True),
+    )
+    metrics = MarketMetrics(adx_m5=30, ema_fast=1.1, ema_slow=1.0, bb_width_m5=0.1)
+    assert select_mode("foo", metrics) == "trend_follow"
+
+
+def test_select_mode_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "piphawk_ai.vote_arch.ai_strategy_selector.select_strategy",
+        lambda _p: ("", False),
+    )
+    metrics = MarketMetrics(adx_m5=15, ema_fast=1.0, ema_slow=1.0, bb_width_m5=0.04)
+    assert select_mode("foo", metrics) == "scalp_momentum"


### PR DESCRIPTION
## Summary
- add a trade_mode_selector that picks final mode by majority vote with fallbacks
- update vote pipeline to use new selector
- fix openai_prompt syntax
- adjust tests for new selector

## Testing
- `pip install -r requirements-test.txt`
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: module import issues)*

------
https://chatgpt.com/codex/tasks/task_e_6854c06f161083338707b4e470e1a91b