### PR TITLE
feat: adjust vol spike threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@
 - Dockerfile now includes strategies and regime modules and installs the package.
 - Offline policy integration added to `StrategySelector`.
 - New environment variables for risk and pattern control.
+- VOL_SPIKE_RATIO default raised to 8.0 for lenient volatility filter.
 - Minor documentation updates.

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -242,6 +242,7 @@ AIがSCALEを返した際に追加するロット数。デフォルトは0.5。
   Recent Candle Bias フィルターで参照する設定。直近のローソク足本数、ヒゲ比率、出来高急増判定期間を指定する。
   デフォルトは 3 / 2.0 / 5。
 - VOL_SPIKE_ADX_MULT / VOL_SPIKE_ATR_MULT: BB幅がしきい値を下回っていても、ADXまたはATRがこの倍率で急拡大した場合は成行エントリーに切り替える
+- VOL_SPIKE_RATIO: ATRの急増を大ボラとみなす比率。デフォルトは 8.0
 - STRICT_TF_ALIGN: マルチTF整合が取れない場合のキャンセル可否
 - ALIGN_STRICT: 上記と同義のエイリアス
 - FALLBACK_FORCE_ON_NO_SIDE: AI が "no" と答えたときトレンド方向へエントリーを強制するオプション。使用時は STRICT_TF_ALIGN の影響を受けない。

--- a/piphawk_ai/tech_arch/risk_filters.py
+++ b/piphawk_ai/tech_arch/risk_filters.py
@@ -77,7 +77,7 @@ def vol_spike_guard(indicators: dict) -> bool:
         if prev <= 0:
             return True
         ratio = last / prev
-        threshold = float(env_loader.get_env("VOL_SPIKE_RATIO", "2.0"))
+        threshold = float(env_loader.get_env("VOL_SPIKE_RATIO", "8.0"))
         return ratio < threshold
     except Exception:
         return True


### PR DESCRIPTION
## Summary
- adjust vol spike ratio default value to 8.0
- document VOL_SPIKE_RATIO
- update changelog

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `bash run_tests.sh` *(fails: 207 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854f00887ac8333a806afb1a6313e9a