### PR TITLE
fix: add info logs for entry filters

### DIFF
--- a/backend/logs/log_manager.py
+++ b/backend/logs/log_manager.py
@@ -423,6 +423,13 @@ def log_param_change(param_name, old_value, new_value, ai_reason):
 
 def log_entry_skip(instrument, side, reason, details=None):
     """Record an entry skip event."""
+    logger.info(
+        "Entry skipped: instrument=%s side=%s reason=%s details=%s",
+        instrument,
+        side,
+        reason,
+        details,
+    )
     with get_db_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -1429,6 +1429,7 @@ class JobRunner:
                         tradeable=tradeable,
                     )
                     if not allow_trade:
+                        log.info(f"Entry blocked by session filter ({reason})")
                         log_entry_skip(DEFAULT_PAIR, None, reason)
                         self.last_ai_call = datetime.min
                         self.last_run = now

--- a/filters/session_filter.py
+++ b/filters/session_filter.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 """セッション判定と超低ボラチェック用フィルター."""
 
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from backend.utils import env_loader
 from filters.market_filters import _in_trade_hours
+
+# ログ出力用ロガー
+log = logging.getLogger(__name__)
 
 
 def is_quiet_hours(now: datetime | None = None) -> bool:
@@ -24,16 +28,21 @@ def apply_filters(
 ) -> tuple[bool, dict[str, Any] | None, str | None]:
     """禁止3条件を評価し、regime_hint を返す."""
     if is_quiet_hours():
+        # 静寂時間帯を検知
+        log.info("Filter blocked: session")
         return False, None, "session"
     # 市場が開いているか、取引可能かを判定
     if not _in_trade_hours() or not tradeable:
+        log.info("Filter blocked: market_closed")
         return False, None, "market_closed"
     scalp_min = float(env_loader.get_env("SCALP_ATR_MIN", "0.02"))
     trend_min = float(env_loader.get_env("TREND_ATR_MIN", "0.05"))
     max_spread = float(env_loader.get_env("MAX_SPREAD_PIPS", "0"))
     if spread_pips is not None and max_spread > 0 and spread_pips > max_spread:
+        log.info("Filter blocked: wide_spread")
         return False, None, "wide_spread"
     if atr < scalp_min and bb_width_pct < 0.10:
+        log.info("Filter blocked: ultra_low_vol")
         return False, None, "ultra_low_vol"
     ctx = {"regime_hint": "scalp" if atr < trend_min else "trend"}
     return True, ctx, None


### PR DESCRIPTION
## Summary
- show info logs when filters block entry
- log entry skip details in log manager

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_685503ce5f6483339d38e772474e3a61