### PR TITLE
docs: add volatility note to scalp prompt

### DIFF
--- a/prompts/scalp_analysis.txt
+++ b/prompts/scalp_analysis.txt
@@ -7,4 +7,5 @@ BB_lower:{bb_lower}
 Candles:{candles}
 Higher direction:{higher_tf_direction}
 {bias_note}
+10-minute volatility is about 10 pips ±2. When configuring TP/SL, target quick 1-2 pip gains.
 Respond with JSON as {{"side":"long|short|no","tp_pips":float,"sl_pips":float,"wait_pips":float}}


### PR DESCRIPTION
## Summary
- スキャルピング用プロンプト `scalp_analysis.txt` に10分間のボラティリティが約10pips±2であることを追記
- TP/SL設定時には1〜2pipsを狙う旨を明記

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(多くのテストが失敗)*


------
https://chatgpt.com/codex/tasks/task_e_68551cd5410c8333a6f1248ad8e659ed