### PR TITLE
fix: use POST for TP order

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -377,9 +377,9 @@ class OrderManager:
         if new_tp is not None:
             for attempt in range(3):
 
-                response = self._request_with_retries("put", url, json=tp_payload)
+                response = self._request_with_retries("post", url, json=tp_payload)
 
-                if response.status_code == 200:
+                if response.status_code in (200, 201):
                     results["tp"] = response.json()
                     break
 

--- a/backend/tests/test_adjust_tp_sl.py
+++ b/backend/tests/test_adjust_tp_sl.py
@@ -39,11 +39,16 @@ class TestAdjustTpSl(unittest.TestCase):
         log_stub = types.ModuleType("backend.logs.log_manager")
         self.log_calls = []
         log_stub.log_trade = lambda *a, **k: None
+        log_stub.add_trade_label = lambda *a, **k: None
         def log_error(module, code, message=None):
             self.log_calls.append((code, message))
         log_stub.log_error = log_error
         log_stub.log_policy_transition = lambda *a, **k: None
         add("backend.logs.log_manager", log_stub)
+
+        uot_stub = types.ModuleType("backend.logs.update_oanda_trades")
+        uot_stub.fetch_trade_details = lambda *_a, **_k: {"trade": {"state": "OPEN", "averagePrice": "0"}}
+        add("backend.logs.update_oanda_trades", uot_stub)
 
         os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")
         os.environ.setdefault("OANDA_API_KEY", "dummy")
@@ -51,12 +56,14 @@ class TestAdjustTpSl(unittest.TestCase):
         import backend.orders.order_manager as om
         importlib.reload(om)
         self.om = om.OrderManager()
+        self.om._request_with_retries = lambda method, url, **kw: getattr(req, method)(url, **kw)
+        self.om.get_current_tp = lambda *_a, **_k: None
 
     def tearDown(self):
         for name in self._added:
             sys.modules.pop(name, None)
 
-    def test_put_payload_for_tp(self):
+    def test_post_payload_for_tp(self):
         res = self.om.adjust_tp_sl("USD_JPY", "t1", new_tp=150.0)
         self.assertEqual(res, {"tp": {"ok": True}})
         body = self.sent[0]
@@ -74,13 +81,13 @@ class TestAdjustTpSl(unittest.TestCase):
         self.assertEqual(body["order"]["clientExtensions"]["comment"], "abc123")
 
     def test_error_logging_on_failure(self):
-        def fail_put(url, json=None, headers=None):
+        def fail_post(url, json=None, headers=None):
             return DummyResponse(
                 status_code=400,
                 json_data={"errorCode": "ERR", "errorMessage": "bad"},
                 text='bad'
             )
-        sys.modules['requests'].put = fail_put
+        sys.modules['requests'].post = fail_post
         res = self.om.adjust_tp_sl("USD_JPY", "t1", new_tp=150.0)
         self.assertIsNone(res)
         self.assertEqual(self.log_calls, [("TP adjustment failed: ERR bad", "bad")])


### PR DESCRIPTION
## Summary
- use POST for OANDA TP orders instead of PUT
- update unit test to mock POST request

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest backend/tests/test_adjust_tp_sl.py`

------
https://chatgpt.com/codex/tasks/task_e_68553c8139cc8333b6b886f2c9d33115