### PR TITLE
fix: handle existing take profit orders

### DIFF
--- a/backend/tests/test_adjust_tp_sl.py
+++ b/backend/tests/test_adjust_tp_sl.py
@@ -99,5 +99,13 @@ class TestAdjustTpSl(unittest.TestCase):
         self.assertIn("stopLoss", body)
         self.assertEqual(body["stopLoss"]["price"], "149.000")
 
+    def test_put_when_tp_exists(self):
+        self.om.get_current_tp = lambda *_a, **_k: 150.0
+        res = self.om.adjust_tp_sl("USD_JPY", "t1", new_tp=151.0)
+        self.assertEqual(res, {"tp": {"ok": True}})
+        body = self.sent[0]
+        self.assertIn("takeProfit", body)
+        self.assertEqual(body["takeProfit"]["price"], "151.000")
+
 if __name__ == '__main__':
     unittest.main()

--- a/backend/tests/test_update_trade_tp.py
+++ b/backend/tests/test_update_trade_tp.py
@@ -1,0 +1,89 @@
+import importlib
+import os
+import sys
+import types
+import unittest
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, json_data=None, text=''):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        pass
+
+    @property
+    def ok(self):
+        return self.status_code == 200
+
+
+class TestUpdateTradeTP(unittest.TestCase):
+    def setUp(self):
+        self._added = []
+        def add(name, mod):
+            sys.modules[name] = mod
+            self._added.append(name)
+
+        req = types.ModuleType("requests")
+        self.captured = {}
+        def put(url, json=None, headers=None):
+            self.captured['body'] = json
+            return DummyResponse(status_code=200, json_data={"ok": True})
+        req.post = lambda *a, **k: DummyResponse()
+        req.put = put
+        req.Session = lambda: types.SimpleNamespace()
+        req.get = lambda *a, **k: DummyResponse()
+        add("requests", req)
+
+        log_stub = types.ModuleType("backend.logs.log_manager")
+        self.log_calls = []
+        log_stub.log_trade = lambda *a, **k: None
+        def log_error(module, code, message=None):
+            self.log_calls.append((code, message))
+        log_stub.log_error = log_error
+        log_stub.log_policy_transition = lambda *a, **k: None
+        add("backend.logs.log_manager", log_stub)
+
+        os.environ.setdefault("OANDA_ACCOUNT_ID", "dummy")
+        os.environ.setdefault("OANDA_API_KEY", "dummy")
+
+        import backend.orders.order_manager as om
+        importlib.reload(om)
+        self.om = om.OrderManager()
+
+    def tearDown(self):
+        for name in self._added:
+            sys.modules.pop(name, None)
+
+    def test_payload_contains_take_profit_block(self):
+        self.om.update_trade_tp("t1", "USD_JPY", 151.1234)
+        body = self.captured.get('body')
+        self.assertIsNotNone(body)
+        self.assertIn('takeProfit', body)
+        self.assertEqual(body['takeProfit']['price'], '151.123')
+
+    def test_error_logging_records_details(self):
+        def error_put(url, json=None, headers=None):
+            self.captured['body'] = json
+            return DummyResponse(
+                status_code=400,
+                json_data={"errorCode": "ERR", "errorMessage": "bad"},
+                text='bad'
+            )
+        sys.modules['requests'].put = error_put
+        self.om.update_trade_tp("t1", "USD_JPY", 151.1234)
+        self.assertEqual(self.log_calls, [("Failed to update TP: ERR bad", "bad")])
+
+    def test_success_returns_json(self):
+        result = self.om.update_trade_tp("t1", "USD_JPY", 151.1234)
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(self.log_calls, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- prevent duplicate TP orders by checking existing take profit
- add `update_trade_tp` helper
- extend unit tests for TP logic

## Testing
- `isort .`
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68557b8c09a48333a9ddde1eb554f808