### PR TITLE
fix tp handling when order exists

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -390,6 +390,15 @@ class OrderManager:
                     code, msg = _extract_error_details(response)
                     err_msg = f"TP adjustment failed: {code} {msg}"
 
+                    if code == "TAKE_PROFIT_ORDER_ALREADY_EXISTS":
+                        logger.info(
+                            "TP already exists; updating existing order instead"
+                        )
+                        tp_res = self.update_trade_tp(trade_id, instrument, new_tp)
+                        if tp_res is not None:
+                            results["tp"] = tp_res
+                        break
+
                     if code in ("NO_SUCH_TRADE", "ORDER_DOESNT_EXIST") or (
                         "NO_SUCH_TRADE" in response.text
                         or "ORDER_DOESNT_EXIST" in response.text


### PR DESCRIPTION
## Summary
- handle TAKE_PROFIT_ORDER_ALREADY_EXISTS by updating existing TP order in adjust_tp_sl

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest` *(fails: various ImportError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_685884a2368c8333b4534b060a80f527