### PR TITLE
fix: handle existing TP update

### DIFF
--- a/backend/orders/order_manager.py
+++ b/backend/orders/order_manager.py
@@ -390,6 +390,13 @@ class OrderManager:
                     code, msg = _extract_error_details(response)
                     err_msg = f"TP adjustment failed: {code} {msg}"
 
+                    if code == "TAKE_PROFIT_ORDER_ALREADY_EXISTS":
+                        logger.info("TP exists, updating instead: %s", trade_id)
+                        tp_res = self.update_trade_tp(trade_id, instrument, new_tp)
+                        if tp_res is not None:
+                            results["tp"] = tp_res
+                            break
+
                     if code in ("NO_SUCH_TRADE", "ORDER_DOESNT_EXIST") or (
                         "NO_SUCH_TRADE" in response.text
                         or "ORDER_DOESNT_EXIST" in response.text

--- a/backend/tests/test_adjust_tp_sl.py
+++ b/backend/tests/test_adjust_tp_sl.py
@@ -107,5 +107,26 @@ class TestAdjustTpSl(unittest.TestCase):
         self.assertIn("takeProfit", body)
         self.assertEqual(body["takeProfit"]["price"], "151.000")
 
+    def test_update_called_on_existing_error(self):
+        def fail_post(url, json=None, headers=None):
+            return DummyResponse(
+                status_code=400,
+                json_data={
+                    "errorCode": "TAKE_PROFIT_ORDER_ALREADY_EXISTS",
+                    "errorMessage": "exists",
+                },
+                text="exists",
+            )
+
+        sys.modules["requests"].post = fail_post
+
+        res = self.om.adjust_tp_sl("USD_JPY", "t1", new_tp=150.0)
+
+        self.assertEqual(res, {"tp": {"ok": True}})
+        self.assertEqual(len(self.sent), 2)
+        body = self.sent[-1]
+        self.assertIn("takeProfit", body)
+        self.assertEqual(body["takeProfit"]["price"], "150.000")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- adjust order manager to update TP when order already exists
- add testcase for TAKE_PROFIT_ORDER_ALREADY_EXISTS

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError/AttributeError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_685885fcc02c833399a82d833e508c07