### PR TITLE
fix: use common DB path

### DIFF
--- a/ai/policy_trainer.py
+++ b/ai/policy_trainer.py
@@ -9,9 +9,9 @@ import numpy as np
 from d3rlpy.algos import DiscreteCQL
 from d3rlpy.dataset import MDPDataset
 
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 
-DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "/app/trades.db"))
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH))
 MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "policy_model.d3"
 
 

--- a/analysis/filter_statistics.py
+++ b/analysis/filter_statistics.py
@@ -5,9 +5,9 @@ import sqlite3
 from collections import Counter
 from pathlib import Path
 
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 
-DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "trades.db"))
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH))
 
 
 def summarize(db_path: Path = DB_PATH) -> dict:

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -115,7 +115,9 @@ app.add_middleware(
 )
 
 
-DATABASE_PATH = env_loader.get_env("TRADES_DB_PATH", "/app/trades.db")
+from backend.utils import db_helper
+
+DATABASE_PATH = env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH)
 ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
 LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "logs")
 

--- a/backend/logs/daily_summary.py
+++ b/backend/logs/daily_summary.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 
 _BASE_DIR = Path(__file__).resolve().parents[2]
-DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", str(_BASE_DIR / "trades.db")))
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH))
 ACCOUNT_ID = env_loader.get_env("OANDA_ACCOUNT_ID")
 
 

--- a/backend/logs/fetch_oanda_trades.py
+++ b/backend/logs/fetch_oanda_trades.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import requests
 
 import backend.logs.log_manager
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 
 # env_loader automatically loads default env files at import time
 # 旧バージョン互換用のトレード取得スクリプト
@@ -13,7 +13,7 @@ from backend.utils import env_loader
 
 
 _BASE_DIR = Path(__file__).resolve().parents[2]
-DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", str(_BASE_DIR / "trades.db")))
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH))
 
 def fetch_oanda_trades():
     api_key = env_loader.get_env('OANDA_API_KEY')

--- a/backend/logs/show_tables.py
+++ b/backend/logs/show_tables.py
@@ -1,11 +1,11 @@
 import sqlite3
 from pathlib import Path
 
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 
 # DBのパスを取得
 _BASE_DIR = Path(__file__).resolve().parents[2]
-DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", str(_BASE_DIR / "trades.db")))
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH))
 
 def list_tables():
     """Return list of table names."""

--- a/backend/strategy/strategy_analyzer.py
+++ b/backend/strategy/strategy_analyzer.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from backend.logs.log_manager import log_param_change
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 from backend.utils.openai_client import ask_openai
 
 log_level = env_loader.get_env("LOG_LEVEL", "INFO").upper()
@@ -17,7 +17,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 _BASE_DIR = Path(__file__).resolve().parents[2]
-DB_PATH = env_loader.get_env("TRADES_DB_PATH", str(_BASE_DIR / "trades.db"))
+DB_PATH = env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH)
 SETTINGS_PATH = "backend/config/settings.env"
 # SQLite table that stores every environment‐parameter change suggested/applied by the strategy optimizer
 PARAM_CHANGE_DB_TABLE = "param_changes"

--- a/maintenance/archive_ticks.py
+++ b/maintenance/archive_ticks.py
@@ -6,9 +6,9 @@ import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 
-DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "data/trades.db"))
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH))
 
 
 def archive_old_ticks(days: int = 30) -> int:

--- a/training/offline_policy_learning.py
+++ b/training/offline_policy_learning.py
@@ -8,9 +8,9 @@ from pathlib import Path
 
 import numpy as np
 
-from backend.utils import env_loader
+from backend.utils import db_helper, env_loader
 
-DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", "/app/trades.db"))
+DB_PATH = Path(env_loader.get_env("TRADES_DB_PATH", db_helper.DB_PATH))
 MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "strategy_policy.pkl"
 
 class SimpleQ:


### PR DESCRIPTION
## Summary
- use `db_helper.DB_PATH` everywhere
- unify default TRADES_DB_PATH across modules

## Testing
- `ruff check training/offline_policy_learning.py ai/policy_trainer.py backend/api/main.py maintenance/archive_ticks.py backend/strategy/strategy_analyzer.py backend/logs/daily_summary.py backend/logs/fetch_oanda_trades.py backend/logs/show_tables.py analysis/filter_statistics.py`
- `isort training/offline_policy_learning.py ai/policy_trainer.py backend/api/main.py maintenance/archive_ticks.py backend/strategy/strategy_analyzer.py backend/logs/daily_summary.py backend/logs/fetch_oanda_trades.py backend/logs/show_tables.py analysis/filter_statistics.py`
- `mypy training/offline_policy_learning.py ai/policy_trainer.py backend/api/main.py maintenance/archive_ticks.py backend/strategy/strategy_analyzer.py backend/logs/daily_summary.py backend/logs/fetch_oanda_trades.py backend/logs/show_tables.py analysis/filter_statistics.py`
- `pytest` *(fails: module backend.strategy.pattern_scanner not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_685886568174833390b763ed0cda805c