### PR TITLE
fix path for log imports

### DIFF
--- a/backend/logs/trade_logger.py
+++ b/backend/logs/trade_logger.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    # スクリプト実行時でも backend パッケージを解決できるようにパスを追加
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
 import json
 from enum import Enum
 from typing import Any

--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -4,6 +4,11 @@ import os
 import sys
 import time
 import uuid
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    # スクリプト実行時にリポジトリルートをパスへ追加
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
 from datetime import datetime, timedelta, timezone
 from logging import getLogger
 from typing import Any

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -4,6 +4,11 @@ import os
 import sys
 import time
 import uuid
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    # スクリプト実行時でも backend をインポートできるようにパスを調整
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
 from datetime import datetime, timedelta, timezone
 
 try:


### PR DESCRIPTION
## Summary
- ensure `backend` package is discoverable when running modules as scripts

## Testing
- `ruff check backend/logs/trade_logger.py backend/scheduler/job_runner.py piphawk_ai/runner/core.py`
- `mypy backend/logs/trade_logger.py backend/scheduler/job_runner.py piphawk_ai/runner/core.py`
- `pytest backend/tests/test_ai_cooldown.py -q` *(fails: ImportError: cannot import name 'reset_call_counter' from 'backend.utils.openai_client')*

------
https://chatgpt.com/codex/tasks/task_e_68589d72be3483338ceecb829b2084f5