### PR TITLE
fix: avoid logging failure when requests missing

### DIFF
--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,6 +1,13 @@
 from .ai_parse import parse_json_answer
 from .async_helper import run_async
-from .http_client import request_with_retries
+
+try:  # requests が無くても動作させるため
+    from .http_client import request_with_retries
+except Exception:  # pragma: no cover - テスト環境で置き換え
+
+    def request_with_retries(*_a, **_k):
+        raise ImportError("requests not available")
+
 from .rate_limiter import TokenBucket
 from .restart_guard import can_restart
 from .tokens import ensure_under_limit, num_tokens


### PR DESCRIPTION
## Summary
- handle `requests` absence so log manager imports reliably

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: tests fail due to ImportError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68589d3379e483339dd4928cb95272a5