### PR TITLE
fix: persist entry info for RL logging

### DIFF
--- a/backend/scheduler/job_runner.py
+++ b/backend/scheduler/job_runner.py
@@ -252,7 +252,12 @@ from strategies.context_builder import (
 )
 
 try:
-    from backend.logs.log_manager import log_policy_transition
+    from backend.logs.log_manager import (
+        clear_last_entry_info,
+        get_last_entry_info,
+        log_policy_transition,
+        set_last_entry_info,
+    )
 except Exception:  # pragma: no cover - test stubs may remove
 
     def log_policy_transition(*_a, **_k):
@@ -577,8 +582,9 @@ class JobRunner:
         )
         if use_policy and self.current_policy is not None:
             self.strategy_selector.offline_policy = self.current_policy
-        self.last_entry_context = None
-        self.last_entry_strategy = None
+        ctx, strat = get_last_entry_info()
+        self.last_entry_context = ctx
+        self.last_entry_strategy = strat
         self.current_context = None
         self.current_strategy_name = None
 
@@ -738,6 +744,7 @@ class JobRunner:
                 )
             except Exception as exc:
                 log.warning(f"Strategy update failed: {exc}")
+            clear_last_entry_info()
             self.last_entry_context = None
             self.last_entry_strategy = None
 
@@ -2497,6 +2504,7 @@ class JobRunner:
                                 self.scale_count = 0
                                 self.last_entry_context = self.current_context
                                 self.last_entry_strategy = self.current_strategy_name
+                                set_last_entry_info(self.last_entry_context, self.last_entry_strategy)
                                 self.last_run = now
                                 update_oanda_trades()
                                 time.sleep(self.interval_seconds)
@@ -2539,6 +2547,7 @@ class JobRunner:
                             self.scale_count = 0
                             self.last_entry_context = self.current_context
                             self.last_entry_strategy = self.current_strategy_name
+                            set_last_entry_info(self.last_entry_context, self.last_entry_strategy)
                         else:
 
                             log.info("Filter blocked → AI entry decision skipped.")
@@ -2577,6 +2586,7 @@ class JobRunner:
                             self.scale_count = 0
                             self.last_entry_context = self.current_context
                             self.last_entry_strategy = self.current_strategy_name
+                            set_last_entry_info(self.last_entry_context, self.last_entry_strategy)
                             self.last_position_review_ts = None
                     # (removed: periodic exit check block)
                 # Update OANDA trade history every second

--- a/piphawk_ai/runner/core.py
+++ b/piphawk_ai/runner/core.py
@@ -179,7 +179,12 @@ from strategies import (
 from strategies.context_builder import build_context, recent_strategy_performance
 
 try:
-    from backend.logs.log_manager import log_policy_transition
+    from backend.logs.log_manager import (
+        clear_last_entry_info,
+        get_last_entry_info,
+        log_policy_transition,
+        set_last_entry_info,
+    )
 except Exception:  # pragma: no cover - test stubs may remove
 
     def log_policy_transition(*_a, **_k):
@@ -488,8 +493,9 @@ class JobRunner:
             },
             use_offline_policy=use_policy,
         )
-        self.last_entry_context = None
-        self.last_entry_strategy = None
+        ctx, strat = get_last_entry_info()
+        self.last_entry_context = ctx
+        self.last_entry_strategy = strat
         self.current_context = None
         self.current_strategy_name = None
 
@@ -604,6 +610,7 @@ class JobRunner:
                 )
             except Exception as exc:
                 logger.warning(f"Strategy update failed: {exc}")
+            clear_last_entry_info()
             self.last_entry_context = None
             self.last_entry_strategy = None
 
@@ -2286,6 +2293,7 @@ class JobRunner:
                             self.scale_count = 0
                             self.last_entry_context = self.current_context
                             self.last_entry_strategy = self.current_strategy_name
+                            set_last_entry_info(self.last_entry_context, self.last_entry_strategy)
                         else:
                             reason = filter_ctx.get("reason", "unknown")
                             logger.info(


### PR DESCRIPTION
## Summary
- keep last entry context/strategy in DB
- restore on startup and clear after recording
- log policy transitions on exit when manual closes occur

## Testing
- `ruff check backend/logs/log_manager.py piphawk_ai/runner/core.py backend/scheduler/job_runner.py`
- `mypy backend/logs/log_manager.py piphawk_ai/runner/core.py backend/scheduler/job_runner.py`
- `pytest` *(fails: 62 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68589cec96708333bf906757632ca8cc