### PR TITLE
feat: allow counter-trend in range

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,8 +381,9 @@ The indicators module also calculates `adx_bb_score`, a composite value derived 
 `REV_BLOCK_BARS`, `TAIL_RATIO_BLOCK` and `VOL_SPIKE_PERIOD` configure the Recent Candle Bias filter, blocking entries when recent candles show sharp tails or volume spikes in the opposite direction.
 `STRICT_TF_ALIGN` enforces multi-timeframe EMA alignment before entering.
 `COUNTER_TREND_TP_RATIO` scales down the take-profit when entering against the higher timeframe trend.
-`BLOCK_COUNTER_TREND` set to `true` skips entries when both M15 and H1 EMA direction oppose the trade.
-`COUNTER_BYPASS_ADX` ignores the counter-trend check when the latest M5 ADX is at or above this value and aligns with the entry side.
+`BLOCK_COUNTER_TREND` (default `true`) skips entries when both M15 and H1 EMA direction oppose the trade.
+`COUNTER_BYPASS_ADX` lets counter entries through when the latest M5 ADX is high (e.g. 30+) and matches the entry side.
+`COUNTER_RANGE_ADX_MAX` disables the counter-trend block when the M5 ADX is below this value, allowing range trades.
 
 `TF_EMA_WEIGHTS` specifies the weight of each timeframe when evaluating EMA alignment, e.g. `M5:0.4,H1:0.3,H4:0.3`.
 `AI_ALIGN_WEIGHT` adds the AI's suggested direction to the multi-timeframe alignment check.

--- a/backend/config/settings.env
+++ b/backend/config/settings.env
@@ -219,8 +219,9 @@ RANGE_ENTRY_OFFSET_PIPS=3.5      # BB中心近傍の指値切替幅
 FOLLOW_PULLBACK_ATR_RATIO=0.5    # フォロープルバックATR比
 
 # === 逆張り・クライマックス ===
-BLOCK_COUNTER_TREND=false         # 逆張り抑制
-COUNTER_BYPASS_ADX=0             # M5 ADX がこの値以上なら逆張り判定を無視
+BLOCK_COUNTER_TREND=true          # 逆張り抑制 (M15/H1同方向かつ逆向きの場合)
+COUNTER_BYPASS_ADX=30             # ADXが高いとき(例:30以上)は逆張りを許可
+COUNTER_RANGE_ADX_MAX=20          # ADXがこの値以下なら逆張り抑制を無効化
 BLOCK_ADX_MIN=25                 # 逆張り抑制ADX
 COUNTER_TREND_TP_RATIO=0.5       # 逆張り時TP倍率
 CLIMAX_ENABLED=true              # クライマックスエントリー

--- a/backend/strategy/signal_filter.py
+++ b/backend/strategy/signal_filter.py
@@ -73,6 +73,17 @@ def counter_trend_block(
     """Return True when higher timeframe trend opposes the side."""
     if side not in ("long", "short"):
         return False
+    range_adx_max = float(env_loader.get_env("COUNTER_RANGE_ADX_MAX", "0"))
+    adx_series = ind_m5.get("adx")
+    if range_adx_max > 0 and adx_series is not None and len(adx_series) >= 1:
+        try:
+            adx_val = float(
+                adx_series.iloc[-1] if hasattr(adx_series, "iloc") else adx_series[-1]
+            )
+            if adx_val <= range_adx_max:
+                return False
+        except Exception:
+            pass
     dir_m15 = (
         _ema_direction(ind_m15.get("ema_fast"), ind_m15.get("ema_slow"))
         if ind_m15

--- a/docs/entry_filter.md
+++ b/docs/entry_filter.md
@@ -21,8 +21,9 @@
 - `REV_BLOCK_BARS`: 急反転を検知するために参照するローソク足本数。
 - `TAIL_RATIO_BLOCK`: ヒゲと実体の比率がこの値以上ならエントリーをブロック。
 - `VOL_SPIKE_PERIOD`: ボリュームスパイク判定に用いる平均期間。
-- `BLOCK_COUNTER_TREND`: M15/H1 が同方向でポジションと逆ならエントリーを停止。
-- `COUNTER_BYPASS_ADX`: M5 ADX がこの値以上でポジションと同方向なら逆張り判定を無視。
+- `BLOCK_COUNTER_TREND`: デフォルト `true`。M15/H1 が同方向でポジションと逆ならエントリーを停止。
+- `COUNTER_BYPASS_ADX`: ADX が高いとき (例:30以上) は逆張り判定を無視してエントリーを許可。
+- `COUNTER_RANGE_ADX_MAX`: M5 ADX がこの値以下なら逆張り抑制を無効化し、レンジ内の逆張りを許可。
 - `LT_TF_PRIORITY_ADX`: 下位足のADXがこの値を超えEMAクロスが発生すると上位足の重みを減少。
 - `LT_TF_WEIGHT_FACTOR`: 重みを減らす際に掛ける係数。
 - `ALIGN_ADX_WEIGHT`: マルチTF整合計算でADX方向を加味する重み。0なら無効。

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -282,8 +282,9 @@ SCALE_TRIGGER_ATR=0.5
 ## 新規追加設定
 
 - ATR_MULT_TP / ATR_MULT_SL: ATR(M5) に掛ける TP, SL の倍率
-- BLOCK_COUNTER_TREND: M15/H1 が同方向のとき逆張りをブロック
-- COUNTER_BYPASS_ADX: M5 ADX がこの値以上かつ同方向なら逆張り判定を無視
+- BLOCK_COUNTER_TREND: デフォルト `true`。M15/H1 が同方向のとき逆張りをブロック
+- COUNTER_BYPASS_ADX: ADX が高い場合 (例:30以上) は逆張り判定を無視してエントリーを許可
+- COUNTER_RANGE_ADX_MAX: ADX がこの値以下なら逆張り抑制を無効化
 - BLOCK_ADX_MIN: ADX がこの値以上で上昇中なら逆張りを抑制
 - COUNTER_TREND_TP_RATIO: 逆張りを許容する際にTPをこの倍率で縮小
 - CLIMAX_ENABLED: クライマックス検出による自動エントリーを有効化


### PR DESCRIPTION
## Summary
- support range trading by skipping counter-trend block when M5 ADX is low
- document `COUNTER_RANGE_ADX_MAX` and add to default settings

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: ImportError/AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68589f3cc42c8333a0c9ff150bc0ba2a