### PR TITLE
feat: add entry reversal option

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -64,6 +64,9 @@ REGIME_BB_NARROW=0.05
 # 強制エントリーフラグ
 FORCE_ENTER=true
 
+# 逆張りモード
+REVERSE_ENTRY=false
+
 # Atmosphere module settings
 ATMOS_EMA_WEIGHT=0.4
 ATMOS_RSI_WEIGHT=0.3

--- a/piphawk_ai/vote_arch/pipeline.py
+++ b/piphawk_ai/vote_arch/pipeline.py
@@ -14,6 +14,7 @@ from .regime_detector import MarketMetrics, rule_based_regime
 from .trade_mode_selector import select_mode
 
 FORCE_ENTER = env_loader.get_env("FORCE_ENTER", "false").lower() == "true"
+REVERSE_ENTRY = env_loader.get_env("REVERSE_ENTRY", "false").lower() == "true"
 
 
 
@@ -63,6 +64,12 @@ def run_cycle(
         avg_plan = buffer.average()
         if avg_plan:
             plan = avg_plan
+
+    if REVERSE_ENTRY:
+        if plan.side == "long":
+            plan = EntryPlan(side="short", tp=plan.tp, sl=plan.sl, lot=plan.lot)
+        elif plan.side == "short":
+            plan = EntryPlan(side="long", tp=plan.tp, sl=plan.sl, lot=plan.lot)
 
     # Post-filter は廃止されたため常に True とする
     passed = True


### PR DESCRIPTION
## Summary
- add `REVERSE_ENTRY` env flag
- flip entry side when the flag is enabled
- document the option in the env template
- test reverse entry behavior

## Testing
- `isort piphawk_ai/vote_arch/pipeline.py tests/test_pipeline.py .env.template`
- `ruff check piphawk_ai/vote_arch/pipeline.py tests/test_pipeline.py`
- `mypy piphawk_ai/vote_arch/pipeline.py tests/test_pipeline.py`
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: ImportError: module backend.strategy.pattern_scanner not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_6858cdcf83dc83339ef219164a13dc6e