### PR TITLE
fix session quiet-hour timezone

### DIFF
--- a/filters/market_filters.py
+++ b/filters/market_filters.py
@@ -9,7 +9,7 @@ from backend.utils import env_loader
 
 def _in_trade_hours(ts: datetime | None = None) -> bool:
     """取引可能時間かを判定する."""
-    ts = (ts or datetime.utcnow()).astimezone(timezone(timedelta(hours=9)))
+    ts = (ts or datetime.now(timezone.utc)).astimezone(timezone(timedelta(hours=9)))
     start = float(env_loader.get_env("TRADE_START_H", "7"))
     end = float(env_loader.get_env("TRADE_END_H", "23"))
     current = ts.hour + ts.minute / 60.0

--- a/filters/session_filter.py
+++ b/filters/session_filter.py
@@ -15,7 +15,8 @@ log = logging.getLogger(__name__)
 
 def is_quiet_hours(now: datetime | None = None) -> bool:
     """JST 03-06時を静寂時間帯として判定する."""
-    jst = (now or datetime.utcnow()).astimezone(timezone(timedelta(hours=9)))
+    base = now or datetime.now(timezone.utc)
+    jst = base.astimezone(timezone(timedelta(hours=9)))
     return 3 <= jst.hour < 6
 
 

--- a/tests/test_market_filter.py
+++ b/tests/test_market_filter.py
@@ -26,3 +26,15 @@ def test_in_trade_hours_decimal(monkeypatch):
 
     ts_block = datetime(2023, 1, 1, 18, 40, tzinfo=timezone.utc)
     assert not _in_trade_hours(ts_block)
+
+
+def test_in_trade_hours_default(monkeypatch):
+    from datetime import datetime, timezone
+
+    from filters.market_filters import _in_trade_hours
+
+    monkeypatch.setenv("TRADE_START_H", "7")
+    monkeypatch.setenv("TRADE_END_H", "23")
+
+    ts = datetime(2023, 1, 1, 4, 0, tzinfo=timezone.utc)
+    assert _in_trade_hours(ts)

--- a/tests/test_session_filter.py
+++ b/tests/test_session_filter.py
@@ -22,3 +22,17 @@ def test_apply_filters_wide_spread(monkeypatch):
     ok, ctx, reason = session_filter.apply_filters(0.1, 0.2, 2.0, tradeable=True)
     assert not ok
     assert reason == "wide_spread"
+
+
+def test_is_quiet_hours_jst_false():
+    from datetime import datetime, timezone
+
+    dt = datetime(2023, 1, 1, 4, 0, tzinfo=timezone.utc)
+    assert not session_filter.is_quiet_hours(dt)
+
+
+def test_is_quiet_hours_jst_true():
+    from datetime import datetime, timezone
+
+    dt = datetime(2023, 1, 1, 20, 0, tzinfo=timezone.utc)
+    assert session_filter.is_quiet_hours(dt)


### PR DESCRIPTION
## Summary
- ensure timezone conversion starts from UTC
- cover timezone checks with new tests

## Testing
- `ruff check .`
- `isort .`
- `mypy .`
- `pytest -q` *(fails: module backend.strategy.pattern_scanner not in sys.modules)*

------
https://chatgpt.com/codex/tasks/task_e_6858d7c2114483338be2336cd4d13d72